### PR TITLE
Fix a typo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ To run both of these sessions, just run::
 
     nox
 
-For each session, Nox will automatically create `virtualenv`_ with the appropriate interpreter, install the specified dependencies, and run the commands in order.
+For each session, Nox will automatically create a `virtualenv`_ with the appropriate interpreter, install the specified dependencies, and run the commands in order.
 
 To learn how to install and use Nox, see the :doc:`tutorial`. For documentation on configuring sessions, see :doc:`config`. For documentation on running ``nox``, see :doc:`usage`.
 


### PR DESCRIPTION
From my point of view, there's a missing 'a', so instead of saying "create virtualenv", we say "create _a_ virtualenv". [^1]

[^1]: Disclaimer: I'm not a native English speaker, so I may be wrong.