### PR TITLE
fix: enable `list_sessions` for session completion

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -229,6 +229,7 @@ def _session_completer(
     prefix: str, parsed_args: argparse.Namespace, **kwargs: Any
 ) -> list[str]:
     global_config = parsed_args
+    global_config.list_sessions = True
     module = load_nox_module(global_config)
     manifest = discover_manifest(module, global_config)
     filtered_manifest = filter_manifest(manifest, global_config)


### PR DESCRIPTION
Otherwise we end up erroring out due to no session being selected (which in turn errors out due to global color setting not finalized/available at this phase yet.)

```shellsession
$ eval -- "$(register-python-argcomplete nox)"
$ export _ARC_DEBUG=1
$ nox -s <TAB>
[...]
  File ".../nox/nox/_options.py", line 234, in _session_completer
    filtered_manifest = filter_manifest(manifest, global_config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../nox/nox/tasks.py", line 185, in filter_manifest
    _produce_listing(manifest, global_config)
  File ".../nox/nox/tasks.py", line 235, in _produce_listing
    reset = parse_colors("reset") if global_config.color else ""
                                     ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'color'. Did you mean: 'nocolor'?
[...]
```