### PR TITLE
fix: PEP 621 license field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2022.1.7"
 description = "Flexible test automation."
 readme = "README.md"
 requires-python = ">=3.7"
-license = { file = "LICENSE" }
+license = { text = "Apache-2.0" }
 authors = [{ name = "Alethea Katherine Flowers" }, { email = "me@thea.codes" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I've discovered (by accident) something quite unfortunate about the PEP 621 pyproject.toml `license` field. I recently ported [pytoil](https://github.com/FollowTheProcess/pytoil) to support PEP 621 and released a new version with the following config:

```toml
license = {file = "LICENSE"}
```

However this gives a rather ugly representation of the entire file on PyPI:

<img width="509" alt="image" src="https://user-images.githubusercontent.com/62767721/167121387-705ff123-1a28-4f4c-a19a-7a3c89e4e28b.png">

This can be fixed by simply passing the name of the license in the `text` key like so:

```toml
license = {text = "Apache-2.0"}
```

Which results in what you'd expect:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/62767721/167123742-6aae6fe9-18c8-4cde-9ee0-b755a846f8ef.png">


And I can confirm that the full LICENSE file is still included when running `pyproject-build`:

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/62767721/167122206-38d9d412-62d8-49fd-b879-f3cb6aebc213.png">
