### PR TITLE
First implementation of tox_to_nox for tox 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        tox-version: ["latest", "<4"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -35,7 +36,33 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --error-on-missing-interpreter --session "tests-${{ matrix.python-version }}" -- --full-trace
+        run: nox --non-interactive --error-on-missing-interpreter --session "tests(python='${{ matrix.python-version }}', tox_version='${{ matrix.tox-version }}')" -- --full-trace
+      - name: Save coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: .coverage.*
+
+  coverage:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Nox-under-test
+        run: |
+          python -m pip install --disable-pip-version-check .
+      - name: Download individual coverage reports
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+      - name: Display structure of downloaded files
+        run: ls -aR
+      - name: Run coverage
+        run: nox --non-interactive --session "cover"
 
   lint:
     runs-on: ubuntu-latest

--- a/nox/tox4_to_nox.jinja2
+++ b/nox/tox4_to_nox.jinja2
@@ -1,0 +1,33 @@
+import nox
+
+{% for envname, envconfig in config.items()|sort: %}
+@nox.session({%- if envconfig.base_python %}python='{{envconfig.base_python}}'{%- endif %})
+def {{fixname(envname)}}(session):
+    {%- if envconfig.description != '' %}
+    """{{envconfig.description}}"""
+    {%- endif %}
+    {%- set envs = envconfig.get('set_env', {}) -%}
+    {%- for key, value in envs.items()|sort: %}
+    session.env['{{key}}'] = '{{value}}'
+    {%- endfor %}
+
+    {%- if envconfig.deps %}
+    session.install({{envconfig.deps}})
+    {%- endif %}
+
+    {%- if not envconfig.skip_install %}
+    {%- if envconfig.use_develop %}
+    session.install('-e', '.')
+    {%- else %}
+    session.install('.')
+    {%- endif -%}
+    {%- endif %}
+
+    {%- if envconfig.change_dir %}
+    session.chdir('{{envconfig.change_dir}}')
+    {%- endif %}
+
+    {%- for command in envconfig.commands %}
+    session.run({{command}})
+    {%- endfor %}
+{% endfor %}

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -17,24 +17,38 @@
 from __future__ import annotations
 
 import argparse
+import os
 import pkgutil
-from typing import Any, Iterator
+import re
+from configparser import ConfigParser
+from pathlib import Path
+from subprocess import check_output
+from typing import Any, Iterable
 
 import jinja2
 import tox.config
+from tox import __version__ as TOX_VERSION
 
-_TEMPLATE = jinja2.Template(
-    pkgutil.get_data(__name__, "tox_to_nox.jinja2").decode("utf-8"),  # type: ignore[union-attr]
-    extensions=["jinja2.ext.do"],
-)
+TOX4 = TOX_VERSION[0] == "4"
+
+if TOX4:
+    _TEMPLATE = jinja2.Template(
+        pkgutil.get_data(__name__, "tox4_to_nox.jinja2").decode("utf-8"),  # type: ignore[union-attr]
+        extensions=["jinja2.ext.do"],
+    )
+else:
+    _TEMPLATE = jinja2.Template(
+        pkgutil.get_data(__name__, "tox_to_nox.jinja2").decode("utf-8"),  # type: ignore[union-attr]
+        extensions=["jinja2.ext.do"],
+    )
 
 
-def wrapjoin(seq: Iterator[Any]) -> str:
+def wrapjoin(seq: Iterable[Any]) -> str:
     return ", ".join([f"'{item}'" for item in seq])
 
 
 def fixname(envname: str) -> str:
-    envname = envname.replace("-", "_")
+    envname = envname.replace("-", "_").replace("testenv:", "")
     if not envname.isidentifier():
         print(
             f"Environment {envname!r} is not a valid nox session name.\n"
@@ -49,7 +63,61 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    config = tox.config.parseconfig([])
+    if TOX4:
+        output = check_output(["tox", "config"], text=True)
+        original_config = ConfigParser()
+        original_config.read_string(output)
+        config: dict[str, dict[str, Any]] = {}
+
+        for name, section in original_config.items():
+            if name == "DEFAULT":
+                continue
+
+            config[name] = dict(section)
+            # Convert set_env from string to dict
+            set_env = {}
+            for var in section.get("set_env", "").strip().splitlines():
+                k, v = var.split("=")
+                if k not in (
+                    "PYTHONHASHSEED",
+                    "PIP_DISABLE_PIP_VERSION_CHECK",
+                    "PYTHONIOENCODING",
+                ):
+                    set_env[k] = v
+
+            config[name]["set_env"] = set_env
+
+            config[name]["commands"] = [
+                wrapjoin(c.split()) for c in section["commands"].strip().splitlines()
+            ]
+
+            config[name]["deps"] = wrapjoin(section["deps"].strip().splitlines())
+
+            for option in "skip_install", "use_develop":
+                if section.get(option):
+                    if section[option] == "False":
+                        config[name][option] = False
+                    else:
+                        config[name][option] = True
+
+            if os.path.isabs(section["base_python"]) or re.match(
+                r"py\d+", section["base_python"]
+            ):
+                impl = (
+                    "python" if section["py_impl"] == "cpython" else section["py_impl"]
+                )
+                config[name]["base_python"] = impl + section["py_dot_ver"]
+
+            change_dir = Path(section.get("change_dir"))
+            rel_to_cwd = change_dir.relative_to(Path.cwd())
+            if str(rel_to_cwd) == ".":
+                config[name]["change_dir"] = None
+            else:
+                config[name]["change_dir"] = rel_to_cwd
+
+    else:
+        config = tox.config.parseconfig([])
+
     output = _TEMPLATE.render(config=config, wrapjoin=wrapjoin, fixname=fixname)
 
     with open(args.output, "w") as outfile:

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -24,7 +24,7 @@ from collections.abc import Iterator
 from configparser import ConfigParser
 from pathlib import Path
 from subprocess import check_output
-from typing import Any, Iterable
+from typing import Any
 
 import jinja2
 import tox.config

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -20,11 +20,10 @@ import argparse
 import os
 import pkgutil
 import re
-from collections.abc import Iterator
 from configparser import ConfigParser
 from pathlib import Path
 from subprocess import check_output
-from typing import Any
+from typing import Any, Iterable
 
 import jinja2
 import tox.config
@@ -44,7 +43,7 @@ else:
     )
 
 
-def wrapjoin(seq: Iterator[Any]) -> str:
+def wrapjoin(seq: Iterable[Any]) -> str:
     """Wrap each item in single quotes and join them with a comma."""
     return ", ".join([f"'{item}'" for item in seq])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,14 +70,6 @@ target-version = "py37"
 [tool.isort]
 profile = "black"
 
-[tool.coverage.run]
-branch = true
-relative_files = true
-omit = [ "nox/_typing.py" ]
-
-[tool.coverage.report]
-exclude_lines = [ "pragma: no cover", "if TYPE_CHECKING:", "@overload" ]
-
 [tool.ruff.lint]
 extend-select = [
   "B",           # flake8-bugbear
@@ -106,6 +98,7 @@ testpaths = [ "tests" ]
 
 [tool.coverage.run]
 branch = true
+relative_files = true
 omit = [ "nox/_typing.py" ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ profile = "black"
 
 [tool.coverage.run]
 branch = true
+relative_files = true
 omit = [ "nox/_typing.py" ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,6 @@ tox-to-nox = "nox.tox_to_nox:main"
 [tool.hatch]
 metadata.allow-ambiguous-features = true # disable normalization (tox-to-nox) for back-compat
 
-[tool.ruff]
-target-version = "py37"
-
-[tool.isort]
-profile = "black"
-
 [tool.ruff.lint]
 extend-select = [
   "B",           # flake8-bugbear
@@ -87,6 +81,12 @@ extend-select = [
 ignore = [
   "ISC001", # Conflicts with formatter
 ]
+
+[tool.ruff]
+target-version = "py37"
+
+[tool.isort]
+profile = "black"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 tox_to_nox = [
   "jinja2",
-  "tox<4",
+  "tox",
 ]
 
 [project.urls]

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -18,8 +18,13 @@ import sys
 import textwrap
 
 import pytest
+from tox import __version__ as TOX_VERSION
 
 from nox import tox_to_nox
+
+TOX4 = TOX_VERSION[0] == "4"
+PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
+PYTHON_VERSION_NODOT = PYTHON_VERSION.replace(".", "")
 
 
 @pytest.fixture
@@ -40,9 +45,9 @@ def makeconfig(tmpdir):
 def test_trivial(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
     [tox]
-    envlist = py27
+    envlist = py{PYTHON_VERSION_NODOT}
     """
         )
     )
@@ -50,12 +55,12 @@ def test_trivial(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
     import nox
 
 
-    @nox.session(python='python2.7')
-    def py27(session):
+    @nox.session(python='python{PYTHON_VERSION}')
+    def py{PYTHON_VERSION_NODOT}(session):
         session.install('.')
     """
         ).lstrip()
@@ -65,9 +70,9 @@ def test_trivial(makeconfig):
 def test_skipinstall(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
     [tox]
-    envlist = py27
+    envlist = py{PYTHON_VERSION_NODOT}
 
     [testenv]
     skip_install = True
@@ -78,12 +83,12 @@ def test_skipinstall(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
     import nox
 
 
-    @nox.session(python='python2.7')
-    def py27(session):
+    @nox.session(python='python{PYTHON_VERSION}')
+    def py{PYTHON_VERSION_NODOT}(session):
     """
         ).lstrip()
     )
@@ -92,9 +97,9 @@ def test_skipinstall(makeconfig):
 def test_usedevelop(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
     [tox]
-    envlist = py27
+    envlist = py{PYTHON_VERSION_NODOT}
 
     [testenv]
     usedevelop = True
@@ -105,12 +110,12 @@ def test_usedevelop(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
     import nox
 
 
-    @nox.session(python='python2.7')
-    def py27(session):
+    @nox.session(python='python{PYTHON_VERSION}')
+    def py{PYTHON_VERSION_NODOT}(session):
         session.install('-e', '.')
     """
         ).lstrip()
@@ -120,12 +125,12 @@ def test_usedevelop(makeconfig):
 def test_commands(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
     [tox]
     envlist = lint
 
     [testenv:lint]
-    basepython = python2.7
+    basepython = python{PYTHON_VERSION}
     commands =
         python setup.py check --metadata --restructuredtext --strict
         flake8 \\
@@ -138,11 +143,11 @@ def test_commands(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
     import nox
 
 
-    @nox.session(python='python2.7')
+    @nox.session(python='python{PYTHON_VERSION}')
     def lint(session):
         session.install('.')
         session.run('python', 'setup.py', 'check', '--metadata', \
@@ -156,12 +161,12 @@ def test_commands(makeconfig):
 def test_deps(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
     [tox]
     envlist = lint
 
     [testenv:lint]
-    basepython = python2.7
+    basepython = python{PYTHON_VERSION}
     deps =
       flake8
       gcp-devrel-py-tools>=0.0.3
@@ -172,11 +177,11 @@ def test_deps(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
     import nox
 
 
-    @nox.session(python='python2.7')
+    @nox.session(python='python{PYTHON_VERSION}')
     def lint(session):
         session.install('flake8', 'gcp-devrel-py-tools>=0.0.3')
         session.install('.')
@@ -188,12 +193,12 @@ def test_deps(makeconfig):
 def test_env(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
     [tox]
     envlist = lint
 
     [testenv:lint]
-    basepython = python2.7
+    basepython = python{PYTHON_VERSION}
     setenv =
         SPHINX_APIDOC_OPTIONS=members,inherited-members,show-inheritance
         TEST=meep
@@ -204,11 +209,11 @@ def test_env(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
     import nox
 
 
-    @nox.session(python='python2.7')
+    @nox.session(python='python{PYTHON_VERSION}')
     def lint(session):
         session.env['SPHINX_APIDOC_OPTIONS'] = \
 'members,inherited-members,show-inheritance'
@@ -222,12 +227,12 @@ def test_env(makeconfig):
 def test_chdir(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
     [tox]
     envlist = lint
 
     [testenv:lint]
-    basepython = python2.7
+    basepython = python{PYTHON_VERSION}
     changedir = docs
     """
         )
@@ -236,11 +241,11 @@ def test_chdir(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
     import nox
 
 
-    @nox.session(python='python2.7')
+    @nox.session(python='python{PYTHON_VERSION}')
     def lint(session):
         session.install('.')
         session.chdir('docs')
@@ -252,12 +257,12 @@ def test_chdir(makeconfig):
 def test_dash_in_envname(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
             [tox]
             envlist = test-with-dash
 
             [testenv:test-with-dash]
-            basepython = python2.7
+            basepython = python{PYTHON_VERSION}
             """
         )
     )
@@ -265,11 +270,11 @@ def test_dash_in_envname(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
         import nox
 
 
-        @nox.session(python='python2.7')
+        @nox.session(python='python{PYTHON_VERSION}')
         def test_with_dash(session):
             session.install('.')
         """
@@ -277,15 +282,16 @@ def test_dash_in_envname(makeconfig):
     )
 
 
+@pytest.mark.skipif(TOX4, reason="Not supported in tox 4.")
 def test_non_identifier_in_envname(makeconfig, capfd):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
             [tox]
             envlist = test-with-&
 
             [testenv:test-with-&]
-            basepython = python2.7
+            basepython = python{PYTHON_VERSION}
             """
         )
     )
@@ -293,11 +299,11 @@ def test_non_identifier_in_envname(makeconfig, capfd):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
         import nox
 
 
-        @nox.session(python='python2.7')
+        @nox.session(python='python{PYTHON_VERSION}')
         def test_with_&(session):
             session.install('.')
         """
@@ -316,12 +322,12 @@ def test_non_identifier_in_envname(makeconfig, capfd):
 def test_descriptions_into_docstrings(makeconfig):
     result = makeconfig(
         textwrap.dedent(
-            """
+            f"""
             [tox]
             envlist = lint
 
             [testenv:lint]
-            basepython = python2.7
+            basepython = python{PYTHON_VERSION}
             description =
                 runs the lint action
                 now with an unnecessary second line
@@ -332,11 +338,11 @@ def test_descriptions_into_docstrings(makeconfig):
     assert (
         result
         == textwrap.dedent(
-            """
+            f"""
             import nox
 
 
-            @nox.session(python='python2.7')
+            @nox.session(python='python{PYTHON_VERSION}')
             def lint(session):
                 \"\"\"runs the lint action now with an unnecessary second line\"\"\"
                 session.install('.')


### PR DESCRIPTION
Fixes: #673 

It seems to me that the easiest way forward is to call `tox config`, parse the output and then preprocess it into a dictionary so it can be easily used in the jinja template.

What do you think?

From this tox.ini:
```
[tox]
envlist = black,mypy,py{36,37,38,39,310,311,312}
isolated_build = True

[testenv]
commands =
    python -m platform
    pytest -v {posargs} test.py
deps =
    pytest

[testenv:black]
description="better than blue"
skip_install=true
deps=black
commands=black --check --diff --extend-exclude=".tox|test" ./

[testenv:mypy]
use_develop=true
deps=mypy
commands=mypy --strict -p marshalparser
```
it now generates this noxfile.py
```python
import nox


@nox.session()
def DEFAULT(session):
    """"""
    session.install('.')

@nox.session(python='/home/lbalhar/.virtualenvs/nox/bin/python')
def testenv_black(session):
    """"better than blue""""
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('black')
    session.run('black --check --diff '--extend-exclude=.tox|test' ./')

@nox.session(python='/home/lbalhar/.virtualenvs/nox/bin/python')
def testenv_mypy(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('mypy')
    session.install('-e', '.')
    session.run('mypy --strict -p marshalparser')

@nox.session(python='py310')
def testenv_py310(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('pytest')
    session.install('.')
    session.run('python -m platform')
    session.run('pytest -v test.py')

@nox.session(python='py311')
def testenv_py311(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('pytest')
    session.install('.')
    session.run('python -m platform')
    session.run('pytest -v test.py')

@nox.session(python='py312')
def testenv_py312(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('pytest')
    session.install('.')
    session.run('python -m platform')
    session.run('pytest -v test.py')

@nox.session(python='py36')
def testenv_py36(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('pytest')
    session.install('.')
    session.run('python -m platform')
    session.run('pytest -v test.py')

@nox.session(python='py37')
def testenv_py37(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('pytest')
    session.install('.')
    session.run('python -m platform')
    session.run('pytest -v test.py')

@nox.session(python='py38')
def testenv_py38(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('pytest')
    session.install('.')
    session.run('python -m platform')
    session.run('pytest -v test.py')

@nox.session(python='py39')
def testenv_py39(session):
    session.env['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
    session.env['PYTHONIOENCODING'] = 'utf-8'
    session.install('pytest')
    session.install('.')
    session.run('python -m platform')
    session.run('pytest -v test.py')

```

I guess that:
* the default env variables should be skipped.
* the default environment should be skipped.

Correct?