### PR TITLE
feat: support for reuse_venv option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -157,7 +157,7 @@ Use of :func:`session.install()` is deprecated without a virtualenv since it mod
     def tests(session):
         session.run("pip", "install", "nox")
 
-You can also specify that the virtualenv should *always* be reused instead of recreated every time:
+You can also specify that the virtualenv should *always* be reused instead of recreated every time unless ``--reuse-venv=never``:
 
 .. code-block:: python
 
@@ -432,7 +432,8 @@ The following options can be specified in the Noxfile:
 * ``nox.options.tags`` is equivalent to specifying :ref:`-t or --tags <opt-sessions-pythons-and-keywords>`.
 * ``nox.options.default_venv_backend`` is equivalent to specifying :ref:`-db or --default-venv-backend <opt-default-venv-backend>`.
 * ``nox.options.force_venv_backend`` is equivalent to specifying :ref:`-fb or --force-venv-backend <opt-force-venv-backend>`.
-* ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation.
+* ``nox.options.reuse_venv`` is equivalent to specifying :ref:`--reuse-venv <opt-reuse-venv>`. Preferred over using ``nox.options.reuse_existing_virtualenvs``.
+* ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation. Alias of ``nox.options.reuse_venv``.
 * ``nox.options.stop_on_first_error`` is equivalent to specifying :ref:`--stop-on-first-error <opt-stop-on-first-error>`. You can force this off by specifying ``--no-stop-on-first-error`` during invocation.
 * ``nox.options.error_on_missing_interpreters`` is equivalent to specifying :ref:`--error-on-missing-interpreters <opt-error-on-missing-interpreters>`. You can force this off by specifying ``--no-error-on-missing-interpreters`` during invocation.
 * ``nox.options.error_on_external_run`` is equivalent to specifying :ref:`--error-on-external-run <opt-error-on-external-run>`. You can force this off by specifying ``--no-error-on-external-run`` during invocation.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -433,7 +433,7 @@ The following options can be specified in the Noxfile:
 * ``nox.options.default_venv_backend`` is equivalent to specifying :ref:`-db or --default-venv-backend <opt-default-venv-backend>`.
 * ``nox.options.force_venv_backend`` is equivalent to specifying :ref:`-fb or --force-venv-backend <opt-force-venv-backend>`.
 * ``nox.options.reuse_venv`` is equivalent to specifying :ref:`--reuse-venv <opt-reuse-venv>`. Preferred over using ``nox.options.reuse_existing_virtualenvs``.
-* ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation. Alias of ``nox.options.reuse_venv``.
+* ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation. Alias of ``nox.options.reuse_venv=yes|no``.
 * ``nox.options.stop_on_first_error`` is equivalent to specifying :ref:`--stop-on-first-error <opt-stop-on-first-error>`. You can force this off by specifying ``--no-stop-on-first-error`` during invocation.
 * ``nox.options.error_on_missing_interpreters`` is equivalent to specifying :ref:`--error-on-missing-interpreters <opt-error-on-missing-interpreters>`. You can force this off by specifying ``--no-error-on-missing-interpreters`` during invocation.
 * ``nox.options.error_on_external_run`` is equivalent to specifying :ref:`--error-on-external-run <opt-error-on-external-run>`. You can force this off by specifying ``--no-error-on-external-run`` during invocation.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -188,7 +188,7 @@ By default, Nox deletes and recreates virtualenvs every time it is run. This is
 usually fine for most projects and continuous integration environments as
 `pip's caching <https://pip.pypa.io/en/stable/cli/pip_install/#caching>`_ makes
 re-install rather quick.  However, there are some situations where it is
-advantageous to re-use the virtualenvs between runs.  Use ``-r`` or
+advantageous to reuse the virtualenvs between runs.  Use ``-r`` or
 ``--reuse-existing-virtualenvs`` or for fine-grained control use
 ``--reuse-venv=yes|no|always|never``:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -201,6 +201,10 @@ advantageous to reuse the virtualenvs between runs.  Use ``-r`` or
 If the Noxfile sets ``nox.options.reuse_existing_virtualenvs``, you can override the Noxfile setting from the command line by using ``--no-reuse-existing-virtualenvs``.
 Similarly you can override ``nox.options.reuse_venvs`` from the Noxfile via the command line by using ``--reuse-venv=yes|no|always|never``.
 
+.. note::
+
+    ``--reuse-existing-virtualenvs`` is a alias for ``--reuse-venv=yes`` and ``--no-reuse-existing-virtualenvs`` is an alias for ``--reuse-venv=no``.
+
 Additionally, you can skip the re-installation of packages when a virtualenv is reused.
 Use ``-R`` or ``--reuse-existing-virtualenvs --no-install`` or ``--reuse-venv=yes --no-install``:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -179,26 +179,36 @@ Finally note that the ``--no-venv`` flag is a shortcut for ``--force-venv-backen
     nox --no-venv
 
 .. _opt-reuse-existing-virtualenvs:
