### PR TITLE
Fix example in docs using `session.posargs`

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -329,7 +329,7 @@ You can also pass the notified session positional arguments:
     def consume_thing(session):
         # The 'consume' command has the arguments
         # sent to it from the 'prepare_thing' session
-        session.run("consume", "thing", session.posargs)
+        session.run("consume", "thing", *session.posargs)
 
 Note that this will only have the desired effect if selecting sessions to run via the ``--session/-s`` flag. If you simply run ``nox``, all selected sessions will be run.
 


### PR DESCRIPTION
Current example feeds `session.posargs` directly into `session.run`. I don't _think_ this works—as `session.posargs` is a list. Added an unpacking argument `*` as a quick fix.

---

Thanks for the great work here!