### PR TITLE
Update the classifiers, documentation, and more to point to the new Winterbloom location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,15 +3,15 @@
 Thank you for your interest in improving Nox. Nox is open-source under the
 [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0) and welcomes contributions in the form of bug reports, feature requests, and pull requests.
 
-Nox is hosted on [GitHub](https://github.com/theacodes/nox).
+Nox is hosted on [GitHub](https://github.com/wntrblm/nox).
 
 ## Support, questions, and feature requests
 
-Feel free to file a bug on [GitHub](https://github.com/theacodes/nox).
+Feel free to file a bug on [GitHub](https://github.com/wntrblm/nox).
 
 ## Reporting issues
 
-File a bug on [GitHub](https://github.com/theacodes/nox). To help us figure out what's going on, please err on the
+File a bug on [GitHub](https://github.com/wntrblm/nox). To help us figure out what's going on, please err on the
 side of including lots of information, such as:
 
 * Operating system.

--- a/README.rst
+++ b/README.rst
@@ -12,4 +12,4 @@ The source code is available on `GitHub`_.
 
 .. _tox: https://tox.readthedocs.io
 .. _Read the Docs: https://nox.readthedocs.io
-.. _GitHub: https://github.com/theacodes/nox
+.. _GitHub: https://github.com/wntrblm/nox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,7 @@ html_theme_options = {
     "logo": "alice.png",
     "logo_name": True,
     "description": "Flexible test automation",
-    "github_user": "theacodes",
+    "github_user": "wntrblm",
     "github_repo": "nox",
     "github_banner": True,
     "github_button": False,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,4 +98,4 @@ Our maintainers are (in alphabetical order):
 * `Thea Flowers <https://github.com/theacodes>`__
 * `Tom Fleet <https://github.com/followtheprocess>`__
 
-Nox also exists due to the various patches and work contributed by `the community <https://github.com/theacodes/nox/graphs/contributors>`__. If you'd like to get involved, see :doc:`CONTRIBUTING`. We pay our contributors using `Open Collective <https://opencollective.com/python-nox>`__.
+Nox also exists due to the various patches and work contributed by `the community <https://github.com/wntrblm/nox/graphs/contributors>`__. If you'd like to get involved, see :doc:`CONTRIBUTING`. We pay our contributors using `Open Collective <https://opencollective.com/python-nox>`__.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ classifiers =
 keywords = testing automation tox
 project_urls =
     Documentation = https://nox.thea.codes
-    Source Code = https://github.com/theacodes/nox
-    Bug Tracker = https://github.com/theacodes/nox/issues
+    Source Code = https://github.com/wntrblm/nox
+    Bug Tracker = https://github.com/wntrblm/nox/issues
 
 [options]
 packages =


### PR DESCRIPTION
Since we have moved to Winterbloom (hooray! :tada:), the current classifiers and links are now outdated. This PR intends to solve this situation.

When this PR gets ready, please let me know if I missed something.