### PR TITLE
fix(docs): Configure language code to avoid warning on sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Warnings are treated as errors so this is currently failing CI builds of docs.

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/638797/173625626-54232e5b-8f2c-4760-9ce2-1306903e2ce7.png">
