### PR TITLE
Create the `config.yml` file for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Winterbloom Discord server
+    url: https://discord.gg/C5EH3N3fsk
+    about: You can ask questions and chat about Nox under this server's #nox channel.


### PR DESCRIPTION
This is the follow-up of #600, as we discussed in #534. This will add a link to the Winterbloom Discord (to be more precise, the link shared in https://github.com/wntrblm/nox/issues/534#issuecomment-1111552113).