### PR TITLE
refactor: Drop `py` as a dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "0.3.3"
+    rev: "0.3.5"
     hooks:
       - id: pyproject-fmt
 

--- a/nox/command.py
+++ b/nox/command.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 
 import os
 import shlex
+import shutil
 import sys
 from typing import Any, Iterable, Sequence
-
-import py
 
 from nox.logger import logger
 from nox.popen import popen
@@ -40,18 +39,14 @@ class CommandFailed(Exception):
 
 def which(program: str, paths: list[str] | None) -> str:
     """Finds the full path to an executable."""
-    full_path = None
+    if paths is not None:
+        full_path = shutil.which(program, path=os.pathsep.join(paths))
+        if full_path:
+            return full_path
 
-    if paths:
-        full_path = py.path.local.sysfind(program, paths=paths)
-
+    full_path = shutil.which(program)
     if full_path:
-        return full_path.strpath  # type: ignore[no-any-return]
-
-    full_path = py.path.local.sysfind(program)
-
-    if full_path:
-        return full_path.strpath  # type: ignore[no-any-return]
+        return full_path
 
     logger.error(f"Program {program} not found.")
     raise CommandFailed(f"Program {program} not found")

--- a/nox/command.py
+++ b/nox/command.py
@@ -18,6 +18,7 @@ import os
 import shlex
 import shutil
 import sys
+from platform import platform
 from typing import Any, Iterable, Sequence
 
 from nox.logger import logger
@@ -39,6 +40,9 @@ class CommandFailed(Exception):
 
 def which(program: str, paths: list[str] | None) -> str:
     """Finds the full path to an executable."""
+    if platform().lower() == "windows":
+        program = f"{program}.exe"
+
     if paths is not None:
         full_path = shutil.which(program, path=os.pathsep.join(paths))
         if full_path:

--- a/nox/command.py
+++ b/nox/command.py
@@ -40,7 +40,7 @@ class CommandFailed(Exception):
 
 def which(program: str, paths: list[str] | None) -> str:
     """Finds the full path to an executable."""
-    if platform().lower() == "windows":
+    if platform().lower() == "windows":  # pragma: no cover
         program = f"{program}.exe"
 
     if paths is not None:

--- a/nox/command.py
+++ b/nox/command.py
@@ -40,7 +40,7 @@ class CommandFailed(Exception):
 
 def which(program: str, paths: list[str] | None) -> str:
     """Finds the full path to an executable."""
-    if platform().lower() == "windows":  # pragma: no cover
+    if "windows" in platform().lower():  # pragma: no cover
         program = f"{program}.exe"
 
     if paths is not None:

--- a/nox/command.py
+++ b/nox/command.py
@@ -18,7 +18,6 @@ import os
 import shlex
 import shutil
 import sys
-from platform import platform
 from typing import Any, Iterable, Sequence
 
 from nox.logger import logger
@@ -40,9 +39,6 @@ class CommandFailed(Exception):
 
 def which(program: str, paths: list[str] | None) -> str:
     """Finds the full path to an executable."""
-    if "windows" in platform().lower():  # pragma: no cover
-        program = f"{program}.exe"
-
     if paths is not None:
         full_path = shutil.which(program, path=os.pathsep.join(paths))
         if full_path:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import enum
 import hashlib
 import os
@@ -23,9 +24,7 @@ import re
 import sys
 import unicodedata
 from types import TracebackType
-from typing import Any, Callable, Iterable, Mapping, Sequence
-
-import py
+from typing import Any, Callable, Generator, Iterable, Mapping, Sequence
 
 import nox.command
 from nox import _typing
@@ -35,6 +34,20 @@ from nox.virtualenv import CondaEnv, PassthroughEnv, ProcessEnv, VirtualEnv
 
 if _typing.TYPE_CHECKING:
     from nox.manifest import Manifest
+
+
+@contextlib.contextmanager
+def _chdir(path: str) -> Generator[None, None, None]:
+    """
+    Change the current working directory to the given path.
+    Follows python 3.11's chdir behaviour.
+    """
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
 
 
 def _normalize_path(envdir: str, path: str | bytes) -> str:
@@ -715,13 +728,9 @@ class SessionRunner:
         logger.warning(f"Running session {self.friendly_name}")
 
         try:
-            # By default, Nox should quietly change to the directory where
-            # the noxfile.py file is located.
-            cwd = py.path.local(
-                os.path.realpath(os.path.dirname(self.global_config.noxfile))
-            ).as_cwd()
+            cwd = os.path.realpath(os.path.dirname(self.global_config.noxfile))
 
-            with cwd:
+            with _chdir(cwd):
                 self._create_venv()
                 session = Session(self)
                 session.env["NOX_CURRENT_SESSION"] = session.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "colorlog<7.0.0,>=2.6.1",
   'importlib-metadata; python_version < "3.8"',
   "packaging>=20.9",
