### PR TITLE
fix: invalid input in action's localpython step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
       id: localpython
       with:
         python-version: "3.7 - 3.10"
-        activate-environment: false
+        update-environment: false
 
     - name: "Validate input"
       id: helper


### PR DESCRIPTION
GHA does not error out on invalid input name but instead only shows a warning which is why this did go unnoticed.