### PR TITLE
chore: move to using Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-extend-ignore = E501, W503, E203
-extend-select = B902, B903, B904
-import-order-style = google
-application-import-names = nox,tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,18 +26,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "0.7.0"
+    rev: "0.9.1"
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.243
+    rev: v0.0.249
     hooks:
       - id: ruff
         args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: mypy
         files: ^nox/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "0.9.1"
+    rev: "0.7.0"
     hooks:
       - id: pyproject-fmt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: v0.0.249
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--fix", "--show-fixes"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.1
@@ -55,13 +55,8 @@ repos:
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-      - id: python-check-blanket-noqa
-      - id: python-check-blanket-type-ignore
-      - id: python-no-log-warn
-        exclude: ^tests/test_sessions.py$
       - id: python-no-eval
         exclude: ^nox/manifest.py$
-      - id: python-use-type-annotations
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,43 +25,16 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: ["-a", "from __future__ import annotations"]
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [--py37-plus]
-
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "0.7.0"
     hooks:
       - id: pyproject-fmt
 
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.3
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.243
     hooks:
-      - id: pycln
-        args: [--all]
-        stages: [manual]
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-      - id: yesqa
-        additional_dependencies: &flake8-dependencies
-          - flake8-bugbear
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        exclude: docs/conf.py
-        additional_dependencies: *flake8-dependencies
+      - id: ruff
+        args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -53,7 +53,7 @@ class Param:
             return self.id
         else:
             call_spec = self.call_spec
-            args = [f"{k}={call_spec[k]!r}" for k in call_spec.keys()]
+            args = [f"{k}={call_spec[k]!r}" for k in call_spec]
             return ", ".join(args)
 
     __repr__ = __str__

--- a/nox/command.py
+++ b/nox/command.py
@@ -115,7 +115,7 @@ def run(
 
     try:
         return_code, output = popen(
-            [cmd_path] + list(args), silent=silent, env=env, **popen_kws
+            [cmd_path, *list(args)], silent=silent, env=env, **popen_kws
         )
 
         if return_code not in success_codes:

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -332,10 +332,7 @@ class KeywordLocals(Mapping[str, bool]):
         self._keywords = keywords
 
     def __getitem__(self, variable_name: str) -> bool:
-        for keyword in self._keywords:
-            if variable_name in keyword:
-                return True
-        return False
+        return any(variable_name in keyword for keyword in self._keywords)
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._keywords)
@@ -347,7 +344,7 @@ class KeywordLocals(Mapping[str, bool]):
 def keyword_match(expression: str, keywords: Iterable[str]) -> Any:
     """See if an expression matches the given set of keywords."""
     locals = KeywordLocals(set(keywords))
-    return eval(expression, {}, locals)
+    return eval(expression, {}, locals)  # noqa: PGH001
 
 
 def _null_session_func_(session: Session) -> None:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -69,7 +69,7 @@ class ProcessEnv:
 
         if self.bin_paths:
             self.env["PATH"] = os.pathsep.join(
-                self.bin_paths + [self.env.get("PATH", "")]
+                [*self.bin_paths, self.env.get("PATH", "")]
             )
 
     @property
@@ -264,10 +264,7 @@ class CondaEnv(ProcessEnv):
         # Ensure the pip package is installed.
         cmd.append("pip")
 
