### PR TITLE
chore: long term fix for bugbear opinionated checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E501, W503, E203, B950, B905
-extend-select = B9
+extend-ignore = E501, W503, E203
+extend-select = B902, B903, B904
 import-order-style = google
 application-import-names = nox,tests


### PR DESCRIPTION
This is a better fix for the opinionated checks for bugbear. Since they may be added supporting newer than EoL Pythons, it’s best to just activate the known safe ones. Otherwise this might have to be fixed every release that adds a new opinionated check.