-  "py<2.0.0,>=1.4",
   'typing-extensions>=3.7.4; python_version < "3.8"',
   "virtualenv>=14",
 ]

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -23,6 +23,7 @@ import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
@@ -155,18 +156,17 @@ def test_run_path_nonexistent():
     assert "/non/existent" not in result
 
 
-def test_run_path_existent(tmpdir, monkeypatch):
+def test_run_path_existent(tmp_path: Path, monkeypatch):
     executable_name = (
-        "testexc" if platform.platform().lower() != "windows" else "testexc.exe"
+        "testexc.exe" if platform.platform().lower() == "windows" else "testexc"
     )
-    executable = tmpdir.join(executable_name)
-    executable.ensure("")
+    executable = tmp_path.joinpath(executable_name)
     executable.chmod(0o700)
 
     with mock.patch("nox.command.popen") as mock_command:
         mock_command.return_value = (0, "")
-        nox.command.run([executable_name], silent=True, paths=[tmpdir.strpath])
-        mock_command.assert_called_with([executable.strpath], env=None, silent=True)
+        nox.command.run([executable_name], silent=True, paths=[str(tmp_path)])
+        mock_command.assert_called_with([str(executable)], env=None, silent=True)
 
 
 def test_run_external_warns(tmpdir, caplog):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -158,7 +158,7 @@ def test_run_path_nonexistent():
 
 def test_run_path_existent(tmp_path: Path):
     executable_name = (
-        "testexc.exe" if platform.platform().lower() == "windows" else "testexc"
+        "testexc.exe" if "windows" in platform.platform().lower() else "testexc"
     )
     tmp_path.touch()
     executable = tmp_path.joinpath(executable_name)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -156,13 +156,16 @@ def test_run_path_nonexistent():
 
 
 def test_run_path_existent(tmpdir, monkeypatch):
-    executable = tmpdir.join("testexc")
+    executable_name = (
+        "testexc" if platform.platform().lower() != "windows" else "testexc.exe"
+    )
+    executable = tmpdir.join(executable_name)
     executable.ensure("")
     executable.chmod(0o700)
 
     with mock.patch("nox.command.popen") as mock_command:
         mock_command.return_value = (0, "")
-        nox.command.run(["testexc"], silent=True, paths=[tmpdir.strpath])
+        nox.command.run([executable_name], silent=True, paths=[tmpdir.strpath])
         mock_command.assert_called_with([executable.strpath], env=None, silent=True)
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -18,6 +18,7 @@ import ctypes
 import logging
 import os
 import platform
+import shutil
 import signal
 import subprocess
 import sys
@@ -55,6 +56,13 @@ def test_run_silent(capsys):
 
     assert "123" in result
     assert out == ""
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="Needs git")
+def test_run_not_in_path(capsys):
+    # Paths falls back on the environment PATH if the command is not found.
+    result = nox.command.run(["git", "--version"], paths=["."])
+    assert result is True
 
 
 def test_run_verbosity(capsys, caplog):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -156,11 +156,13 @@ def test_run_path_nonexistent():
     assert "/non/existent" not in result
 
 
-def test_run_path_existent(tmp_path: Path, monkeypatch):
+def test_run_path_existent(tmp_path: Path):
     executable_name = (
         "testexc.exe" if platform.platform().lower() == "windows" else "testexc"
     )
+    tmp_path.touch()
     executable = tmp_path.joinpath(executable_name)
+    executable.touch()
     executable.chmod(0o700)
 
     with mock.patch("nox.command.popen") as mock_command:

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -227,7 +227,7 @@ def test_condaenv_detection(make_conda):
     venv.create()
 
     proc_result = subprocess.run(
-        [py.path.local.sysfind("conda").strpath, "list"],
+        [shutil.which("conda"), "list"],
         env=venv.env,
         check=True,
         capture_output=True,
@@ -565,7 +565,7 @@ def test__resolved_interpreter_windows_full_path(which, make_one):
     # or otherwise) and the path exists, that we accept it.
     venv, _ = make_one(interpreter=r"c:\Python36\python.exe")
 
-    which.return_value = py.path.local(venv.interpreter)
+    which.return_value = venv.interpreter
     assert venv._resolved_interpreter == r"c:\Python36\python.exe"
     which.assert_called_once_with(r"c:\Python36\python.exe")
 


### PR DESCRIPTION
closes #583 

I picked up @henryiii's excellent work on #592, resolved the conflicts and the issue he described with `shutil.which` expecting a `.exe`.

This should hopefully be everything needed to drop `py.path`, @henryiii I'd be grateful if you could check this out to see if I've solved the issue adequately as you have more of the context than me 🙂 