### PR TITLE
Removed the problematic Python 2.7.18 version

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -34,7 +34,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
       - uses: ./
         with:
-          python-versions: "2.7.18, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9-v7.3.9"
+          python-versions: "3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9-v7.3.9"
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_all_tests


### PR DESCRIPTION
Removed the problematic Python 2.7.18 version, since Python 2.7 is no longer supported and the specific version 2.7.18 was not found.
I removed it from the python-versions list.

Reference: https://github.com/actions/setup-python/issues/672


<img width="999" alt="image" src="https://github.com/wntrblm/nox/assets/6159524/41a4eada-777e-40d9-95a3-6cd35496f126">
