### PR TITLE
Prefer type checking against Jinja2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         files: ^nox/
         args: []
         additional_dependencies:
-          - types-jinja2
+          - jinja2
           - packaging
           - importlib_metadata
 


### PR DESCRIPTION
As of version 3.0, Jinja2 includes type hints. These should be preferred to the (no longer updated) stub package from typeshed.