### PR TITLE
Replace deprecated `load_module` with `exec_module`

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -117,37 +117,26 @@ def test_load_nox_module_OSError(caplog):
         assert "Failed to load Noxfile" in caplog.text
 
 
-def test_load_nox_module_invalid_spec(caplog, tmp_path):
-    bad_noxfile = tmp_path / "badspec.py"
-    config = _options.options.namespace(noxfile=str(bad_noxfile))
+def test_load_nox_module_invalid_spec():
+    our_noxfile = Path(__file__).parent.parent.joinpath("noxfile.py")
+    config = _options.options.namespace(noxfile=str(our_noxfile))
 
     with mock.patch("nox.tasks.importlib.util.spec_from_file_location") as mock_spec:
         mock_spec.return_value = None
 
-        assert tasks.load_nox_module(config) == 2
-        assert "Failed to load Noxfile" in caplog.text
+        with pytest.raises(IOError):
+            tasks._load_and_exec_nox_module(config)
 
 
-def test_load_nox_module_invalid_module(caplog, tmp_path):
-    bad_noxfile = tmp_path / "badspec.py"
-    config = _options.options.namespace(noxfile=str(bad_noxfile))
+def test_load_nox_module_invalid_module():
+    our_noxfile = Path(__file__).parent.parent.joinpath("noxfile.py")
+    config = _options.options.namespace(noxfile=str(our_noxfile))
 
     with mock.patch("nox.tasks.importlib.util.module_from_spec") as mock_spec:
         mock_spec.return_value = None
 
-        assert tasks.load_nox_module(config) == 2
-        assert "Failed to load Noxfile" in caplog.text
-
-
-def test_load_nox_module_invalid_module_loader(caplog, tmp_path):
-    bad_noxfile = tmp_path / "badspec.py"
-    config = _options.options.namespace(noxfile=str(bad_noxfile))
-
-    with mock.patch("nox.tasks.importlib.machinery.ModuleSpec") as mock_spec:
-        mock_spec.loader = None
-
-        assert tasks.load_nox_module(config) == 2
-        assert "Failed to load Noxfile" in caplog.text
+        with pytest.raises(IOError):
+            tasks._load_and_exec_nox_module(config)
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #494 

This was a bit of a nightmare! 😬 this implementation is by no means perfect and it took a great deal of trial and error as well as at least a few days off my lifespan!

A brief summary of what I've done and how I got here (not all of this is in the PR commit history):

- The deprecation warning attached to `load_module` suggests replacing with `exec_module`. However, nox needs the module to be passed around and `exec_module` returns `None` so this was a non-starter.
- I then tried to replace it with a call to `importlib.import_module` as this will return the `ModuleType`. This appeared to work when using nox at the command line but every test that uses one of the demo noxfiles in the `tests/resources/` kept failing with a `ModuleNotFound` error. I tried various things to fix this such as making the `resources` dir a valid package, manually changing directories in the tests, trying to resolve relative to absolute imports etc. All to no avail!
- Then I more or less arrived at the current implementation by roughly following this: [https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly](https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly).

This still gave me some grief as mypy wouldn't recognise the `exec_module` method despite its use in the exact same way as the example in the link, so I had to `# type ignore` that and I had some difficulty with ensuring coverage. You'll notice a single `# pragma: no cover` for one of the guard statements as I just couldn't figure out how to mock it out properly for tests.

I think if we could get `importlib.import_module` to work here this would be by far the cleanest solution, but as I said I couldn't get it to pass the tests, it kept importing the project's noxfile, not the ones under `tests/resources` which was very weird!