### PR TITLE
Enhance environment variables passing

### DIFF
--- a/nox/command.py
+++ b/nox/command.py
@@ -52,16 +52,16 @@ def which(program: str, paths: list[str] | None) -> str:
     raise CommandFailed(f"Program {program} not found")
 
 
-def _clean_env(env: dict[str, str] | None) -> dict[str, str] | None:
-    if env is None:
-        return None
-
+def _clean_env(env: dict[str, str] | None) -> dict[str, str]:
     clean_env = {}
 
     # Ensure systemroot is passed down, otherwise Windows will explode.
-    clean_env["SYSTEMROOT"] = os.environ.get("SYSTEMROOT", "")
+    if sys.platform == "win32":
+        clean_env["SYSTEMROOT"] = os.environ.get("SYSTEMROOT", "")
 
-    clean_env.update(env)
+    if env is not None:
+        clean_env.update(env)
+
     return clean_env
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -144,6 +144,7 @@ def test_run_env_unicode():
     assert "123" in result
 
 
+@mock.patch("sys.platform", "win32")
 def test_run_env_systemroot():
     systemroot = os.environ.setdefault("SYSTEMROOT", "sigil")
 
@@ -181,7 +182,7 @@ def test_run_path_existent(tmp_path: Path):
     with mock.patch("nox.command.popen") as mock_command:
         mock_command.return_value = (0, "")
         nox.command.run([executable_name], silent=True, paths=[str(tmp_path)])
-        mock_command.assert_called_with([str(executable)], env=None, silent=True)
+        mock_command.assert_called_with([str(executable)], env=mock.ANY, silent=True)
 
 
 def test_run_external_warns(tmpdir, caplog):


### PR DESCRIPTION
Closes #253 

Introduced a new parameter `include_invocation_env_vars` to the `session.run` related methods. It can be a boolean or an iterable of vars that should be included from the nox invocation environment. Some env vars (inspired by [tox](https://tox.wiki/en/latest/config.html#conf-passenv) are always passed in to ensure proper functionality of stdlib functions and pip.