### PR TITLE
Create an official Nox badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # Nox
 
+[![Nox](https://img.shields.io/badge/%F0%9F%91%97-Nox-3CE9CE.svg)](https://github.com/wntrblm/nox)
 [![License](https://img.shields.io/github/license/wntrblm/nox)](https://github.com/wntrblm/nox)
 [![PyPI](https://img.shields.io/pypi/v/nox.svg?logo=python)](https://pypi.python.org/pypi/nox)
 [![GitHub](https://img.shields.io/github/v/release/wntrblm/nox?logo=github&sort=semver)](https://github.com/wntrblm/nox)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Nox
 
-[![Nox](https://img.shields.io/badge/%F0%9F%91%97-Nox-3CE9CE.svg)](https://github.com/wntrblm/nox)
+[![Nox](https://img.shields.io/badge/%F0%9F%A6%8A-Nox-D85E00.svg)](https://github.com/wntrblm/nox)
 [![License](https://img.shields.io/github/license/wntrblm/nox)](https://github.com/wntrblm/nox)
 [![PyPI](https://img.shields.io/pypi/v/nox.svg?logo=python)](https://pypi.python.org/pypi/nox)
 [![GitHub](https://img.shields.io/github/v/release/wntrblm/nox?logo=github&sort=semver)](https://github.com/wntrblm/nox)


### PR DESCRIPTION
Projects such as black, isort, Ruff, and Hatch have official badges that they provide to users to allow them to promote their projects to great affect.

### Examples

[![Code style: black][black-badge]](https://github.com/psf/black) [![Imports: isort][isort-badge]](https://pycqa.github.io/isort/) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v1.json)](https://github.com/charliermarsh/ruff) ![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)

[black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
[isort-badge]: https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336

### Proposal

This adds a new badge for Nox inspired by [Alice's dress in the docs](https://github.com/wntrblm/nox/blob/main/docs/_static/alice-full.png). This seemed like as close a logo as the project currently has:

[![Nox](https://img.shields.io/badge/%F0%9F%91%97-Nox-3CE9CE.svg)](https://github.com/wntrblm/nox)

To embed the image:

```
[![Nox](https://img.shields.io/badge/%F0%9F%91%97-Nox-3CE9CE.svg)](https://github.com/wntrblm/nox)
```


### Alternatives

We can't use the current logo directly because shields.io only supports custom logos using SVG thumbnails.

If [Andrea Caprotti](https://github.com/wntrblm/nox/commit/7cbf30f6fb292bc774c170b2d672a35f72e02adf) is able to provide an SVG of the original Alice image (or one derived/inspired by it), we could create a custom badge the way [Ruff does](https://github.com/charliermarsh/ruff/tree/main/assets/badge).