### PR TITLE
Support session dependencies (`requires`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
             python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
+      - name: Set up non-default Pythons
+        uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.9
+            3.10
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -386,6 +386,41 @@ You can also pass the notified session positional arguments:
 
 Note that this will only have the desired effect if selecting sessions to run via the ``--session/-s`` flag. If you simply run ``nox``, all selected sessions will be run.
 
+Requiring sessions
+------------------
+
+You can also request sessions be run before your session runs. This is done with the ``requires=`` keyword:
+
+
+.. code-block:: python
+
+    @nox.session
+    def tests(session):
+        session.install("pytest")
+        session.run("pytest")
+
+    @nox.session(requires=["tests"])
+    def coverage(session):
+        session.install("coverage")
+        session.run("coverage")
+
+The required sessions will be stably topologically sorted and run. Parametrized
+sessions are supported. You can also get the current Python version with
+``{python}``, though arbitrary parametrizations are not supported.
+
+
+.. code-block:: python
+
+    @nox.session(python=["3.10", "3.13"])
+    def tests(session):
+        session.install("pytest")
+        session.run("pytest")
+
+    @nox.session(python=["3.10", "3.13"], requires=["tests-{python}"])
+    def coverage(session):
+        session.install("coverage")
+        session.run("coverage")
+
 Testing against different and multiple Pythons
 ----------------------------------------------
 

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -122,7 +122,9 @@ class Func(FunctionDecorator):
                 msg = "Cannot parametrize requires with {python} when python is None or a bool."
                 raise ValueError(msg)
             return formatted
-        msg = "The requires of a not-yet-parametrized session cannot be parametrized."
+        msg = (
+            "The requires of a not-yet-parametrized session cannot be parametrized."
+        )  # pragma: no cover
         raise TypeError(msg)  # pragma: no cover
 
 

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -114,9 +114,11 @@ class Func(FunctionDecorator):
         self._requires = list(value)
 
     def format_dependency(self, dependency: str) -> str:
-        if isinstance(self.python, (bool, str)):
+        if isinstance(self.python, (bool, str)) or self.python is None:
             formatted = dependency.format(python=self.python, py=self.python)
-            if isinstance(self.python, bool) and formatted != dependency:
+            if (
+                self.python is None or isinstance(self.python, bool)
+            ) and formatted != dependency:
                 msg = "Cannot parametrize requires with {python} when python is None or a bool."
                 raise ValueError(msg)
             return formatted

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -71,6 +71,7 @@ class Func(FunctionDecorator):
         tags: Sequence[str] | None = None,
         *,
         default: bool = True,
+        requires: Sequence[str] | None = None,
     ) -> None:
         self.func = func
         self.python = python
@@ -81,6 +82,7 @@ class Func(FunctionDecorator):
         self.should_warn = dict(should_warn or {})
         self.tags = list(tags or [])
         self.default = default
+        self.requires = list(requires or [])
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.func(*args, **kwargs)
@@ -98,7 +100,28 @@ class Func(FunctionDecorator):
             self.should_warn,
             self.tags,
             default=self.default,
+            requires=self._requires,
         )
+
+    @property
+    def requires(self) -> list[str]:
+        # Compute dynamically on lookup since ``self.python`` can be modified after
+        # creation (e.g. on an instance from ``self.copy``).
+        return list(map(self.format_dependency, self._requires))
+
+    @requires.setter
+    def requires(self, value: Sequence[str]) -> None:
+        self._requires = list(value)
+
+    def format_dependency(self, dependency: str) -> str:
+        if isinstance(self.python, (bool, str)):
+            formatted = dependency.format(python=self.python, py=self.python)
+            if isinstance(self.python, bool) and formatted != dependency:
+                msg = "Cannot parametrize requires with {python} when python is None or a bool."
+                raise ValueError(msg)
+            return formatted
+        msg = "The requires of a not-yet-parametrized session cannot be parametrized."
+        raise TypeError(msg)  # pragma: no cover
 
 
 class Call(Func):
@@ -130,6 +153,7 @@ class Call(Func):
             func.should_warn,
             func.tags + param_spec.tags,
             default=func.default,
+            requires=func.requires,
         )
         self.call_spec = call_spec
         self.session_signature = session_signature

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -122,9 +122,7 @@ class Func(FunctionDecorator):
                 msg = "Cannot parametrize requires with {python} when python is None or a bool."
                 raise ValueError(msg)
             return formatted