+.. _opt-reuse-venv:
 
 Re-using virtualenvs
 --------------------
 
-By default, Nox deletes and recreates virtualenvs every time it is run. This is usually fine for most projects and continuous integration environments as `pip's caching <https://pip.pypa.io/en/stable/cli/pip_install/#caching>`_ makes re-install rather quick. However, there are some situations where it is advantageous to reuse the virtualenvs between runs. Use ``-r`` or ``--reuse-existing-virtualenvs``:
+By default, Nox deletes and recreates virtualenvs every time it is run. This is
+usually fine for most projects and continuous integration environments as
+`pip's caching <https://pip.pypa.io/en/stable/cli/pip_install/#caching>`_ makes
+re-install rather quick.  However, there are some situations where it is
+advantageous to re-use the virtualenvs between runs.  Use ``-r`` or
+``--reuse-existing-virtualenvs`` or for fine-grained control use
+``--reuse-venv=yes|no|always|never``:
 
 .. code-block:: console
 
     nox -r
     nox --reuse-existing-virtualenvs
-
+    nox --reuse-venv=yes # preferred
 
 If the Noxfile sets ``nox.options.reuse_existing_virtualenvs``, you can override the Noxfile setting from the command line by using ``--no-reuse-existing-virtualenvs``.
+Similarly you can override ``nox.options.reuse_venvs`` from the Noxfile via the command line by using ``--reuse-venv=yes|no|always|never``.
 
-Additionally, you can skip the re-installation of packages when a virtualenv is reused. Use ``-R`` or ``--reuse-existing-virtualenvs --no-install``:
+Additionally, you can skip the re-installation of packages when a virtualenv is reused.
+Use ``-R`` or ``--reuse-existing-virtualenvs --no-install`` or ``--reuse-venv=yes --no-install``:
 
 .. code-block:: console
 
     nox -R
     nox --reuse-existing-virtualenvs --no-install
+    nox --reuse-venv=yes --no-install
 
 The ``--no-install`` option causes the following session methods to return early:
 
@@ -206,7 +216,10 @@ The ``--no-install`` option causes the following session methods to return early
 - :func:`session.conda_install <nox.sessions.Session.conda_install>`
 - :func:`session.run_install <nox.sessions.Session.run_install>`
 
-This option has no effect if the virtualenv is not being reused.
+The ``never`` and ``always`` options in ``--reuse-venv`` gives you more fine-grained control
+as it ignores when a ``@nox.session`` has ``reuse_venv=True|False`` defined.
+
+These options have no effect if the virtualenv is not being reused.
 
 .. _opt-running-extra-pythons:
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -27,6 +27,13 @@ import argcomplete
 from nox import _option_set
 from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 
