### PR TITLE
Point action docs to 2022.8.7 not latest

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -36,6 +36,7 @@ If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/n
     # setup nox with all active CPython and PyPY versions provided by
     # the GitHub Actions environment i.e.
     # python-versions: "3.7, 3.8, 3.9, 3.10, pypy-3.7, pypy-3.8, pypy-3.9"
+    # this uses version 2022.8.7 but any Nox tag will work here
     - uses: wntrblm/nox@2022.8.7
 
     # setup nox only for a given list of python versions
@@ -43,6 +44,7 @@ If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/n
     # - Version specifiers shall be supported by actions/setup-python
     # - You can specify up-to 20 versions
     # - There can only be one "major.minor" per interpreter i.e. "3.7.0, 3.7.1" is invalid
+    # this uses version 2022.8.7 but any Nox tag will work here
     - uses: wntrblm/nox@2022.8.7
       with:
           python-versions: "2.7, 3.5, 3.11-dev, pypy-3.9"

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -36,14 +36,14 @@ If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/n
     # setup nox with all active CPython and PyPY versions provided by
     # the GitHub Actions environment i.e.
     # python-versions: "3.7, 3.8, 3.9, 3.10, pypy-3.7, pypy-3.8, pypy-3.9"
-    - uses: wntrblm/nox@latest
+    - uses: wntrblm/nox@2022.8.7
 
     # setup nox only for a given list of python versions
     # Limitations:
     # - Version specifiers shall be supported by actions/setup-python
     # - You can specify up-to 20 versions
     # - There can only be one "major.minor" per interpreter i.e. "3.7.0, 3.7.1" is invalid
-    - uses: wntrblm/nox@latest
+    - uses: wntrblm/nox@2022.8.7
       with:
           python-versions: "2.7, 3.5, 3.11-dev, pypy-3.9"
 


### PR DESCRIPTION
Fixes a mention in the docs to `@latest` which doesn't actually refer to a valid tag, my bad for not spotting! 👍🏻 Thanks @henryiii 