### PR TITLE
fix: nox.session.run-ing commands with pathlib.Path arguments

### DIFF
--- a/nox/command.py
+++ b/nox/command.py
@@ -71,8 +71,7 @@ def _clean_env(env: dict[str, str] | None) -> dict[str, str] | None:
 
 
 def _shlex_join(args: Sequence[str]) -> str:
-    # shlex.join() was added in Python 3.8
-    return " ".join(shlex.quote(arg) for arg in args)
+    return " ".join(shlex.quote(os.fspath(arg)) for arg in args)
 
 
 def run(
@@ -92,10 +91,7 @@ def run(
         success_codes = [0]
 
     cmd, args = args[0], args[1:]
-    try:
-        full_cmd = f"{cmd} {_shlex_join(args)}"
-    except TypeError:
-        full_cmd = f"{cmd} {args}"
+    full_cmd = f"{cmd} {_shlex_join(args)}"
 
     cmd_path = which(cmd, paths)
 

--- a/nox/command.py
+++ b/nox/command.py
@@ -92,7 +92,10 @@ def run(
         success_codes = [0]
 
     cmd, args = args[0], args[1:]
-    full_cmd = f"{cmd} {_shlex_join(args)}"
+    try:
+        full_cmd = f"{cmd} {_shlex_join(args)}"
+    except TypeError:
+        full_cmd = f"{cmd} {args}"
 
     cmd_path = which(cmd, paths)
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -22,6 +22,7 @@ import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
@@ -110,6 +111,19 @@ def test_run_verbosity_failed_command(capsys, caplog):
 
     # Nothing is logged but the error is still written to stderr
     assert not logs
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="See https://github.com/python/cpython/issues/85815",
+)
+def test_run_non_str():
+    result = nox.command.run(
+        [Path(PYTHON), "-c", "import sys; print(sys.argv)", Path(PYTHON)],
+        silent=True,
+    )
+
+    assert PYTHON in result
 
 
 def test_run_env_unicode():


### PR DESCRIPTION
Everything previously really worked fine in theory, but the debug string
which is logged (and calls shlex.quote) was blowing up trying
to quote a pathlib.Path object. I'm somewhat surprised upstream
shlex.quote doesn't support pathlib.Path objects (yet?) but for
now this just falls back to a cruder representation.

(Obviously there are other ways to handle this, like calling str() on all the args, let me know if you prefer something else).

This also apparently doesn't work on Windows, but that's because `subprocess.Popen` is apparently broken with WindowsPaths. The upstream bug is  https://github.com/python/cpython/issues/85815.