### PR TITLE
tests: configure pytest

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -36,14 +36,13 @@ def tests(session):
     session.create_tmp()
     session.install("-r", "requirements-test.txt")
     session.install("-e", ".[tox_to_nox]")
-    tests = session.posargs or ["tests/"]
     session.run(
         "pytest",
         "--cov=nox",
         "--cov-config",
         "pyproject.toml",
         "--cov-report=",
-        *tests,
+        *session.posargs,
         env={"COVERAGE_FILE": f".coverage.{session.python}"},
     )
     session.notify("cover")
@@ -57,8 +56,7 @@ def conda_tests(session):
         "--file", "requirements-conda-test.txt", "--channel", "conda-forge"
     )
     session.install("-e", ".", "--no-deps")
-    tests = session.posargs or ["tests/"]
-    session.run("pytest", *tests)
+    session.run("pytest", *session.posargs)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,16 @@ exclude_lines = [
     "@overload",
 ]
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = ["-ra", "--strict-markers", "--strict-config"]
+xfail_strict = true
+filterwarnings = ["error"]
+log_cli_level = "info"
+testpaths = [
+    "tests",
+]
+
 [tool.mypy]
 files = ["nox"]
 python_version = "3.7"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 flask
 myst-parser
-pytest
+pytest>=6.0
 pytest-cov
 sphinx>=3.0
 sphinx-autobuild

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -64,7 +64,7 @@ def test_formatter(caplog):
     [
         # This currently fails due to some incompatibility between caplog and colorlog
         # that causes caplog to not collect the asctime from colorlog.
-        pytest.param(True, id="color", marks=pytest.mark.xfail),
+        pytest.param(True, id="color", marks=pytest.mark.xfail(strict=False)),
         pytest.param(False, id="no-color"),
     ],
 )


### PR DESCRIPTION
This configures pytest using pyproject.toml, and simplifies the noxfile a tiny bit - pytests's testfiles already has the correct behavior for session.posargs.
