### PR TITLE
Change _color_finalizer behavior

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -177,7 +177,7 @@ def _color_finalizer(value: bool, args: argparse.Namespace) -> bool:
     if args.forcecolor:
         return True
 
-    if args.nocolor or 'NO_COLOR' in os.environ:
+    if args.nocolor or "NO_COLOR" in os.environ:
         return False
 
     return sys.stdout.isatty()

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -177,7 +177,7 @@ def _color_finalizer(value: bool, args: argparse.Namespace) -> bool:
     if args.forcecolor:
         return True
 
-    if args.nocolor:
+    if args.nocolor or 'NO_COLOR' in os.environ:
         return False
 
     return sys.stdout.isatty()


### PR DESCRIPTION
Issue: https://github.com/wntrblm/nox/issues/708

### Expected Behavior
`Tests passing. Ideally, I think --force-color should override NO_COLOR in the containing environment rather than collide with it.`


With this modification, if `--force-color` is provided, it will return `True` and **enforce colors**, even if `NO_COLOR` is set in the environment. If `--no-color` is provided or `NO_COLOR` is set in the environment, it will return `False` and **disable** colors unless `--force-color` is also provided.

