### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,8 @@ repos:
     hooks:
       - id: pyproject-fmt
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.249
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.255
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.

Also bumped the version while touching it.