### PR TITLE
fix: use setup-python v4.1's environmentless setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,12 @@ branding:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v4.1.0
       id: localpython
       with:
         python-version: "3.7-3.10"
         activate-environment: false
-        
+
     - name: "Validate input"
       id: helper
       run: >

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ branding:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4.1
+    - uses: actions/setup-python@v4
       id: localpython
       with:
         python-version: "3.7 - 3.10"

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ branding:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4.1.0
+    - uses: actions/setup-python@v4.1
       id: localpython
       with:
         python-version: "3.7 - 3.10"

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     - uses: actions/setup-python@v4.1.0
       id: localpython
       with:
-        python-version: "3.7-3.10"
+        python-version: "3.7 - 3.10"
         activate-environment: false
 
     - name: "Validate input"

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,15 @@ branding:
 runs:
   using: composite
   steps:
+    - uses: actions/setup-python@v4
+      id: localpython
+      with:
+        python-version: "3.7-3.10"
+        activate-environment: false
+        
     - name: "Validate input"
       id: helper
-      run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} '${{ github.action_path }}/.github/action_helper.py' '${{ inputs.python-versions }}'
+      run: '${{ steps.localpython.outputs.python-path }}' '${{ github.action_path }}/.github/action_helper.py' '${{ inputs.python-versions }}'
       shell: bash
 
     - uses: actions/setup-python@v4
@@ -99,6 +105,5 @@ runs:
       if: ${{ steps.helper.outputs.interpreter_count > 19 }}
 
     - name: "Install nox"
-      # --python "$(which python)" => always use the last setup-python version to install nox.
-      run: pipx install --python "$(which python)" '${{ github.action_path }}'
+      run: pipx install --python "${{ steps.localpython.outputs.python-path }}" '${{ github.action_path }}'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,8 @@ runs:
         
     - name: "Validate input"
       id: helper
-      run: '${{ steps.localpython.outputs.python-path }}' '${{ github.action_path }}/.github/action_helper.py' '${{ inputs.python-versions }}'
+      run: >
+        '${{ steps.localpython.outputs.python-path }}' '${{ github.action_path }}/.github/action_helper.py' '${{ inputs.python-versions }}'
       shell: bash
 
     - uses: actions/setup-python@v4


### PR DESCRIPTION
This removes the dependence on the final output being reasonable to run nox. Targeting only <3.7 is valid now.

CC @mayeut 