+if sys.version_info < (3, 8):  # pragma: no cover
+    from typing_extensions import Literal
+else:  # pragma: no cover
+    from typing import Literal
+
+ReuseVenvType = Literal["no", "yes", "never", "always"]
+
 """All of Nox's configuration options."""
 
 options = _option_set.OptionSet(
@@ -150,7 +157,7 @@ def _envdir_merge_func(
 
 def _reuse_venv_merge_func(
     command_args: argparse.Namespace, noxfile_args: argparse.Namespace
-) -> str:
+) -> ReuseVenvType:
     """Merge reuse_venv from command args and Noxfile while maintaining
     backwards compatibility with reuse_existing_virtualenvs. Default is "no".
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -27,9 +27,9 @@ import argcomplete
 from nox import _option_set
 from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 
-if sys.version_info < (3, 8):  # pragma: no cover
+if sys.version_info < (3, 8):
     from typing_extensions import Literal
-else:  # pragma: no cover
+else:
     from typing import Literal
 
 ReuseVenvType = Literal["no", "yes", "never", "always"]

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -796,7 +796,7 @@ class SessionRunner:
     def reuse_existing_venv(self) -> bool:
         return any(
             (
-                # forces every session to re-use its env
+                # forces every session to reuse its env
                 self.global_config.reuse_venv == "always",
                 # sessions marked True will always be reused unless never is specified
                 self.func.reuse_venv is True

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -794,14 +794,45 @@ class SessionRunner:
         self.venv.create()
 
     def reuse_existing_venv(self) -> bool:
+        """
+        Determines whether to reuse an existing virtual environment.
+
+        The decision matrix is as follows:
+
+        +--------------------------+-----------------+-------------+
+        | global_config.reuse_venv | func.reuse_venv | Reuse venv? |
+        +==========================+=================+=============+
+        | "always"                 | N/A             | Yes         |
+        +--------------------------+-----------------+-------------+
+        | "never"                  | N/A             | No          |
+        +--------------------------+-----------------+-------------+
+        | "yes"                    | True|None       | Yes         |
+        +--------------------------+-----------------+-------------+
+        | "yes"                    | False           | No          |
+        +--------------------------+-----------------+-------------+
+        | "no"                     | True            | Yes         |
+        +--------------------------+-----------------+-------------+
+        | "no"                     | False|None      | No          |
+        +--------------------------+-----------------+-------------+
+
+        Summary
+        ~~~~~~~
+        - "always" forces reuse regardless of `func.reuse_venv`.
+        - "never" forces recreation regardless of `func.reuse_venv`.
+        - "yes" and "no" respect `func.reuse_venv` being ``False`` or ``True`` respectively.
+
+        Returns:
+            bool: True if the existing virtual environment should be reused, False otherwise.
+        """
+
         return any(
             (
-                # forces every session to reuse its env
+                # "always" forces reuse regardless of func.reuse_venv
                 self.global_config.reuse_venv == "always",
-                # sessions marked True will always be reused unless never is specified
+                # Respect func.reuse_venv when it's explicitly True, unless global_config is "never"
                 self.func.reuse_venv is True
                 and self.global_config.reuse_venv != "never",
-                # session marked False will never be reused unless always is specified
+                # Delegate to reuse ("yes") when func.reuse_venv is not explicitly False
                 self.func.reuse_venv is not False
                 and self.global_config.reuse_venv == "yes",
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def reset_color_envvars(monkeypatch):
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.delenv("NO_COLOR", raising=False)
 
+
 RESOURCES = Path(__file__).parent.joinpath("resources")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,22 @@
+# Copyright 2023 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+import re
+from pathlib import Path
+from string import Template
+from typing import Callable
+
 import pytest
 
 
@@ -6,3 +25,28 @@ def reset_color_envvars(monkeypatch):
     """Remove color-related envvars to fix test output"""
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.delenv("NO_COLOR", raising=False)
+
+RESOURCES = Path(__file__).parent.joinpath("resources")
+
+
+@pytest.fixture
+def generate_noxfile_options(tmp_path: Path) -> Callable[..., str]:
+    """Generate noxfile.py with test and templated options.
+
+    The options are enabled (if disabled) and the values are applied
+    if a matching format string is encountered with the option name.
+    """
+
+    def generate_noxfile(**option_mapping: str | bool) -> str:
+        path = Path(RESOURCES) / "noxfile_options.py"
+        text = path.read_text(encoding="utf8")
+        if option_mapping:
+            for opt, _val in option_mapping.items():
+                # "uncomment" options with values provided
+                text = re.sub(rf"(# )?nox.options.{opt}", f"nox.options.{opt}", text)
+            text = Template(text).safe_substitute(**option_mapping)
+        path = tmp_path / "noxfile.py"
+        path.write_text(text)
+        return str(path)
+
+    return generate_noxfile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
+
 import re
 from pathlib import Path
 from string import Template

--- a/tests/resources/noxfile_options.py
+++ b/tests/resources/noxfile_options.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import nox
 
-nox.options.reuse_existing_virtualenvs = True
-# nox.options.error_on_missing_interpreters = {error_on_missing_interpreters} # used by tests
+# nox.options.reuse_existing_virtualenvs = ${reuse_existing_virtualenvs}
+# nox.options.reuse_venv = "${reuse_venv}"
+# nox.options.error_on_missing_interpreters = ${error_on_missing_interpreters}
 nox.options.sessions = ["test"]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,10 +16,8 @@ from __future__ import annotations
 
 import contextlib
 import os
-import re
 import sys
 from pathlib import Path
-from string import Template
 from unittest import mock
 
 import pytest
@@ -549,29 +547,6 @@ def test_main_noxfile_options_sessions(monkeypatch, generate_noxfile_options):
         # Verify that the config looks correct.
         config = honor_list_request.call_args[1]["global_config"]
         assert config.sessions == ["test"]
-
-
-@pytest.fixture
-def generate_noxfile_options(tmp_path):
-    """Generate noxfile.py with test and templated options.
-
-    The options are enabled (if disabled) and the values are applied
-    if a matching format string is encountered with the option name.
-    """
-
-    def generate_noxfile(**option_mapping: str | bool):
-        path = Path(RESOURCES) / "noxfile_options.py"
-        text = path.read_text(encoding="utf8")
-        if option_mapping:
-            for opt, _val in option_mapping.items():
-                # "uncomment" options with values provided
-                text = re.sub(rf"(# )?nox.options.{opt}", f"nox.options.{opt}", text)
-            text = Template(text).safe_substitute(**option_mapping)
-        path = tmp_path / "noxfile.py"
-        path.write_text(text)
-        return str(path)
-
-    return generate_noxfile
 
 
 @pytest.fixture

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -857,7 +857,7 @@ class TestSessionRunner:
                 noxfile=os.path.join(os.getcwd(), "noxfile.py"),
                 envdir="envdir",
                 posargs=[],
-                reuse_existing_virtualenvs=False,
+                reuse_venv="no",
                 error_on_missing_interpreters="CI" in os.environ,
             ),
             manifest=mock.create_autospec(nox.manifest.Manifest),
@@ -960,9 +960,31 @@ class TestSessionRunner:
     def test__create_venv_unexpected_venv_backend(self):
         runner = self.make_runner()
         runner.func.venv_backend = "somenewenvtool"
-
         with pytest.raises(ValueError, match="venv_backend"):
             runner._create_venv()
+
+    @pytest.mark.parametrize(
+        ("reuse_venv", "reuse_venv_func", "should_reuse"),
+        [
+            ("yes", None, True),
+            ("yes", False, False),
+            ("yes", True, True),
+            ("no", None, False),
+            ("no", False, False),
+            ("no", True, True),
+            ("always", None, True),
+            ("always", False, True),
+            ("always", True, True),
+            ("never", None, False),
+            ("never", False, False),
+            ("never", True, False),
+        ],
+    )
+    def test__reuse_venv_outcome(self, reuse_venv, reuse_venv_func, should_reuse):
+        runner = self.make_runner()
+        runner.func.reuse_venv = reuse_venv_func
+        runner.global_config.reuse_venv = reuse_venv
+        assert runner.reuse_existing_venv() == should_reuse
 
     def make_runner_with_mock_venv(self):
         runner = self.make_runner()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -24,7 +24,6 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
-from test_main import generate_noxfile_options  # noqa: F401
 
 import nox
 from nox import _options, sessions, tasks
@@ -321,10 +320,7 @@ def test_filter_manifest_tags_not_found(tags, caplog):
     assert "Tag selection caused no sessions to be selected." in caplog.text
 
 
-def test_merge_sessions_and_tags(
-    reset_global_nox_options,
-    generate_noxfile_options,  # noqa: F811
-):
+def test_merge_sessions_and_tags(reset_global_nox_options, generate_noxfile_options):
     @nox.session(tags=["foobar"])
     def test():
         pass

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -24,6 +24,7 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
+from test_main import generate_noxfile_options  # noqa: F401
 
 import nox
 from nox import _options, sessions, tasks
@@ -320,7 +321,9 @@ def test_filter_manifest_tags_not_found(tags, caplog):
     assert "Tag selection caused no sessions to be selected." in caplog.text
 
 
-def test_merge_sessions_and_tags(reset_global_nox_options):
+def test_merge_sessions_and_tags(
+    reset_global_nox_options, generate_noxfile_options  # noqa: F811
+):
     @nox.session(tags=["foobar"])
     def test():
         pass
@@ -329,8 +332,9 @@ def test_merge_sessions_and_tags(reset_global_nox_options):
     def bar():
         pass
 
+    noxfile_path = generate_noxfile_options(reuse_existing_virtualenvs=True)
     config = _options.options.namespace(
-        noxfile=os.path.join(RESOURCES, "noxfile_options.py"),
+        noxfile=noxfile_path,
         sessions=None,
         pythons=(),
         posargs=[],

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -322,7 +322,8 @@ def test_filter_manifest_tags_not_found(tags, caplog):
 
 
 def test_merge_sessions_and_tags(
-    reset_global_nox_options, generate_noxfile_options  # noqa: F811
+    reset_global_nox_options,
+    generate_noxfile_options,  # noqa: F811
 ):
     @nox.session(tags=["foobar"])
     def test():


### PR DESCRIPTION
Closes #488

This PR introduces a new option `reuse_venv` at the CLI and nox.options level as discussed in #488. It takes 4 possible values, namely `no`, `yes`, `never`, and `always` as discussed in the issue.
The code that evaluates if a venv should be reused has been switched to use this new option, and backwards compatiblity with `reuse_existing_virtualenvs` is kept using appropriate `finalizer_func` and `merge_func` on `_options.py`.

I've added tests to test new functionality as well do backwards compatibility checks and hopefully 🤞 updated the docs properly. I also added a new fixture `generate_noxfile_options` that helps with more dynamic configuration of `resources/noxfile_options.py` used in the tests to reduce boilerplate.
