### PR TITLE
chore: move to 3.11 final

### DIFF
--- a/.github/action_helper.py
+++ b/.github/action_helper.py
@@ -14,7 +14,7 @@ def filter_version(version: str) -> str:
     else:
         version_ = version
 
-    # remove extra specifier e.g. "3.11-dev" => "3.11"
+    # remove extra specifier e.g. "3.12-dev" => "3.12"
     version_ = version_.split("-")[0]
 
     version_parts = version_.split(".")
@@ -52,15 +52,15 @@ def setup_action(input_: str) -> None:
     # other interpreters also define pythonX.Y symlinks.
     versions = pypy_versions + cpython_versions
 
-    # we want to install python 3.10 last to ease nox set-up
-    if "3.10" in cpython_versions_filtered:
-        index = cpython_versions_filtered.index("3.10")
+    # we want to install python 3.11 last to ease nox set-up
+    if "3.11" in cpython_versions_filtered:
+        index = cpython_versions_filtered.index("3.11")
         index = versions.index(cpython_versions[index])
         cpython_310 = versions.pop(index)
         versions.append(cpython_310)
     else:
         # add this to install nox
-        versions.append("3.10")
+        versions.append("3.11")
 
     if len(versions) > 20:
         raise ValueError(f"too many interpreters to install: {len(versions)} > 20")

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -26,5 +26,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
         with:
-          python-versions: "2.7.18, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11-dev, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9-v7.3.9"
+          python-versions: "2.7.18, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9-v7.3.9"
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_all_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -18,7 +18,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v2
-        if: matrix.python-version != '3.11-dev'
+        if: matrix.python-version != '3.11'
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -27,9 +27,9 @@ jobs:
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
         run: nox --non-interactive --error-on-missing-interpreter --session "tests-${{ matrix.python-version }}" -- --full-trace
-        if: matrix.python-version != '3.11-dev'
+        if: matrix.python-version != '3.11'
       - name: Run tests on ${{ matrix.os }}
-        if: matrix.python-version == '3.11-dev'
+        if: matrix.python-version == '3.11'
         run: nox --non-interactive --error-on-missing-interpreter --session "tests-3.11" -- --full-trace
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,7 @@ jobs:
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
         run: nox --non-interactive --error-on-missing-interpreter --session "tests-${{ matrix.python-version }}" -- --full-trace
-        if: matrix.python-version != '3.11'
-      - name: Run tests on ${{ matrix.os }}
-        if: matrix.python-version == '3.11'
-        run: nox --non-interactive --error-on-missing-interpreter --session "tests-3.11" -- --full-trace
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-versions:
     description: "comma-separated list of python versions to install"
     required: false
-    default: "3.7, 3.8, 3.9, 3.10, pypy-3.7, pypy-3.8, pypy-3.9"
+    default: "3.7, 3.8, 3.9, 3.10, 3.11, pypy-3.7, pypy-3.8, pypy-3.9"
 branding:
   icon: package
   color: blue
@@ -15,7 +15,7 @@ runs:
     - uses: actions/setup-python@v4
       id: localpython
       with:
-        python-version: "3.7 - 3.10"
+        python-version: "3.7 - 3.11"
         update-environment: false
 
     - name: "Validate input"

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -47,7 +47,7 @@ If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/n
     # this uses version 2022.8.7 but any Nox tag will work here
     - uses: wntrblm/nox@2022.8.7
       with:
-          python-versions: "2.7, 3.5, 3.11-dev, pypy-3.9"
+          python-versions: "2.7, 3.5, 3.11, pypy-3.9"
 
 .. _pip: https://pip.readthedocs.org
 .. _user site: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -186,17 +186,17 @@ In addition to Nox supporting executing single sessions, it also supports runnin
 
 .. code-block:: console
 
-    nox --extra-pythons 3.8 3.9
+    nox --extra-pythons 3.8 3.9 3.10
 
 This will, in addition to specified Python versions in the Noxfile, also create sessions for the specified versions.
 
 This option can be combined with ``--python`` to replace, instead of appending, the Python interpreter for a given session::
 
-    nox --python 3.10 --extra-python 3.10 -s lint
+    nox --python 3.11 --extra-python 3.11 -s lint
 
 Instead of passing both options, you can use the ``--force-python`` shorthand::
 
