### PR TITLE
Action: Replace deprecated set-output command

### DIFF
--- a/.github/action_helper.py
+++ b/.github/action_helper.py
@@ -65,9 +65,9 @@ def setup_action(input_: str) -> None:
     if len(versions) > 20:
         raise ValueError(f"too many interpreters to install: {len(versions)} > 20")
 
-    print(f"::set-output name=interpreter_count::{len(versions)}")
+    print(f"interpreter_count={len(versions)}")
     for i, version in enumerate(versions):
-        print(f"::set-output name=interpreter_{i}::{version}")
+        print(f"interpreter_{i}={version}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/action.yml'
+      - '.github/action_helper.py'
       - 'action.yml'
 env:
   FORCE_COLOR: "1"

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: "Validate input"
       id: helper
       run: >
-        '${{ steps.localpython.outputs.python-path }}' '${{ github.action_path }}/.github/action_helper.py' '${{ inputs.python-versions }}'
+        '${{ steps.localpython.outputs.python-path }}' '${{ github.action_path }}/.github/action_helper.py' '${{ inputs.python-versions }}' >>${GITHUB_OUTPUT}
       shell: bash
 
     - uses: actions/setup-python@v4

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -43,45 +43,43 @@ def test_filter_version_invalid_minor():
 
 VALID_VERSION_LISTS = {
     "3.7, 3.8, 3.9, 3.10, 3.11, pypy-3.7, pypy-3.8, pypy-3.9": [
-        "::set-output name=interpreter_count::8",
-        "::set-output name=interpreter_0::pypy-3.7",
-        "::set-output name=interpreter_1::pypy-3.8",
-        "::set-output name=interpreter_2::pypy-3.9",
-        "::set-output name=interpreter_3::3.7",
-        "::set-output name=interpreter_4::3.8",
-        "::set-output name=interpreter_5::3.9",
-        "::set-output name=interpreter_6::3.10",
-        "::set-output name=interpreter_7::3.11",
+        "interpreter_count=8",
+        "interpreter_0=pypy-3.7",
+        "interpreter_1=pypy-3.8",
+        "interpreter_2=pypy-3.9",
+        "interpreter_3=3.7",
+        "interpreter_4=3.8",
+        "interpreter_5=3.9",
+        "interpreter_6=3.10",
+        "interpreter_7=3.11",
     ],
     "": [
-        "::set-output name=interpreter_count::1",
-        "::set-output name=interpreter_0::3.11",
+        "interpreter_count=1",
+        "interpreter_0=3.11",
     ],
     "3.11.4": [
-        "::set-output name=interpreter_count::1",
-        "::set-output name=interpreter_0::3.11.4",
+        "interpreter_count=1",
+        "interpreter_0=3.11.4",
     ],
     "3.9-dev,pypy3.9-nightly": [
-        "::set-output name=interpreter_count::3",
-        "::set-output name=interpreter_0::pypy3.9-nightly",
-        "::set-output name=interpreter_1::3.9-dev",
-        "::set-output name=interpreter_2::3.11",
+        "interpreter_count=3",
+        "interpreter_0=pypy3.9-nightly",
+        "interpreter_1=3.9-dev",
+        "interpreter_2=3.11",
     ],
     "3.11, 3.10, 3.9, 3.8": [
-        "::set-output name=interpreter_count::4",
-        "::set-output name=interpreter_0::3.10",
-        "::set-output name=interpreter_1::3.9",
-        "::set-output name=interpreter_2::3.8",
-        "::set-output name=interpreter_3::3.11",
+        "interpreter_count=4",
+        "interpreter_0=3.10",
+        "interpreter_1=3.9",
+        "interpreter_2=3.8",
+        "interpreter_3=3.11",
     ],
-    ",".join(f"3.{minor}" for minor in range(20)): [
-        "::set-output name=interpreter_count::20"
-    ]
+    ",".join(f"3.{minor}" for minor in range(20)): ["interpreter_count=20"]
     + [
-        f"::set-output name=interpreter_{i}::3.{minor}"
+        f"interpreter_{i}=3.{minor}"
         for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 11)
     ]
-    + ["::set-output name=interpreter_19::3.11"],
+    + ["interpreter_19=3.11"],
 }
 
 


### PR DESCRIPTION
The `set-output` workflow command [has been deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and replaced with writing to an environment file. Update `.github/action_helper.py` to use the new file.