-        if self.interpreter:
-            python_dep = f"python={self.interpreter}"
-        else:
-            python_dep = "python"
+        python_dep = f"python={self.interpreter}" if self.interpreter else "python"
         cmd.append(python_dep)
 
         logger.info(f"Creating conda env in {self.location_name} with {python_dep}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,11 @@ ignore_missing_imports = true
 
 
 
+
 [tool.ruff]
 select = [
-  "E", "F", "W",  # flake8
-  "B", "B904",  # flake8-bugbear
+  "E", "F", "W", # flake8
+  "B", "B904",   # flake8-bugbear
   "I",           # isort
   "C4",          # flake8-comprehensions
   "ICN",         # flake8-import-conventions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,28 +52,17 @@ tox_to_nox = [
   "jinja2",
   "tox<4",
 ]
-
 [project.urls]
 bug-tracker = "https://github.com/wntrblm/nox/issues"
 documentation = "https://nox.thea.codes"
 homepage = "https://github.com/wntrblm/nox"
 repository = "https://github.com/wntrblm/nox"
-
 [project.scripts]
 nox = "nox.__main__:main"
 tox-to-nox = "nox.tox_to_nox:main"
 
-
 [tool.hatch]
 metadata.allow-ambiguous-features = true # disable normalization (tox-to-nox) for back-compat
-
-
-[tool.coverage.run]
-branch = true
-omit = [ "nox/_typing.py" ]
-
-[tool.coverage.report]
-exclude_lines = [ "pragma: no cover", "if TYPE_CHECKING:", "@overload" ]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -82,6 +71,13 @@ xfail_strict = true
 filterwarnings = [ "error" ]
 log_cli_level = "info"
 testpaths = [ "tests" ]
+
+[tool.coverage.run]
+branch = true
+omit = [ "nox/_typing.py" ]
+
+[tool.coverage.report]
+exclude_lines = [ "pragma: no cover", "if TYPE_CHECKING:", "@overload" ]
 
 [tool.mypy]
 files = [ "nox/**/*.py", "noxfile.py" ]
@@ -94,6 +90,8 @@ enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
 [[tool.mypy.overrides]]
 module = [ "argcomplete", "colorlog.*", "py", "tox.*" ]
 ignore_missing_imports = true
+
+
 
 [tool.ruff]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,14 +52,17 @@ tox_to_nox = [
   "jinja2",
   "tox<4",
 ]
+
 [project.urls]
 bug-tracker = "https://github.com/wntrblm/nox/issues"
 documentation = "https://nox.thea.codes"
 homepage = "https://github.com/wntrblm/nox"
 repository = "https://github.com/wntrblm/nox"
+
 [project.scripts]
 nox = "nox.__main__:main"
 tox-to-nox = "nox.tox_to_nox:main"
+
 
 [tool.hatch]
 metadata.allow-ambiguous-features = true # disable normalization (tox-to-nox) for back-compat
@@ -90,9 +93,6 @@ enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
 [[tool.mypy.overrides]]
 module = [ "argcomplete", "colorlog.*", "py", "tox.*" ]
 ignore_missing_imports = true
-
-
-
 
 [tool.ruff]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,6 @@ tox-to-nox = "nox.tox_to_nox:main"
 metadata.allow-ambiguous-features = true # disable normalization (tox-to-nox) for back-compat
 
 
-[tool.isort]
-profile = "black"
-
 [tool.coverage.run]
 branch = true
 omit = [ "nox/_typing.py" ]
@@ -97,3 +94,22 @@ enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
 [[tool.mypy.overrides]]
 module = [ "argcomplete", "colorlog.*", "py", "tox.*" ]
 ignore_missing_imports = true
+
+[tool.ruff]
+select = [
+  "E", "F", "W",  # flake8
+  "B", "B904",  # flake8-bugbear
+  "I",           # isort
+  "C4",          # flake8-comprehensions
+  "ICN",         # flake8-import-conventions
+  "ISC",         # flake8-implicit-str-concat
+  "PGH",         # pygrep-hooks
+  "PIE",         # flake8-pie
+  "RUF",         # Ruff-specific
+  "SIM",         # flake8-simplify
+  "UP",          # pyupgrade
+  "YTT",         # flake8-2020
+]
+extend-ignore = ["E501"]
+target-version = "py37"
+exclude = []

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -410,7 +410,7 @@ def test_custom_stdout(capsys, tmpdir):
 
 
 def test_custom_stdout_silent_flag(capsys, tmpdir):
-    with open(str(tmpdir / "out.txt"), "w+b") as stdout:
+    with open(str(tmpdir / "out.txt"), "w+b") as stdout:  # noqa: SIM117
         with pytest.raises(ValueError, match="silent"):
             nox.command.run([PYTHON, "-c", 'print("hi")'], stdout=stdout, silent=True)
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -448,7 +448,7 @@ def test_no_venv_backend_but_some_pythons():
     # the session sets "no venv backend" but declares some pythons
     my_session.python = ["3.7", "3.8"]
     my_session.venv_backend = "none"
-    my_session.should_warn = dict()
+    my_session.should_warn = {}
 
     sessions = manifest.make_session("my_session", my_session)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -38,7 +38,7 @@ def session_func():
 
 session_func.python = None
 session_func.venv_backend = None
-session_func.should_warn = dict()
+session_func.should_warn = {}
 session_func.tags = []
 
 


### PR DESCRIPTION
Ruff can take the place of a lot of other tools, and is 10-100x faster (written in Rust), plugins can't get out of sync, zero dependencies, can auto-fix in some cases, pyproject.toml configuration, and poetry-core updates can't break it (like isort). :)

cibuildwheel, build, scipy, and others have already moved to it.

There are some other nice codes we could enable, but stuck with either what was there before or easy-to-enable (minimal changes) ones.
