### PR TITLE
Drop 99% coverage threshold flag for 3.10 in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -68,16 +68,9 @@ def cover(session):
     if ON_WINDOWS_CI:
         return
 
-    # 3.10 produces different coverage results for some reason
-    # see https://github.com/theacodes/nox/issues/478
-    fail_under = 100
-    py_version = sys.version_info
-    if py_version.major == 3 and py_version.minor == 10:
-        fail_under = 99
-
     session.install("coverage[toml]")
     session.run("coverage", "combine")
-    session.run("coverage", "report", f"--fail-under={fail_under}", "--show-missing")
+    session.run("coverage", "report", "--fail-under=100", "--show-missing")
     session.run("coverage", "erase")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,6 @@ import functools
 import os
 import platform
 import shutil
-import sys
 
 import nox
 


### PR DESCRIPTION
This PR drops the flag in our Noxfile that would set the `fail_under` threshold to 99% on python 3.10. This was a hangover from when we were testing against 3.10.0-rc.2 in GHA and coverage was raising a few false positives.

Judging by recent runs this flag can be removed now.

See this comment for further details: https://github.com/wntrblm/nox/pull/592#issuecomment-1091830649