### PR TITLE
chore: use python 3.7+ syntax for action_helper.py

### DIFF
--- a/.github/action_helper.py
+++ b/.github/action_helper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,14 +29,12 @@ repos:
     hooks:
       - id: isort
         args: ["-a", "from __future__ import annotations"]
-        exclude: ^.github/action_helper.py$
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
-        exclude: ^.github/action_helper.py$
 
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "0.3.3"


### PR DESCRIPTION
With #629 merged in, `action_helper.py` can now use python 3.7+ syntax and undergo the same pre-commit checks as the rest of the code base.