### PR TITLE
action: use multiple interpreters features from 'actions/setup-python@v4'

### DIFF
--- a/.github/action_helper.py
+++ b/.github/action_helper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 
 
@@ -11,10 +12,12 @@ def filter_version(version: str) -> str:
         version_ = version[5:]
     elif version.startswith("pypy"):
         version_ = version[4:]
+    elif version.startswith("~"):
+        version_ = version[1:]
     else:
         version_ = version
 
-    # remove extra specifier e.g. "3.12-dev" => "3.12"
+    # remove extra specifier e.g. "3.12-dev" => "3.12", "~3.12.0-0" => "3.12"
     version_ = version_.split("-")[0]
 
     version_parts = version_.split(".")
@@ -56,18 +59,13 @@ def setup_action(input_: str) -> None:
     if "3.11" in cpython_versions_filtered:
         index = cpython_versions_filtered.index("3.11")
         index = versions.index(cpython_versions[index])
-        cpython_310 = versions.pop(index)
-        versions.append(cpython_310)
+        cpython_nox = versions.pop(index)
+        versions.append(cpython_nox)
     else:
         # add this to install nox
         versions.append("3.11")
 
-    if len(versions) > 20:
-        raise ValueError(f"too many interpreters to install: {len(versions)} > 20")
-
-    print(f"interpreter_count={len(versions)}")
-    for i, version in enumerate(versions):
-        print(f"interpreter_{i}={version}")
+    print(f"interpreters={json.dumps(versions)}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -24,6 +24,7 @@ jobs:
             windows-2022,
             macos-11,
             macos-12,
+            macos-13,
           ]
     steps:
       - uses: actions/checkout@v3
@@ -35,5 +36,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
         with:
-          python-versions: "2.7.18, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9-v7.3.9"
+          python-versions: "2.7.18, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9-v7.3.9"
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_all_tests

--- a/action.yml
+++ b/action.yml
@@ -25,86 +25,11 @@ runs:
       shell: bash
 
     - uses: actions/setup-python@v4
+      id: allpython
       with:
-        python-version: "${{ steps.helper.outputs.interpreter_0 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 0 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_1 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 1 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_2 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 2 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_3 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 3 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_4 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 4 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_5 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 5 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_6 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 6 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_7 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 7 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_8 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 8 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_9 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 9 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_10 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 10 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_11 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 11 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_12 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 12 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_13 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 13 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_14 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 14 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_15 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 15 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_16 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 16 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_17 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 17 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_18 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 18 }}
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ steps.helper.outputs.interpreter_19 }}"
-      if: ${{ steps.helper.outputs.interpreter_count > 19 }}
+        python-version: "${{ join(fromJSON(steps.helper.outputs.interpreters), '\n') }}"
+        allow-prereleases: true
 
     - name: "Install nox"
-      run: pipx install --python "${{ steps.localpython.outputs.python-path }}" '${{ github.action_path }}'
+      run: pipx install --python "${{ steps.allpython.outputs.python-path }}" '${{ github.action_path }}'
       shell: bash

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -42,7 +42,6 @@ If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/n
     # setup nox only for a given list of python versions
     # Limitations:
     # - Version specifiers shall be supported by actions/setup-python
-    # - You can specify up-to 20 versions
     # - There can only be one "major.minor" per interpreter i.e. "3.7.0, 3.7.1" is invalid
     # this uses version 2022.8.7 but any Nox tag will work here
     - uses: wntrblm/nox@2022.8.7

--- a/noxfile.py
+++ b/noxfile.py
@@ -149,6 +149,7 @@ def github_actions_default_tests(session: nox.Session) -> None:
         "3.9",
         "3.10",
         "3.11",
+        "3.12",
         "pypy3.7",
         "pypy3.8",
         "pypy3.9",

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -14,6 +15,7 @@ VALID_VERSIONS = {
     "3.9-dev": "3.9",
     "3.10": "3.10",
     "3.11": "3.11",
+    "~3.12.0-0": "3.12",
     "pypy-3.7": "3.7",
     "pypy-3.8-v7.3.9": "3.8",
     "pypy-3.9": "3.9",
@@ -43,45 +45,24 @@ def test_filter_version_invalid_minor():
 
 VALID_VERSION_LISTS = {
     "3.7, 3.8, 3.9, 3.10, 3.11, pypy-3.7, pypy-3.8, pypy-3.9": [
-        "interpreter_count=8",
-        "interpreter_0=pypy-3.7",
-        "interpreter_1=pypy-3.8",
-        "interpreter_2=pypy-3.9",
-        "interpreter_3=3.7",
-        "interpreter_4=3.8",
-        "interpreter_5=3.9",
-        "interpreter_6=3.10",
-        "interpreter_7=3.11",
+        "pypy-3.7",
+        "pypy-3.8",
+        "pypy-3.9",
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
     ],
-    "": [
-        "interpreter_count=1",
-        "interpreter_0=3.11",
-    ],
-    "3.11.4": [
-        "interpreter_count=1",
-        "interpreter_0=3.11.4",
-    ],
-    "3.9-dev,pypy3.9-nightly": [
-        "interpreter_count=3",
-        "interpreter_0=pypy3.9-nightly",
-        "interpreter_1=3.9-dev",
-        "interpreter_2=3.11",
-    ],
-    "3.11, 3.10, 3.9, 3.8": [
-        "interpreter_count=4",
-        "interpreter_0=3.10",
-        "interpreter_1=3.9",
-        "interpreter_2=3.8",
-        "interpreter_3=3.11",
-    ],
-    ",".join(f"3.{minor}" for minor in range(20)): (
-        ["interpreter_count=20"]
-        + [
-            f"interpreter_{i}=3.{minor}"
-            for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 11)
-        ]
-        + ["interpreter_19=3.11"]
-    ),
+    "": ["3.11"],
+    "~3.12.0-0": ["~3.12.0-0", "3.11"],
+    "3.11.4": ["3.11.4"],
+    "3.9-dev,pypy3.9-nightly": ["pypy3.9-nightly", "3.9-dev", "3.11"],
+    "3.11, 3.10, 3.9, 3.8": ["3.10", "3.9", "3.8", "3.11"],
+    ",".join(f"3.{minor}" for minor in range(20)): [
+        f"3.{minor}"
+        for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 11)
+    ] + ["3.11"],
 }
 
 
@@ -90,7 +71,8 @@ def test_setup_action(capsys, version_list):
     setup_action(version_list)
     captured = capsys.readouterr()
     lines = captured.out.splitlines()
-    assert lines == VALID_VERSION_LISTS[version_list]
+    ordered_versions = VALID_VERSION_LISTS[version_list]
+    assert lines == [f"interpreters={json.dumps(ordered_versions)}"]
 
 
 def test_setup_action_multiple_pypy():
@@ -112,8 +94,3 @@ def test_setup_action_multiple_cpython():
         ),
     ):
         setup_action("3.10, 3.10.4")
-
-
-def test_setup_action_too_many_interpreters():
-    with pytest.raises(ValueError, match=r"too many interpreters to install: 21 > 20"):
-        setup_action(",".join(f"3.{minor}" for minor in range(21)))


### PR DESCRIPTION
The nox action can be simplified now that setup-python allows to setup multiple interpreters natively.

This also adds support for `~` version specifier (e.g. `~3.12.0-0`) which mostly should not be necessary as setup-python now supports `allow-prereleases` which transforms `3.12` into `~3.12.0-0` when searching for CPython 3.12.
The `~` specifier might be interesting for those who want a minimum patch version, e.g. `~3.11.1` <=> `>=3.11.1 <3.12`.