### PR TITLE
docs: Use link for README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="docs/_static/alice.png" alt="logo" width=50%>
+<img src="https://github.com/wntrblm/nox/raw/main/docs/_static/alice.png" alt="logo" width=50%>
 </p>
 
 # Nox


### PR DESCRIPTION
This PR changes the syntax for the alice logo in the README from a hardcoded relative path to a static GitHub link so that it will render properly on e.g. PyPI