### PR TITLE
Fix assertion in GHA tests

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -2,13 +2,13 @@ name: Action
 on:
   push:
     branches:
-      - 'main'
-      - '**action**'
+      - "main"
+      - "**action**"
   pull_request:
     paths:
-      - '.github/workflows/action.yml'
-      - '.github/action_helper.py'
-      - 'action.yml'
+      - ".github/workflows/action.yml"
+      - ".github/action_helper.py"
+      - "action.yml"
 env:
   FORCE_COLOR: "1"
 jobs:
@@ -16,7 +16,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-11, macos-12]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            windows-2019,
+            windows-2022,
+            macos-11,
+            macos-12,
+          ]
     steps:
       - uses: actions/checkout@v3
       - uses: ./

--- a/noxfile.py
+++ b/noxfile.py
@@ -130,10 +130,12 @@ def _check_python_version(session: nox.Session) -> None:
         )
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.7", "pypy3.8", "pypy3.9"])
+@nox.session(
+    python=["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9"]
+)
 def github_actions_default_tests(session: nox.Session) -> None:
     """Check default versions installed by the nox GHA Action"""
-    assert sys.version_info[:2] == (3, 10)
+    assert sys.version_info[:2] == (3, 11)
     _check_python_version(session)
 
 


### PR DESCRIPTION
I noticed that on the recent release, the `action_default_tests` were failing asserting that the calling python was 3.10 when in fact it was 3.11 due to #667 

This PR updates the assertion to 3.11 