### PR TITLE
Export session name in envvar NOX_CURRENT_SESSION

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -724,6 +724,7 @@ class SessionRunner:
             with cwd:
                 self._create_venv()
                 session = Session(self)
+                session.env["NOX_CURRENT_SESSION"] = session.name
                 self.func(session)
 
             # Nothing went wrong; return a success.


### PR DESCRIPTION
Closes #636. The environment variable `NOX_CURRENT_SESSION` is populated with the name of the current session in all subcommands of that session. 

There were a couple places to place this small bit of code. Each location caused some problems with the existing tests. The current place was chosen because it intuitively makes sense to take code that the user would write at the top of their session functions and move it up into the thing that calls the session function. Let me know if you think it belongs elsewhere.