### PR TITLE
Allow override via noxfile of nox.options.error_on_missing_interpreters

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -454,7 +454,7 @@ options.add_options(
         ("--no-error-on-missing-interpreters",),
         group=options.groups["execution"],
         help="Error instead of skipping sessions if an interpreter can not be located.",
-        default="CI" in os.environ,
+        default=lambda: "CI" in os.environ,
     ),
     *_option_set.make_flag_pair(
         "error_on_external_run",

--- a/tests/resources/noxfile_options.py
+++ b/tests/resources/noxfile_options.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
+# nox.options.error_on_missing_interpreters = {error_on_missing_interpreters} # used by tests
 nox.options.sessions = ["test"]
 
 


### PR DESCRIPTION
Minor follow up to changes introduced by #567 which caused the regression issue for #650 

This PR fixes an issue with the new `default` option in `make_flag_pair` introduced in #567 that caused values set in the `noxfile.py` to be ignored when set to `False` if the default is `True` due to the evaluation done in `flag_pair_merge_func`.

This PR also changes the `default` kwarg option in `make_flag_pair` introduced in #567 to allow callables for ease of testing and therefore switches the default of `error_on_missing_interpreters` to `default=lambda: "CI" in os.environ`. End result should be the same as before.

Also added a test for this to be a bit more thorough with this particular issue of default is `True`, but noxfile is `False`.