### PR TITLE
Fix discord channel name in config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Winterbloom Discord server
     url: https://discord.gg/C5EH3N3fsk
-    about: You can ask questions and chat about Nox under this server's #nox channel.
+    about: You can ask questions and chat about Nox under this server's '#nox' channel.


### PR DESCRIPTION
This PR fixes the Nox channel name in the `config.yml` which, as it's preceeded by a '#', yaml assumes it's a comment and does not display everything after it:

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/62767721/166108037-e4d7a3c7-c069-4d97-aa70-06e68b74660c.png">
