### PR TITLE
chore: switch to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ repository = "https://github.com/wntrblm/nox"
 nox = "nox.__main__:main"
 tox-to-nox = "nox.tox_to_nox:main"
 
+
 [tool.hatch]
 metadata.allow-ambiguous-features = true  # disable normalization (tox-to-nox) for back-compat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
-build-backend = "setuptools.build_meta"
+build-backend = "hatchling.build"
 requires = [
-  "setuptools>=61",
+  "hatchling"
 ]
 
 [project]
@@ -63,11 +63,6 @@ repository = "https://github.com/wntrblm/nox"
 nox = "nox.__main__:main"
 tox-to-nox = "nox.tox_to_nox:main"
 
-
-[tool.setuptools]
-zip-safe = false
-include-package-data = true
-package-data = { "nox" = [ "py.typed" ] }
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "hatchling.build"
 requires = [
-  "hatchling"
+  "hatchling",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,8 @@ repository = "https://github.com/wntrblm/nox"
 nox = "nox.__main__:main"
 tox-to-nox = "nox.tox_to_nox:main"
 
-# Disable extra name normalization (tox-to-nox) for back-compat.
 [tool.hatch]
-metadata.allow-ambiguous-features = true
+metadata.allow-ambiguous-features = true  # disable normalization (tox-to-nox) for back-compat
 
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ repository = "https://github.com/wntrblm/nox"
 nox = "nox.__main__:main"
 tox-to-nox = "nox.tox_to_nox:main"
 
+# Disable extra name normalization (tox-to-nox) for back-compat.
+[tool.hatch]
+metadata.allow-ambiguous-features = true
+
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Quick examples of moving to hatchling. Slightly less config, 2 seconds faster, less verbose build messages, ~~reduced chance of version conflicts~~, and slightly cleaner output. Other packages using hatchling include pipx, black, tox4, etc.

Just thought I'd throw it out there. Current system is completely fine too. Mostly making the PR since I tried it out and already had it. One benefit of PEP 621 is that it's easy to switch to the best performing backend. :)

PS: It occurred to me on the version conflicts (some packages limit setuptools < 60), that you don't have hatchling or setuptools when you have a wheel, so that should never be a problem. This is very much just a developer choice.

From #655.