### PR TITLE
Bump the ReadTheDocs Python version to 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.6
+  version: 3.8
   pip_install: true
 
 requirements_file: requirements-test.txt


### PR DESCRIPTION
Python 3.9 is not supported yet, and 3.6 [could reach its EOL soon](https://www.python.org/dev/peps/pep-0494/#lifespan).