-    nox --force-python 3.10 -s lint
+    nox --force-python 3.11 -s lint
 
 Also, you can specify ``python`` in place of a specific version. This will run the session
 using the ``python`` specified for the current ``PATH``::

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -13,7 +13,7 @@ VALID_VERSIONS = {
     "2.7.18": "2.7",
     "3.9-dev": "3.9",
     "3.10": "3.10",
-    "3.11.0.beta1": "3.11",
+    "3.11": "3.11",
     "pypy-3.7": "3.7",
     "pypy-3.8-v7.3.9": "3.8",
     "pypy-3.9": "3.9",
@@ -42,8 +42,8 @@ def test_filter_version_invalid_minor():
 
 
 VALID_VERSION_LISTS = {
-    "3.7, 3.8, 3.9, 3.10, pypy-3.7, pypy-3.8, pypy-3.9": [
-        "::set-output name=interpreter_count::7",
+    "3.7, 3.8, 3.9, 3.10, 3.11, pypy-3.7, pypy-3.8, pypy-3.9": [
+        "::set-output name=interpreter_count::8",
         "::set-output name=interpreter_0::pypy-3.7",
         "::set-output name=interpreter_1::pypy-3.8",
         "::set-output name=interpreter_2::pypy-3.9",
@@ -51,35 +51,37 @@ VALID_VERSION_LISTS = {
         "::set-output name=interpreter_4::3.8",
         "::set-output name=interpreter_5::3.9",
         "::set-output name=interpreter_6::3.10",
+        "::set-output name=interpreter_7::3.11",
     ],
     "": [
         "::set-output name=interpreter_count::1",
-        "::set-output name=interpreter_0::3.10",
+        "::set-output name=interpreter_0::3.11",
     ],
-    "3.10.4": [
+    "3.11.4": [
         "::set-output name=interpreter_count::1",
-        "::set-output name=interpreter_0::3.10.4",
+        "::set-output name=interpreter_0::3.11.4",
     ],
     "3.9-dev,pypy3.9-nightly": [
         "::set-output name=interpreter_count::3",
         "::set-output name=interpreter_0::pypy3.9-nightly",
         "::set-output name=interpreter_1::3.9-dev",
-        "::set-output name=interpreter_2::3.10",
+        "::set-output name=interpreter_2::3.11",
     ],
-    "3.10, 3.9, 3.8": [
-        "::set-output name=interpreter_count::3",
-        "::set-output name=interpreter_0::3.9",
-        "::set-output name=interpreter_1::3.8",
-        "::set-output name=interpreter_2::3.10",
+    "3.11, 3.10, 3.9, 3.8": [
+        "::set-output name=interpreter_count::4",
+        "::set-output name=interpreter_0::3.10",
+        "::set-output name=interpreter_1::3.9",
+        "::set-output name=interpreter_2::3.8",
+        "::set-output name=interpreter_3::3.11",
     ],
     ",".join(f"3.{minor}" for minor in range(20)): [
         "::set-output name=interpreter_count::20"
     ]
     + [
         f"::set-output name=interpreter_{i}::3.{minor}"
-        for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 10)
+        for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 11)
     ]
-    + ["::set-output name=interpreter_19::3.10"],
+    + ["::set-output name=interpreter_19::3.11"],
 }
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -658,12 +658,12 @@ def test_main_color_conflict(capsys, monkeypatch):
 
 
 def test_main_force_python(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["nox", "--force-python=3.10"])
+    monkeypatch.setattr(sys, "argv", ["nox", "--force-python=3.11"])
     with mock.patch("nox.workflow.execute", return_value=0) as execute:
         with mock.patch.object(sys, "exit"):
             nox.__main__.main()
         config = execute.call_args[1]["global_config"]
-    assert config.pythons == config.extra_pythons == ["3.10"]
+    assert config.pythons == config.extra_pythons == ["3.11"]
 
 
 def test_main_reuse_existing_virtualenvs_no_install(monkeypatch):


### PR DESCRIPTION
This moves to using Python 3.11 final on GHA as well as uses it by default for the action.

While doing this, I noticed we are using the deprecated set-output string. I'll try to make a followup that fixes this.
