### PR TITLE
tests: fixes when running locally

### DIFF
--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -19,7 +19,7 @@ import textwrap
 
 import pytest
 
-from nox import tox_to_nox
+tox_to_nox = pytest.importorskip("nox.tox_to_nox")
 
 
 @pytest.fixture

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -32,7 +32,7 @@ import nox.virtualenv
 IS_WINDOWS = nox.virtualenv._SYSTEM == "Windows"
 HAS_CONDA = shutil.which("conda") is not None
 RAISE_ERROR = "RAISE_ERROR"
-VIRTUALENV_VERSION = virtualenv.version.version
+VIRTUALENV_VERSION = virtualenv.__version__
 
 
 class TextProcessResult(NamedTuple):


### PR DESCRIPTION
Noticed these when running locally. I think `tox_to_nox` was forcing an old version of `virtualenv` that still had `version.version` - current versions do not. Made the simplest change - a safer long term fix would probably be to use `importlib.metadata.version` instead of depending on something inside the package.
