### PR TITLE
Constrain tox to <4.0.0 and minor fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E501, W503, E203, B950
+extend-ignore = E501, W503, E203, B950, B905
 extend-select = B9
 import-order-style = google
 application-import-names = nox,tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,6 @@ jobs:
       - name: Build sdist and wheel
         run: pipx run build
       - name: Publish distribution PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 [project.optional-dependencies]
 tox_to_nox = [
   "jinja2",
-  "tox",
+  "tox<4",
 ]
 
 [project.urls]
@@ -65,7 +65,7 @@ tox-to-nox = "nox.tox_to_nox:main"
 
 
 [tool.hatch]
-metadata.allow-ambiguous-features = true  # disable normalization (tox-to-nox) for back-compat
+metadata.allow-ambiguous-features = true # disable normalization (tox-to-nox) for back-compat
 
 
 [tool.isort]

--- a/requirements-conda-test.txt
+++ b/requirements-conda-test.txt
@@ -1,7 +1,6 @@
 argcomplete >=1.9.4,<3.0
 colorlog >=2.6.1,<7.0.0
 jinja2
-py >=1.4.0,<2.0.0
 pytest
-tox
+tox<4.0.0
 virtualenv >=14.0.0

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -23,7 +23,6 @@ from textwrap import dedent
 from typing import NamedTuple
 from unittest import mock
 
-import py
 import pytest
 
 import nox.virtualenv

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -675,16 +675,14 @@ def test__resolved_interpreter_windows_path_and_version_fails(
 
 
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
-@mock.patch.object(py._path.local.LocalPath, "check")
 @mock.patch.object(shutil, "which")
-def test__resolved_interpreter_not_found(which, check, make_one):
+def test__resolved_interpreter_not_found(which, make_one):
     # Establish that if an interpreter cannot be found at a standard
     # location on Windows, we raise a useful error.
     venv, _ = make_one(interpreter="python3.6")
 
     # We are on Windows, and nothing can be found.
     which.return_value = None
-    check.return_value = False
 
     # Run the test.
     with pytest.raises(nox.virtualenv.InterpreterNotFound):


### PR DESCRIPTION
- Constrain to tox<4.0.0 until #673 is addressed
- Use recommended pypa/publish version syntax
- Ignore B905 warning which is only specific to 3.10+
- Remove an unused rogue mock of `py._path`
