### PR TITLE
Use double quotes instead of single in github actions examples

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -162,4 +162,4 @@ Nox knows what sessions it needs to run. Why not tell GitHub Actions what jobs t
         steps:
         - uses: actions/checkout@v3
         - uses: wntrblm/nox@main
-        - run: nox -s '${{ matrix.session }}'
+        - run: nox -s "${{ matrix.session }}"


### PR DESCRIPTION
If you use parametrized tests they will include single quotes, breaking the output 😊

<img width="1699" alt="CleanShot 2023-07-08 at 11 52 11@2x" src="https://github.com/wntrblm/nox/assets/667029/cf6160f2-e08c-4542-855f-4ba5bda25925">