-        msg = (
-            "The requires of a not-yet-parametrized session cannot be parametrized."
-        )  # pragma: no cover
+        msg = "The requires of a not-yet-parametrized session cannot be parametrized."  # pragma: no cover
         raise TypeError(msg)  # pragma: no cover
 
 

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -201,5 +201,4 @@ def lazy_stable_topo_sort(
         return filter(
             lambda node: not (node == root and hash(node) == hash(root)), sort
         )
-    else:
-        return sort
+    return sort

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -1,0 +1,205 @@
+# Copyright 2022 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import itertools
+from collections import OrderedDict
+from typing import Hashable, Iterable, Iterator, Mapping, TypeVar
+
+Node = TypeVar("Node", bound=Hashable)
+
+
+class CycleError(ValueError):
+    """An exception indicating that a cycle was encountered in a graph."""
+
+
+def lazy_stable_topo_sort(
+    dependencies: Mapping[Node, Iterable[Node]],
+    root: Node,
+    drop_root: bool = True,
+) -> Iterator[Node]:
+    """Returns the "lazy, stable" topological sort of a dependency graph.
+
+    The sort returned will be a topological sort of the subgraph containing only
+    ``root`` and its (recursive) dependencies. ``root`` will not be included in the
+    output sort if ``drop_root`` is ``True``.
+
+    The sort returned is "lazy" in the sense that a node will not appear any earlier in
+    the output sort than is necessitated by its dependents.
+
+    The sort returned is "stable" in the sense that the relative order of two nodes in
+    ``dependencies[node]`` is preserved in the output sort, except when doing so would
+    prevent the output sort from being either topological or lazy. The order of nodes in
+    ``dependencies[node]`` allows the caller to exert a preference on the order of the
+    output sort.
+
+    For example, consider:
+
+    >>> list(
+    ...     lazy_stable_topo_sort(
+    ...         dependencies = {
+    ...             "a": ["c", "b"],
+    ...             "b": [],
+    ...             "c": [],
+    ...             "d": ["e"],
+    ...             "e": ["c"],
+    ...             "root": ["a", "d"],
+    ...         },
+    ...         "root",
+    ...         drop_root=False,
+    ...     )
+    ... )
+    ["c", "b", "a", "e", "d", "root"]
+
+    Notice that:
+
+        1.  This is a topological sort of the dependency graph. That is, nodes only
+            occur in the sort after all of their dependencies occur.
+
+        2.  Had we also included a node ``"f": ["b"]`` but kept ``dependencies["root"]``
+            the same, the output would not have changed. This is because ``"f"`` was not
+            requested directly by including it in ``dependencies["root"]`` or
+            transitively as a (recursive) dependency of a node in
+            ``dependencies["root"]``.
+
+        3.  ``"e"`` occurs no earlier than was required by its dependents ``{"d"}``.
+            This is an example of the sort being "lazy". If ``"e"`` had occurred in the
+            output any earlier---for example, just before ``"a"``---the sort would not
+            have been lazy, but (in this example) the output would still have been a
+            topological sort.
+
+        4.  Because the topological order between ``"a"`` and ``"d"`` is undefined and
+            because it is possible to do so without making the output sort non-lazy,
+            ``"a"`` and ``"d"`` are kept in the relative order that they have in
+            ``dependencies["root"]``. This is an example of the sort being stable
+            between pairs in ``dependencies[node]`` whenever possible. If ``"a"``'s
+            dependency list was instead ``["d"]``, however, the relative order between
+            ``"a"`` and ``"d"`` in ``dependencies["root"]`` would have been ignored to
+            satisfy this dependency.
+
+            Similarly, ``"b"`` and ``"c"`` are kept in the relative order that they have
+            in ``dependencies["a"]``. If ``"c"``'s dependency list was instead
+            ``["b"]``, however, the relative order between ``"b"`` and ``"c"`` in
+            ``dependencies["a"]`` would have been ignored to satisfy this dependency.
+
+    This implementation of this function is recursive and thus should not be used on
+    large dependency graphs, but it is suitable for noxfile-sized dependency graphs.
+
+    Args:
+        dependencies (Mapping[~nox._resolver.Node, Iterable[~nox._resolver.Node]]):
+            A mapping from each node in the graph to the (ordered) list of nodes that it
+            depends on. Using a mapping type with O(1) lookup (e.g. `dict`) is strongly
+            suggested.
+        root (~nox._resolver.Node):
+            The root node to start the sort at. If ``drop_root`` is not ``True``,
+            ``root`` will be the last element of the output.
+        drop_root (bool):
+            If ``True``, ``root`` will be not be included in the output sort. Defaults
+            to ``True``.
+
+
+    Returns:
+        Iterator[~nox._resolver.Node]: The "lazy, stable" topological sort of the
+        subgraph containing ``root`` and its dependencies.
+
+    Raises:
+        ~nox._resolver.CycleError: If a dependency cycle is encountered.
+    """
+
+    visited = {node: False for node in dependencies}
+
+    def prepended_by_dependencies(
+        node: Node,
+        walk: OrderedDict[Node, None] | None = None,
+    ) -> Iterator[Node]:
+        """Yields a node's dependencies depth-first, followed by the node itself.
+
+        A dependency will be skipped if has already been yielded by another call of
+        ``prepended_by_dependencies``. Since ``prepended_by_dependencies`` is recursive,
+        this means that each node will only be yielded once, and only the deepest
+        occurrence of a node will be yielded.
+
+        Args:
+            node (~nox._resolver.Node):
+                A node in the dependency graph.
+            walk (OrderedDict[~nox._resolver.Node, None] | None):
+                An ``OrderedDict`` whose keys are the nodes traversed when walking a
+                path leading up to ``node`` on the reversed-edge dependency graph.
+                Defaults to ``OrderedDict()``.
+
+        Yields:
+            ~nox._resolver.Node: ``node``'s direct dependencies, each
+            prepended by their own direct dependencies, and so forth recursively,
+            depth-first, followed by ``node``.
+
+        Raises:
+            ValueError: If a dependency cycle is encountered.
+        """
+        nonlocal visited
+        # We would like for ``walk`` to be an ordered set so that we get (a) O(1) ``node
+        # in walk`` and (b) so that we can use the order to report to the user what the
+        # dependency cycle is, if one is encountered. The standard library does not have
+        # an ordered set type, so we instead use the keys of an ``OrderedDict[Node,
+        # None]`` as an ordered set.
+        walk = walk or OrderedDict()
+        walk = extend_walk(walk, node)
+        if not visited[node]:
+            visited[node] = True
+            # Recurse for each node in dependencies[node] in order so that we adhere to
+            # the ``dependencies[node]`` order preference if doing so is possible.
+            yield from itertools.chain.from_iterable(
+                prepended_by_dependencies(dependency, walk)
+                for dependency in dependencies[node]
+            )
+            yield node
+        else:
+            return
+
+    def extend_walk(
+        walk: OrderedDict[Node, None], node: Node
+    ) -> OrderedDict[Node, None]:
+        """Extend a walk by a node, checking for dependency cycles.
+
+        Args:
+            walk (OrderedDict[~nox._resolver.Node, None]):
+                See ``prepended_by_dependencies``.
+            nodes (~nox._resolver.Node):
+                A node to extend the walk with.
+
+        Returns:
+            OrderedDict[~nox._resolver.Node, None]: ``walk``, extended by
+            ``node``.
+
+        Raises:
+            ValueError: If extending ``walk`` by ``node`` introduces a cycle into the
+                represented walk on the dependency graph.
+        """
+        walk = walk.copy()
+        if node in walk:
+            # Dependency cycle found.
+            walk_list = list(walk)
+            cycle = walk_list[walk_list.index(node) :] + [node]
+            raise CycleError("Nodes are in a dependency cycle", tuple(cycle))
+        else:
+            walk[node] = None
+        return walk
+
+    sort = prepended_by_dependencies(root)
+    if drop_root:
+        return filter(
+            lambda node: not (node == root and hash(node) == hash(root)), sort
+        )
+    else:
+        return sort

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -192,8 +192,7 @@ def lazy_stable_topo_sort(
             walk_list = list(walk)
             cycle = walk_list[walk_list.index(node) :] + [node]
             raise CycleError("Nodes are in a dependency cycle", tuple(cycle))
-        else:
-            walk[node] = None
+        walk[node] = None
         return walk
 
     sort = prepended_by_dependencies(root)

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -228,6 +228,7 @@ class Manifest:
             ~nox._resolver.CycleError: If a dependency cycle is encountered.
         """
         sessions_by_id = self.all_sessions_by_signature
+
         # For each session that was parametrized from a list of Pythons, create a fake
         # parent session that depends on it.
         parent_sessions: set[SessionRunner] = set()

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -45,8 +45,7 @@ def session_decorator(
     *,
     default: bool = ...,
     requires: Sequence[str] | None = ...,
-) -> Callable[[F], F]:
-    ...
+) -> Callable[[F], F]: ...
 
 
 def session_decorator(

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -44,7 +44,9 @@ def session_decorator(
     tags: Sequence[str] | None = ...,
     *,
     default: bool = ...,
-) -> Callable[[F], F]: ...
+    requires: Sequence[str] | None = ...,
+) -> Callable[[F], F]:
+    ...
 
 
 def session_decorator(
@@ -58,6 +60,7 @@ def session_decorator(
     tags: Sequence[str] | None = None,
     *,
     default: bool = True,
+    requires: Sequence[str] | None = None,
 ) -> F | Callable[[F], F]:
     """Designate the decorated function as a session."""
     # If `func` is provided, then this is the decorator call with the function
@@ -78,6 +81,7 @@ def session_decorator(
             venv_params=venv_params,
             tags=tags,
             default=default,
+            requires=requires,
         )
 
     if py is not None and python is not None:
@@ -90,6 +94,7 @@ def session_decorator(
         python = py
 
     final_name = name or func.__name__
+
     fn = Func(
         func,
         python,
@@ -99,8 +104,9 @@ def session_decorator(
         venv_params,
         tags=tags,
         default=default,
+        requires=requires,
     )
-    _REGISTRY[final_name] = fn
+    _REGISTRY[name or func.__name__] = fn
     return fn
 
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -915,6 +915,12 @@ class SessionRunner:
         self.result: Result | None = None
         self.multi = multi
 
+        if getattr(func, "parametrize", None):
+            self.multi = True
+
+    def __repr__(self) -> str:
+        return f"<SessionRunner {self.name}: {self.signatures!r} {self.multi}>"
+
     @property
     def description(self) -> str | None:
         doc = self.func.__doc__

--- a/tests/resources/noxfile_requires.py
+++ b/tests/resources/noxfile_requires.py
@@ -57,9 +57,6 @@ def h(session):
     print(session.name)
 
 
-#
-
-
 @nox.session(requires=["j"])
 def i(session):
     print(session.name)
@@ -68,9 +65,6 @@ def i(session):
 @nox.session(requires=["i"])
 def j(session):
     print(session.name)
-
-
-#
 
 
 @nox.session(python=["3.9", "3.10"])
@@ -88,15 +82,9 @@ def n(session):
     print(session.name)
 
 
-#
-
-
 @nox.session(requires=["does_not_exist"])
 def o(session):
     print(session.name)
-
-
-#
 
 
 @nox.session(python=["3.9", "3.10"])
@@ -107,9 +95,6 @@ def p(session):
 @nox.session(python=None, requires=["p-{python}"])
 def q(session):
     print(session.name)
-
-
-#
 
 
 @nox.session

--- a/tests/resources/noxfile_requires.py
+++ b/tests/resources/noxfile_requires.py
@@ -1,0 +1,128 @@
+# Copyright 2022 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import nox
+
+
+@nox.session(requires=["c", "b"])
+def a(session):
+    print(session.name)
+
+
+@nox.session()
+def b(session):
+    print(session.name)
+
+
+@nox.session()
+def c(session):
+    print(session.name)
+
+
+@nox.session(requires=["e"])
+def d(session):
+    print(session.name)
+
+
+@nox.session(requires=["c"])
+def e(session):
+    print(session.name)
+
+
+@nox.session(requires=["b", "g"])
+def f(session):
+    print(session.name)
+
+
+@nox.session(requires=["b", "h"])
+def g(session):
+    print(session.name)
+
+
+@nox.session(requires=["c"])
+def h(session):
+    print(session.name)
+
+
+#
+
+
+@nox.session(requires=["j"])
+def i(session):
+    print(session.name)
+
+
+@nox.session(requires=["i"])
+def j(session):
+    print(session.name)
+
+
+#
+
+
+@nox.session(python=["3.9", "3.10"])
+def k(session):
+    print(session.name)
+
+
+@nox.session(requires=["k"])
+def m(session):
+    print(session.name)
+
+
+@nox.session(python="3.10", requires=["k-{python}"])
+def n(session):
+    print(session.name)
+
+
+#
+
+
+@nox.session(requires=["does_not_exist"])
+def o(session):
+    print(session.name)
+
+
+#
+
+
+@nox.session(python=["3.9", "3.10"])
+def p(session):
+    print(session.name)
+
+
+@nox.session(python=None, requires=["p-{python}"])
+def q(session):
+    print(session.name)
+
+
+#
+
+
+@nox.session
+def r(session):
+    print(session.name)
+    raise Exception("Fail!")
+
+
+@nox.session(requires=["r"])
+def s(session):
+    print(session.name)
+
+
+@nox.session(requires=["r"])
+def t(session):
+    print(session.name)

--- a/tests/resources/noxfile_requires.py
+++ b/tests/resources/noxfile_requires.py
@@ -126,3 +126,19 @@ def s(session):
 @nox.session(requires=["r"])
 def t(session):
     print(session.name)
+
+
+@nox.parametrize("django", ["1.9", "2.0"])
+@nox.session
+def u(session, django):
+    print(session.name)
+
+
+@nox.session(requires=["u(django='1.9')", "u(django='2.0')"])
+def v(session):
+    print(session.name)
+
+
+@nox.session(requires=["u"])
+def w(session):
+    print(session.name)

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -248,7 +248,7 @@ def test_generate_calls_ids():
 
 
 def test_generate_calls_tags():
-    f = mock.Mock(should_warn={}, tags=[])
+    f = mock.Mock(should_warn={}, tags=[], requires=[])
     f.__name__ = "f"
 
     arg_names = ("foo",)
@@ -267,7 +267,7 @@ def test_generate_calls_tags():
 
 
 def test_generate_calls_merge_tags():
-    f = mock.Mock(should_warn={}, tags=["tag1", "tag2"])
+    f = mock.Mock(should_warn={}, tags=["tag1", "tag2"], requires=[])
     f.__name__ = "f"
 
     arg_names = ("foo",)

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -167,6 +167,7 @@ def test_parametrize_decorator_multiple_and_stack():
 def test_generate_calls_simple():
     f = mock.Mock(should_warn={}, tags=[])
     f.__name__ = "f"
+    f.requires = None
     f.some_prop = 42
 
     arg_names = ("abc",)
@@ -199,6 +200,7 @@ def test_generate_calls_simple():
 def test_generate_calls_multiple_args():
     f = mock.Mock(should_warn=None, tags=[])
     f.__name__ = "f"
+    f.requires = None
 
     arg_names = ("foo", "abc")
     call_specs = [
@@ -225,6 +227,7 @@ def test_generate_calls_multiple_args():
 def test_generate_calls_ids():
     f = mock.Mock(should_warn={}, tags=[])
     f.__name__ = "f"
+    f.requires = None
 
     arg_names = ("foo",)
     call_specs = [

--- a/tests/test__resolver.py
+++ b/tests/test__resolver.py
@@ -1,0 +1,165 @@
+# Copyright 2022 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from nox._resolver import CycleError, lazy_stable_topo_sort
+
+
+@pytest.mark.parametrize(
+    ("dependencies", "expected"),
+    [
+        # Assert typical example with the following features:
+        # 1.  Topological sort.
+        # 2.  Ignores nodes outside the subgraph of ``dependencies[root]`` and its
+        #     (recursive) dependencies. (``"f"`` and ``"g"``).
+        # 3.  Lazy (``"e"`` does not occur any earlier than it needs to for ``"d"``).
+        # 4.  Obeys ``dependencies[node]`` order preference when possible (``"a"`` and
+        #     ``"d"``, ``"c"`` and ``"b"``).
+        (
+            {
+                "a": ("c", "b"),
+                "b": (),
+                "c": (),
+                "d": ("e",),
+                "e": ("c",),
+                "f": ("b", "g"),
+                "g": (),
+                "0": ("a", "d"),
+            },
+            ("c", "b", "a", "e", "d"),
+        ),
+        # 1.  Topological sort.
+        # 2.  Ignores (``"f"`` and ``"g"``).
+        # 3.  Lazy (``"b"``).
+        # 4.  Obeys order preference (``"d"`` and ``"a"``).
+        # 4.  Obeys order preference (``"c"`` and ``"b"``).
+        (
+            {
+                "a": ("c", "b"),
+                "b": (),
+                "c": (),
+                "d": ("e",),
+                "e": ("c",),
+                "f": ("b", "g"),
+                "g": (),
+                "0": ("d", "a"),
+            },
+            ("c", "e", "d", "b", "a"),
+        ),
+        # 1.  Topological sort.
+        # 2.  Ignores (``"f"`` and ``"g"``).
+        # 4.  Ignores order preference (``"a"`` and ``"d"``) when it is impossible to
+        #     both satisfy a pair preference and produce a producing a topological and
+        #     lazy sort.
+        (
+            {
+                "a": ("d",),
+                "b": (),
+                "c": (),
+                "d": ("e",),
+                "e": ("c",),
+                "f": ("b", "g"),
+                "g": (),
+                "0": ("a", "d"),
+            },
+            ("c", "e", "d", "a"),
+        ),
+        # 1.  Topological sort.
+        # 2.  Ignores (``"f"`` and ``"g"``).
+        # 3.  Lazy (``"e"``).
+        # 4.  Obeys order preference (``"a"`` and ``"d"``).
+        # 4.  Ignores order preference (``"c"`` and ``"b"``).
+        (
+            {
+                "a": ("c", "b"),
+                "b": (),
+                "c": ("b",),
+                "d": ("e",),
+                "e": ("c",),
+                "f": ("b",),
+                "0": ("a", "d"),
+            },
+            ("b", "c", "a", "e", "d"),
+        ),
+        # 1.  Topological sort.
+        # 2.  Ignores (``"f"``).
+        # 3.  Lazy (``"c"``, ``"h"``, ``"a"``, and ``"e"``).
+        # 4.  Obeys order preference (``"g"``, ``"a"``, and ``"d"``).
+        # 4.  Obeys order preference (``"b"`` and ``"g"``).
+        # 4.  Obeys order preference (``"b"`` and ``"h"``).
+        # 4.  Ignores order preference (``"c"`` and ``"b"``). Note that this is despite
+        #     the fact that the topological order between ``"b"`` and ``"c"`` is
+        #     undefined. In the tests above, we only saw a pair order preference ignored
+        #     because the topological order between that pair was defined. Here,
+        #     however, the ``dependencies["a"]`` order preference between ``"b"`` and
+        #     ``"c"`` is ignored because obeying this order preference cannot be done
+        #     without making the sort non-lazy (here, calling ``"c"`` earlier than is
+        #     required by one of its dependents (``"h"``) would be non-lazy).
+        (
+            {
+                "a": ("c", "b"),
+                "b": (),
+                "c": (),
+                "d": ("e",),
+                "e": ("c",),
+                "f": ("b", "g"),
+                "g": ("b", "h"),
+                "h": ("c",),
+                "0": ("g", "a", "d"),
+            },
+            ("b", "c", "h", "g", "a", "e", "d"),
+        ),
+    ],
+)
+def test_lazy_stable_topo_sort(dependencies, expected):
+    actual = tuple(lazy_stable_topo_sort(dependencies, "0"))
+    actual_with_root = tuple(lazy_stable_topo_sort(dependencies, "0", drop_root=False))
+    assert actual == actual_with_root[:-1] == expected
+
+
+@pytest.mark.parametrize(
+    ("dependencies", "expected_cycle"),
+    [
+        # Note that these cycles are inherent to the dependency graph; they cannot be
+        # resolved by ignoring the order preference for a pair in ``dependencies[node]``
+        # for some ``node``.
+        (
+            {
+                "a": ("b",),
+                "b": ("a",),
+                "0": ("a",),
+            },
+            ("a", "b", "a"),
+        ),
+        (
+            {
+                "a": ("c", "b"),
+                "b": (),
+                "c": ("a", "b"),
+                "0": ("a",),
+            },
+            ("a", "c", "a"),
+        ),
+    ],
+)
+def test_lazy_stable_topo_sort_CycleError(dependencies, expected_cycle):
+    with pytest.raises(CycleError) as exc_info:
+        tuple(lazy_stable_topo_sort(dependencies, "0"))
+    # While the exact cycle reported is not unique and is an implementation detail, this
+    # still serves as a regression test for unexpected changes in the implementation's
+    # behavior.
+    assert exc_info.value.args[1] == expected_cycle

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -495,6 +495,8 @@ def test_main_with_bad_session_names(run_nox, session):
         (("g", "a", "d"), ("b", "c", "h", "g", "a", "e", "d")),
         (("m",), ("k-3.9", "k-3.10", "m")),
         (("n",), ("k-3.10", "n")),
+        (("v",), ("u(django='1.9')", "u(django='2.0')", "v")),
+        (("w",), ("u(django='1.9')", "u(django='2.0')", "w")),
     ],
 )
 def test_main_requires(run_nox, sessions, expected_order):
@@ -537,6 +539,13 @@ def test_main_requires_chain_fail(run_nox, session):
     returncode, _, stderr = run_nox(f"--noxfile={noxfile}", f"--session={session}")
     assert returncode != 0
     assert "Prerequisite session r was not successful" in stderr
+
+
+@pytest.mark.parametrize("session", ("w", "u"))
+def test_main_requries_modern_param(run_nox, session):
+    noxfile = os.path.join(RESOURCES, "noxfile_requires.py")
+    returncode, _, stderr = run_nox(f"--noxfile={noxfile}", f"--session={session}")
+    assert returncode == 0
 
 
 def test_main_noxfile_options(monkeypatch, generate_noxfile_options):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -965,6 +965,7 @@ class TestSessionRunner:
         func.python = None
         func.venv_backend = None
         func.reuse_venv = False
+        func.requires = []
         return nox.sessions.SessionRunner(
             name="test",
             signatures=["test(1, 2)"],
@@ -1168,6 +1169,7 @@ class TestSessionRunner:
         def func(session):
             session.error("meep")
 
+        func.requires = []
         runner.func = func
 
         result = runner.execute()
@@ -1180,6 +1182,7 @@ class TestSessionRunner:
         def func(session):
             session.skip("meep")
 
+        func.requires = []
         runner.func = func
 
         result = runner.execute()
@@ -1237,6 +1240,7 @@ class TestSessionRunner:
         def func(session):
             raise nox.command.CommandFailed()
 
+        func.requires = []
         runner.func = func
 
         result = runner.execute()
@@ -1249,6 +1253,7 @@ class TestSessionRunner:
         def func(session):
             raise KeyboardInterrupt()
 
+        func.requires = []
         runner.func = func
 
         with pytest.raises(KeyboardInterrupt):
@@ -1260,6 +1265,7 @@ class TestSessionRunner:
         def func(session):
             raise ValueError("meep")
 
+        func.requires = []
         runner.func = func
 
         result = runner.execute()
@@ -1277,6 +1283,7 @@ class TestSessionRunner:
                 f' os.environ["NOX_CURRENT_SESSION"] == {session.name!r} else 0)',
             )
 
+        func.requires = []
         runner.func = func
 
         result = runner.execute()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -41,6 +41,7 @@ session_func.venv_backend = None
 session_func.should_warn = {}
 session_func.tags = []
 session_func.default = True
+session_func.requires = []
 
 
 def session_func_with_python():
@@ -50,6 +51,7 @@ def session_func_with_python():
 session_func_with_python.python = "3.8"
 session_func_with_python.venv_backend = None
 session_func_with_python.default = True
+session_func_with_python.requires = []
 
 
 def session_func_venv_pythons_warning():


### PR DESCRIPTION
Hi! This adds session dependency resolution support to close #453 and as a prerequisite for #167. This implementation works and is fully tested, but this PR still needs some documentation and discussion.

To get a topological sort of the dependency graph, I haven't used `graphlib.TopologicalSorter` or [NetworkX DAG methods](https://networkx.org/documentation/stable/reference/algorithms/dag.html) because I don't think that such sorters can give nox the desired behavior. The problem, essentially, is that we don't just want any topological sorter but a specific (unique, hopefully) topological sort that the user can exert some ordering preference over. For example:

```python
#  /<- e <- d
# c <------ a
# b <------/
#  \<------ f

@nox.session(python=False, requires=["c", "b"])
def a(session): pass

@nox.session(python=False)
def b(session): pass

@nox.session(python=False)
def c(session): pass

@nox.session(python=False, requires=["e"])
def d(session): pass

@nox.session(python=False, requires=["c"])
def e(session): pass

@nox.session(python=False, requires=["b"])
def f(session): pass
```

For this noxfile I would expect the following behavior:

*   `nox -s e` runs ``c, e``.
*   `nox -s d a` runs ``c, e, d, b, a``. Note that `d` and its dependencies run before `a` and its dependencies.
*   `nox -s a d` runs ``c, b, a, e, d``. Note that `a` and its dependencies run before `d` and its dependencies. Also note that `c` runs before `b`; I'll get to the reasoning for this in a moment.

The problem with using `graphlib.TopologicalSorter` or NetworkX DAG methods is twofold:

1.  These sorters/methods take as argument just the graph. One cannot specify that they want only a topological sort of the subgraph specifically containing the `-s` sessions and their dependencies. That is, in the examples above, nox should not run `f` because `f` is not a (direct or recursive) dependency of any of the sessions specified by `-s`.

    One could work around this issue by using e.g. `graphlib.TopologicalSorter` to produce a topological sort of the entire graph, and then drop from this sort anything in `{f and its recursive dependencies} - {*{node and its recursive dependencies} for node in (sessions listed in -s)}`. This is still more computationally expensive than it needs to be though, although this should have minimal effect for typical noxfile-sized graphs.

2.  Crucially: `graphlib.TopologicalSorter` and `networkx.topological_sort` give no guarantee over *which* topological sort you get; they just guarantee that you get *some* topological sort. (The other NX topo. sorter, `networkx.lexicographical_topological_sort`, does give a unique sort, but I don't think that it can be used to produce the desired behavior still.)

    For nox's behavior to be deterministic, though, we want a specific topological sort<sup>1</sup>. For example, in the example above, all of the following are valid topological sorts for subgraph for `nox -s a d` (i.e. the subgraph containing only `a`, `d`, and their recursive dependencies):

    1. `c, b, a, e, d` # the desired sort for nox -s a d ?
    1. `b, c, a, e, d` # the desired sort for nox -s a d ?
    1. `c, e, b, a, d`
    1. `b, c, e, a, d`
    1. `c, b, e, a, d`
    1. `c, e, d, b, a` # the desired sort for nox -s d a
    1. `b, c, e, d, a`
    1. `c, b, e, d, a`
    1. `c, e, b, d, a`

    I would argue that (i) is the desired sort for `nox -s a d` because it is

    *   "Lazy", i.e. it does not try run dependencies earlier than necessary. E.g. `e` does not run any earlier than is required for `d`.
    *   "Stable". E.g. it runs `a` and its dependencies before `d` and its dependencies since `a` occurred before `d` in the `-s` listing. Similarly, it runs `c` before `b` since `c` occurred before `b` in `a`'s `requires`.

    (ii) almost satisfies the same properties, but it is not stable in `b` and `c`. The way that the dependency resolver can choose between (1) and (2) without leaving this choice as an undefined implementation detail is by preferring to run `b` and `c` in the order that they appear in `a`'s `requires`. This is exactly analogous to how the resolver prefers to run `a` and `d` in the order that they occur in in `nox -s a d`.

3.  As a minor point, using `graphlib` would require nox to either vendor graphlib or depend on e.g. `graphlib-backport`, which is a small third-party dependency that would be best to avoid for security.

`nox._resolver.lazy_stable_topo_sort` is a topological sorting algorithm with these properties. It can also detect what graph cycle prevented the subgraph from having a topological sort if the subgraph is cyclic. Its implementation is recursive, but I believe it is still best-case and worst-case `O(n)` where `n` is the number of nodes in the subgraph that a sort is requested for. I would love to hear if these properties also make sense to others.

Another point of discussion for this is how `requires` should interact with filtering flags (`-k`, `-t`). I think that nox should not allow sessions to be accidentally run without their dependencies, i.e. the manifest filtering should be done first, followed by inserting the dependencies of the filtered queue into to the queue appropriately. Thoughts?

### More Examples

*   Change `a` in the above example to 

    ```python
    @nox.session(python=False, requires=["d"])
    def a(session): pass
    ```

    Then `nox -s a d` runs `c, e, d, a`. The resolver ignores the order preference `a, d` and will instead run `d` before `a` to satisfy the dependency `a -> d`.

*   ```python
    #  /<------\
    # a    b    c
    #  \->/ \->/

    # E.g. `nox -s c` gives "Sessions are in a dependency cycle: c -> a -> b -> c".

    @nox.session(python=False, requires=["b"])
    def a(session): pass

    @nox.session(python=False, requires=["c"])
    def b(session): pass

    @nox.session(python=False, requires=["a"])
    def c(session): pass
    ```

*   ```python
    # a <- b <- c

    nox.options.error_on_external_run = True
    nox.options.sessions = ("c",)

    @nox.session(python=False)
    def a(session):
        session.run("fail")

    @nox.session(python=False, requires=["a"])
    def b(session):
        print("I will never run since one of my required sessions doesn't succeed!")

    @nox.session(python=False, requires=["b"])
    def c(session):
        print("I will never run since one of my required sessions doesn't succeed!")
    ```

*   Putting `{python}` in `requires` is also supported:

    ```python
    @nox.session(python=["3.8", "3.9"])
    def a(session): pass

    @nox.session(requires=["a"])
    def b(session): pass
    # e.g `nox -s b` runs [a-3.8, a-3.9, b].

    @nox.session(python="3.8", requires=["a-{python}"])
    def c(session): pass
    # e.g. `nox -s c` runs [a-3.8, c].
    ```

Also see the `nox._resolver.lazy_stable_topo_sort` docstring and `tests/test__resolver.py` for more examples and comments.

<sup>1</sup>: It would also be great if the topo. sort was not just deterministic but was mathematically unique such that which sort nox uses is not simply an implementation detail but part of the spec. Uniqueness is hard though. In any case, I think nox should pin its topological sorting algorithm for stability, i.e. don't use an algorithm implemented in an external dependency that we can't pin since pinning it could break installs of other packages into the same venv (thus potentially breaking packaging of nox for most non-Nix package managers).