### PR TITLE
Don't run python 2.7 virtualenv tests for newer versions of virtualenv

### DIFF
--- a/nox/_version.py
+++ b/nox/_version.py
@@ -37,7 +37,7 @@ class InvalidVersionSpecifier(Exception):
 
 def get_nox_version() -> str:
     """Return the version of the installed Nox package."""
-    return metadata.version("nox")  # type: ignore[no-untyped-call, no-any-return]
+    return metadata.version("nox")
 
 
 def _parse_string_constant(node: ast.AST) -> str | None:  # pragma: no cover

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -476,7 +476,7 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
 
 @enable_staleness_check
 def test_inner_functions_reusing_venv(make_one):
-    venv, location = make_one(reuse_existing=True, interpreter="3.10")
+    venv, location = make_one(reuse_existing=True)
     venv.create()
 
     # Drop a venv-style pyvenv.cfg into the environment.

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -475,6 +475,20 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
 
 
 @enable_staleness_check
+def test_create_reuse_python38_environment(make_one):
+    venv, location = make_one(reuse_existing=True, interpreter="3.8")
+
+    try:
+        venv.create()
+    except nox.virtualenv.InterpreterNotFound:
+        pytest.skip("Requires Python 3.8 installation.")
+
+    reused = not venv.create()
+
+    assert reused
+
+
+@enable_staleness_check
 @pytest.mark.skipif(
     version.parse(VIRTUALENV_VERSION) >= version.parse("20.22.0"),
     reason="Python 2.7 unsupported for virtualenv>=20.22.0",

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -24,12 +24,15 @@ from typing import NamedTuple
 from unittest import mock
 
 import pytest
+import virtualenv
+from packaging import version
 
 import nox.virtualenv
 
 IS_WINDOWS = nox.virtualenv._SYSTEM == "Windows"
 HAS_CONDA = shutil.which("conda") is not None
 RAISE_ERROR = "RAISE_ERROR"
+VIRTUALENV_VERSION = virtualenv.version.version
 
 
 class TextProcessResult(NamedTuple):
@@ -472,6 +475,10 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
 
 
 @enable_staleness_check
+@pytest.mark.skipif(
+    version.parse(VIRTUALENV_VERSION) >= version.parse("20.22.0"),
+    reason="Python 2.7 unsupported for virtualenv>=20.22.0",
+)
 def test_create_reuse_python2_environment(make_one):
     venv, location = make_one(reuse_existing=True, interpreter="2.7")
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -475,6 +475,7 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
 
 
 @enable_staleness_check
+@pytest.mark.skipif(IS_WINDOWS, reason="Avoid 'No pyvenv.cfg file' error on Windows.")
 def test_inner_functions_reusing_venv(make_one):
     venv, location = make_one(reuse_existing=True)
     venv.create()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -475,8 +475,11 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
 
 
 @enable_staleness_check
-def test_create_reuse_python38_environment(make_one):
+def test_create_reuse_environment_missing_pyvenv_cfg(make_one, monkeypatch):
     venv, location = make_one(reuse_existing=True, interpreter="3.8")
+
+    # Pretend we couldn't read pyvenv config.
+    monkeypatch.setattr(venv, "_read_base_prefix_from_pyvenv_cfg", lambda: None)
 
     try:
         venv.create()


### PR DESCRIPTION
fixes #701 

Newer virtualenv versions have dropped py2.7 support.