### PR TITLE
feat: --json --list-sessions

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,6 +30,11 @@ To list all available sessions, including parametrized sessions:
     nox --list
     nox --list-sessions
 
+If you'd like to use the output in later processing, you can add ``--json`` to
+get json output for the selected session. Fields include ``session`` (pretty
+name), ``name``, ``description``, ``python`` (null if not specified), ``tags``,
+and ``call_spec`` (for parametrized sessions).
+
 
 .. _session_execution_order:
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -265,6 +265,13 @@ options.add_options(
         help="List all available sessions and exit.",
     ),
     _option_set.Option(
+        "json",
+        "--json",
+        group=options.groups["sessions"],
+        action="store_true",
+        help="JSON output formatting. Requires list-sessions currently.",
+    ),
+    _option_set.Option(
         "sessions",
         "-s",
         "-e",

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -179,15 +179,11 @@ def filter_manifest(manifest: Manifest, global_config: Namespace) -> Manifest | 
             logger.error("Error while collecting sessions.")
             logger.error(exc.args[0])
             return 3
+
     if not manifest and not global_config.list_sessions:
         print("No sessions selected. Please select a session with -s <session name>.\n")
         _produce_listing(manifest, global_config)
         return 0
-
-    # JSON output requires list sessions also be specified
-    if global_config.json and not global_config.list_sessions:
-        logger.error("Must specify --list-sessions with --json")
-        return 3
 
     # Filter by python interpreter versions.
     if global_config.pythons:
@@ -299,6 +295,11 @@ def honor_list_request(manifest: Manifest, global_config: Namespace) -> Manifest
     """
     if not (global_config.list_sessions or global_config.json):
         return manifest
+
+    # JSON output requires list sessions also be specified
+    if global_config.json and not global_config.list_sessions:
+        logger.error("Must specify --list-sessions with --json")
+        return 3
 
     if global_config.json:
         _produce_json_listing(manifest, global_config)


### PR DESCRIPTION
Closes https://github.com/wntrblm/nox/issues/658.

No tests yet. Putting out an initial design.

Here's the output on nox itself:

```bash
nox --json -l -s cover lint | jq
```
```json
[
  {
    "session": "cover",
    "name": "cover",
    "description": "Coverage analysis.",
    "python": null,
    "tags": [],
    "call_spec": {}
  },
  {
    "session": "lint",
    "name": "lint",
    "description": "Run pre-commit linting.",
    "python": "3.9",
    "tags": [],
    "call_spec": {}
  }
]
```

And it can be processed by jq:

```console
$ nox --json -l -s tests | jq '.[].session'
"tests-3.7"
"tests-3.8"
"tests-3.9"
"tests-3.10"
"tests-3.11"
```

Thoughts?
