### PR TITLE
fix: Include action helper in MANIFEST.in

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "0.3.3"
+    rev: "0.3.5"
     hooks:
       - id: pyproject-fmt
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 recursive-include nox *.jinja2
-include nox/py.typed
+include nox/py.typed .github/action_helper.py
 recursive-include tests *.py


### PR DESCRIPTION
Closes #644 

Added `.github/action_helper.py` to manifest file.

I unpacked the tarball generated by [pypa/build](https://github.com/pypa/build) and you can see that it gets correctly included:

<img width="309" alt="image" src="https://user-images.githubusercontent.com/62767721/184829681-e4faa200-22ae-4dd8-ade9-c2736f63e12d.png">
