### PR TITLE
docs: Fix and update "Instant Dev Environment" recipe

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -40,6 +40,7 @@ Enter the ``dev`` nox session:
 .. code-block:: python
 
     import os
+    from pathlib import Path
 
     import nox
 
@@ -50,7 +51,7 @@ Enter the ``dev`` nox session:
     # this VENV_DIR constant specifies the name of the dir that the `dev`
     # session will create, containing the virtualenv;
     # the `resolve()` makes it portable
-    VENV_DIR = pathlib.Path('./.venv').resolve()
+    VENV_DIR = Path('.').resolve() / ".venv"
 
     @nox.session
     def dev(session: nox.Session) -> None:


### PR DESCRIPTION
This adds a **missing** import of `pathlib` module and modifies the way `Path` object is used:
- usually `Path` is imported directly to the namespace;
- slash operator of "`pathlib`-way" for defining paths.