### PR TITLE
feat: expose no_install and install_only as public API

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -162,6 +162,22 @@ class Session:
         return self._runner.posargs
 
     @property
+    def no_install(self) -> bool:
+        """
+        Whether ``--no-install`` is passed to the ``nox`` command line.
+        This property may be useful if a user is using their own installing
+        command (e.g., ``pip-sync``).
+        """
+        return self._runner.global_config.no_install
+
+    @property
+    def install_only(self) -> bool:
+        """
+        Whether ``--install-only`` is passed to the ``nox`` command line.
+        """
+        return self._runner.global_config.install_only
+
+    @property
     def virtualenv(self) -> ProcessEnv:
         """The virtualenv that all commands are run in."""
         venv = self._runner.venv

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -23,7 +23,7 @@ import re
 import sys
 import unicodedata
 from types import TracebackType
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence, cast
 
 import py
 
@@ -168,14 +168,14 @@ class Session:
         This property may be useful if a user is using their own installing
         command (e.g., ``pip-sync``).
         """
-        return self._runner.global_config.no_install
+        return cast(bool, self._runner.global_config.no_install)
 
     @property
     def install_only(self) -> bool:
         """
         Whether ``--install-only`` is passed to the ``nox`` command line.
         """
-        return self._runner.global_config.install_only
+        return cast(bool, self._runner.global_config.install_only)
 
     @property
     def virtualenv(self) -> ProcessEnv:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -225,6 +225,7 @@ class TestSession:
         caplog.set_level(logging.INFO)
         session, runner = self.make_session_and_runner()
         runner.global_config.install_only = True
+        assert session.install_only
 
         with mock.patch.object(nox.command, "run") as run:
             assert session.run("spam", "eggs") is None
@@ -236,6 +237,7 @@ class TestSession:
     def test_run_install_only_should_install(self):
         session, runner = self.make_session_and_runner()
         runner.global_config.install_only = True
+        assert session.install_only
 
         with mock.patch.object(nox.command, "run") as run:
             session.install("spam")
@@ -344,6 +346,7 @@ class TestSession:
     def test_run_always_install_only(self, caplog):
         session, runner = self.make_session_and_runner()
         runner.global_config.install_only = True
+        assert session.install_only
 
         assert session.run_always(operator.add, 23, 19) == 42
 
@@ -409,6 +412,7 @@ class TestSession:
     def test_run_always_no_install(self, no_install, reused, run_called):
         session, runner = self.make_session_and_runner()
         runner.global_config.no_install = no_install
+        assert session.no_install == no_install
         runner.venv._reused = reused
 
         with mock.patch.object(nox.command, "run") as run:
@@ -518,6 +522,7 @@ class TestSession:
         runner.venv.conda_cmd = "conda"
 
         runner.global_config.no_install = no_install
+        assert session.no_install == no_install
         runner.venv._reused = reused
 
         with mock.patch.object(nox.command, "run") as run:
@@ -756,6 +761,7 @@ class TestSession:
     def test_session_venv_reused_with_no_install(self, no_install, reused, run_called):
         session, runner = self.make_session_and_runner()
         runner.global_config.no_install = no_install
+        assert session.no_install == no_install
         runner.venv._reused = reused
 
         with mock.patch.object(nox.command, "run") as run:


### PR DESCRIPTION
Just an idea, but I feel it convenient if they are exposed as public API.
I'm using [pip-sync](https://github.com/jazzband/pip-tools/) to install dependencies, so I want to re-use `--no-install` flag for disabling running `pip-sync`. I sometimes pass `posargs` to external tools like pytest, so I want to avoid `nox -s ~ -- --no-sync`.

I feel that some other people may find them useful, but I don't have any other use case. Suggestions are welcome 🙂 