### PR TITLE
chore: Few tidy ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ on: [push, pull_request]
 env:
   FORCE_COLOR: "1"
   PRE_COMMIT_COLOR: "always"
-  # See https://github.com/theacodes/nox/issues/545
-  # and https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763
-  SETUPTOOLS_USE_DISTUTILS: "stdlib"
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,9 +31,8 @@ if shutil.which("conda"):
 
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10"])
-def tests(session):
+def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
-    session.create_tmp()
     session.install("-r", "requirements-test.txt")
     session.install("-e", ".[tox_to_nox]")
     session.run(
@@ -49,9 +48,8 @@ def tests(session):
 
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10"], venv_backend="conda")
-def conda_tests(session):
+def conda_tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
-    session.create_tmp()
     session.conda_install(
         "--file", "requirements-conda-test.txt", "--channel", "conda-forge"
     )
@@ -60,7 +58,7 @@ def conda_tests(session):
 
 
 @nox.session
-def cover(session):
+def cover(session: nox.Session) -> None:
     """Coverage analysis."""
     if ON_WINDOWS_CI:
         return
@@ -72,24 +70,21 @@ def cover(session):
 
 
 @nox.session(python="3.9")
-def lint(session):
+def lint(session: nox.Session) -> None:
     """Run pre-commit linting."""
     session.install("pre-commit")
-    # See https://github.com/theacodes/nox/issues/545
-    # and https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763
     session.run(
         "pre-commit",
         "run",
         "--all-files",
         "--show-diff-on-failure",
         "--hook-stage=manual",
-        env={"SETUPTOOLS_USE_DISTUTILS": "stdlib"},
         *session.posargs,
     )
 
 
 @nox.session
-def docs(session):
+def docs(session: nox.Session) -> None:
     """Build the documentation."""
     output_dir = os.path.join(session.create_tmp(), "output")
     doctrees, html = map(

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,6 +33,7 @@ if shutil.which("conda"):
 @nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
+    session.create_tmp()  # Fixes permission errors on Windows
     session.install("-r", "requirements-test.txt")
     session.install("-e", ".[tox_to_nox]")
     session.run(
@@ -50,6 +51,7 @@ def tests(session: nox.Session) -> None:
 @nox.session(python=["3.7", "3.8", "3.9", "3.10"], venv_backend="conda")
 def conda_tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
+    session.create_tmp()  # Fixes permission errors on Windows
     session.conda_install(
         "--file", "requirements-conda-test.txt", "--channel", "conda-forge"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,10 @@ profile = "black"
 
 [tool.coverage.run]
 branch = true
-omit = [
-    "nox/_typing.py",
-]
+omit = ["nox/_typing.py"]
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    "if _typing.TYPE_CHECKING:",
-    "@overload",
-]
+exclude_lines = ["pragma: no cover", "if _typing.TYPE_CHECKING:", "@overload"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -24,12 +18,10 @@ addopts = ["-ra", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = ["error"]
 log_cli_level = "info"
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
 
 [tool.mypy]
-files = ["nox"]
+files = ["nox/**/*.py", "noxfile.py"]
 python_version = "3.7"
 show_error_codes = true
 strict = true
@@ -37,7 +29,7 @@ warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
 [[tool.mypy.overrides]]
-module = [ "argcomplete", "colorlog.*", "py", "tox.*" ]
+module = ["argcomplete", "colorlog.*", "py", "tox.*"]
 ignore_missing_imports = true
 
 [tool.check-manifest]


### PR DESCRIPTION
This PR does a few little chore type items:

* Type check the `noxfile.py`
* I attempted to remove the seemingly unnecessary `session.create_tmp()` call in the test sessions but this then failed on Windows with the classic Errno13 Permissions so I put them back with an explanatory comment to warn future meddlers
* Format the `pyproject.toml` using the [even better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) VSCode extension (This was mostly by accident but it looks nice)
* Remove the `SETUPTOOLS_USE_DISTUTILS` switches mentioned in #545 as the underlying issue is now fixed