### PR TITLE
feat: allow defining a python version list for GHA action

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -20,3 +20,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_default_tests
+  action-all-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          python-versions: "['2.7', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy2.7', 'pypy3.7', 'pypy3.8', 'pypy3.9']"
+      - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_all_tests

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,10 @@
 name: Setup Nox
-description: 'Prepares all python versions for nox'
+description: "Prepares all python versions for nox"
+inputs:
+  python-versions:
+    description: "List of python versions to install"
+    required: true
+    default: "['3.7', '3.8', '3.9', '3.10', 'pypy3.7', 'pypy3.8', 'pypy3.9']"
 branding:
   icon: package
   color: blue
@@ -9,26 +14,54 @@ runs:
   steps:
     - uses: actions/setup-python@v3
       with:
+        python-version: "pypy-2.7"
+      if: ${{ contains(fromJSON(inputs.python-versions), 'pypy2.7') }}
+    - uses: actions/setup-python@v3
+      with:
         python-version: "pypy-3.7"
+      if: ${{ contains(fromJSON(inputs.python-versions), 'pypy3.7') }}
     - uses: actions/setup-python@v3
       with:
         python-version: "pypy-3.8"
+      if: ${{ contains(fromJSON(inputs.python-versions), 'pypy3.8') }}
     - uses: actions/setup-python@v3
       with:
         python-version: "pypy-3.9"
+      if: ${{ contains(fromJSON(inputs.python-versions), 'pypy3.9') }}
 
     - uses: actions/setup-python@v3
       with:
+        python-version: "2.7"
+      if: ${{ contains(fromJSON(inputs.python-versions), '2.7') }}
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.4"
+      if: ${{ contains(fromJSON(inputs.python-versions), '3.4') }}
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.5"
+      if: ${{ contains(fromJSON(inputs.python-versions), '3.5') }}
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.6"
+      if: ${{ contains(fromJSON(inputs.python-versions), '3.6') }}
+    - uses: actions/setup-python@v3
+      with:
         python-version: "3.7"
+      if: ${{ contains(fromJSON(inputs.python-versions), '3.7') }}
     - uses: actions/setup-python@v3
       with:
         python-version: "3.8"
+      if: ${{ contains(fromJSON(inputs.python-versions), '3.8') }}
     - uses: actions/setup-python@v3
       with:
         python-version: "3.9"
+      if: ${{ contains(fromJSON(inputs.python-versions), '3.9') }}
     - uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+      # used to install nox
+      # if: ${{ contains(fromJSON(inputs.python-versions), '3.10') }}
 
     - name: "Install nox"
       # --python "$(which python)" => always use the last setup-python version to install nox.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -29,7 +29,27 @@ Either way, Nox is usually installed *globally*, similar to ``tox``, ``pip``, an
 
 If you're interested in running ``nox`` within `docker`_, you can use the `thekevjames/nox images`_ on DockerHub which contain builds for all ``nox`` versions and all supported ``python`` versions. Nox is also supported via ``pipx run nox`` in the `manylinux images`_.
 
-If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/nox`` action, which installs the latest ``nox`` and makes available all active CPython and PyPY versions provided by the GitHub Actions environment. You can safely combine this with with ``setup-python`` for past end-of-life or development versions of Python, as well.
+If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/nox`` action, which installs the latest ``nox`` and makes available all active CPython and PyPY versions provided by the GitHub Actions environment. You can combine this with ``setup-python`` for past end-of-life or development versions of Python, as well:
+
+.. code-block:: yaml
+
+    # setup nox with all active CPython and PyPY versions provided by
+    # the GitHub Actions environment i.e.
+    # python-versions: "['3.7', '3.8', '3.9', '3.10', 'pypy3.7', 'pypy3.8', 'pypy3.9']"
+    - uses: wntrblm/nox
+
+    # setup nox only for a given list of python versions
+    # The supported set of versions is the one below,
+    # you must choose from this subset
+    - uses: wntrblm/nox
+      with:
+          python-versions: "['2.7', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3.7', 'pypy3.8', 'pypy3.9']"
+
+    # You can also combine this with setup-python
+    - uses: wntrblm/nox
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.11-dev"
 
 .. _pip: https://pip.readthedocs.org
 .. _user site: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site

--- a/noxfile.py
+++ b/noxfile.py
@@ -133,3 +133,25 @@ def _check_python_version(session: nox.Session) -> None:
 def github_actions_default_tests(session: nox.Session) -> None:
     """Check default versions installed by the nox GHA Action"""
     _check_python_version(session)
+
+
+# The following sessions are only to be run in CI to check the nox GHA action
+@nox.session(
+    python=[
+        "2.7",
+        "3.4",
+        "3.5",
+        "3.6",
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "pypy2.7",
+        "pypy3.7",
+        "pypy3.8",
+        "pypy3.9",
+    ]
+)
+def github_actions_all_tests(session):
+    """Check all versions installed by the nox GHA Action"""
+    _check_python_version(session)


### PR DESCRIPTION
This PR extends #594 by allowing to define a list of python versions to setup.
The default list is the same as in #594 
The list is defined as a string because GitHub Actions does not support lists as inputs.
