### PR TITLE
chore: ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: "23.10.1"
-    hooks:
-      - id: black
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
@@ -33,6 +28,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.6.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,6 @@ repos:
     rev: "23.10.1"
     hooks:
       - id: black
-        args:
-          - "--preview"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -205,9 +205,9 @@ class OptionSet:
         self.parser_args = args
         self.parser_kwargs = kwargs
         self.options: collections.OrderedDict[str, Option] = collections.OrderedDict()
-        self.groups: collections.OrderedDict[str, OptionGroup] = (
-            collections.OrderedDict()
-        )
+        self.groups: collections.OrderedDict[
+            str, OptionGroup
+        ] = collections.OrderedDict()
 
     def add_options(self, *args: Option) -> None:
         """Adds a sequence of Options to the OptionSet.

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -29,7 +29,8 @@ _REGISTRY: collections.OrderedDict[str, Func] = collections.OrderedDict()
 
 
 @overload
-def session_decorator(__func: F) -> F: ...
+def session_decorator(__func: F) -> F:
+    ...
 
 
 @overload
@@ -42,7 +43,8 @@ def session_decorator(
     venv_backend: Any | None = ...,
     venv_params: Any | None = ...,
     tags: Sequence[str] | None = ...,
-) -> Callable[[F], F]: ...
+) -> Callable[[F], F]:
+    ...
 
 
 def session_decorator(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ extend-select = [
   "UP",          # pyupgrade
   "YTT",         # flake8-2020
 ]
+ignore = [
+  "ISC001", # Conflicts with formatter
+]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/tests/test__version.py
+++ b/tests/test__version.py
@@ -56,32 +56,40 @@ def test_get_nox_version() -> None:
     [
         ("", None),
         (
-            dedent("""
+            dedent(
+                """
                 import nox
                 nox.needs_version = '>=2020.12.31'
-                """),
+                """
+            ),
             ">=2020.12.31",
         ),
         (
-            dedent("""
+            dedent(
+                """
                 import nox
                 nox.needs_version = 'bogus'
                 nox.needs_version = '>=2020.12.31'
-                """),
+                """
+            ),
             ">=2020.12.31",
         ),
         (
-            dedent("""
+            dedent(
+                """
                 import nox.sessions
                 nox.needs_version = '>=2020.12.31'
-                """),
+                """
+            ),
             ">=2020.12.31",
         ),
         (
-            dedent("""
+            dedent(
+                """
                 import nox as _nox
                 _nox.needs_version = '>=2020.12.31'
-                """),
+                """
+            ),
             None,
         ),
     ],
@@ -94,20 +102,24 @@ def test_parse_needs_version(text: str, expected: str | None) -> None:
 @pytest.mark.parametrize("specifiers", ["", ">=2020.12.31", ">=2020.12.31,<9999.99.99"])
 def test_check_nox_version_succeeds(temp_noxfile, specifiers: str) -> None:
     """It does not raise if the version specifiers are satisfied."""
-    text = dedent(f"""
+    text = dedent(
+        f"""
         import nox
         nox.needs_version = "{specifiers}"
-        """)
+        """
+    )
     check_nox_version(temp_noxfile(text))
 
 
 @pytest.mark.parametrize("specifiers", [">=9999.99.99"])
 def test_check_nox_version_fails(temp_noxfile, specifiers: str) -> None:
     """It raises an exception if the version specifiers are not satisfied."""
-    text = dedent(f"""
+    text = dedent(
+        f"""
         import nox
         nox.needs_version = "{specifiers}"
-        """)
+        """
+    )
     with pytest.raises(VersionCheckFailed):
         check_nox_version(temp_noxfile(text))
 
@@ -115,9 +127,11 @@ def test_check_nox_version_fails(temp_noxfile, specifiers: str) -> None:
 @pytest.mark.parametrize("specifiers", ["invalid", "2020.12.31"])
 def test_check_nox_version_invalid(temp_noxfile, specifiers: str) -> None:
     """It raises an exception if the version specifiers cannot be parsed."""
-    text = dedent(f"""
+    text = dedent(
+        f"""
         import nox
         nox.needs_version = "{specifiers}"
-        """)
+        """
+    )
     with pytest.raises(InvalidVersionSpecifier):
         check_nox_version(temp_noxfile(text))

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -62,7 +62,8 @@ VALID_VERSION_LISTS = {
     ",".join(f"3.{minor}" for minor in range(20)): [
         f"3.{minor}"
         for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 11)
-    ] + ["3.11"],
+    ]
+    + ["3.11"],
 }
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -113,10 +113,12 @@ def reset_global_nox_options():
 
 
 def test_load_nox_module_needs_version_static(reset_needs_version, tmp_path):
-    text = dedent("""
+    text = dedent(
+        """
         import nox
         nox.needs_version = ">=9999.99.99"
-        """)
+        """
+    )
     noxfile = tmp_path / "noxfile.py"
     noxfile.write_text(text)
     config = _options.options.namespace(noxfile=str(noxfile))
@@ -124,11 +126,13 @@ def test_load_nox_module_needs_version_static(reset_needs_version, tmp_path):
 
 
 def test_load_nox_module_needs_version_dynamic(reset_needs_version, tmp_path):
-    text = dedent("""
+    text = dedent(
+        """
         import nox
         NOX_NEEDS_VERSION = ">=9999.99.99"
         nox.needs_version = NOX_NEEDS_VERSION
-        """)
+        """
+    )
     noxfile = tmp_path / "noxfile.py"
     noxfile.write_text(text)
     config = _options.options.namespace(noxfile=str(noxfile))

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -38,60 +38,89 @@ def makeconfig(tmpdir):
 
 
 def test_trivial(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
     [tox]
     envlist = py27
-    """))
+    """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
     import nox
 
 
     @nox.session(python='python2.7')
     def py27(session):
         session.install('.')
-    """).lstrip()
+    """
+        ).lstrip()
+    )
 
 
 def test_skipinstall(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
     [tox]
     envlist = py27
 
     [testenv]
     skip_install = True
-    """))
+    """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
     import nox
 
 
     @nox.session(python='python2.7')
     def py27(session):
-    """).lstrip()
+    """
+        ).lstrip()
+    )
 
 
 def test_usedevelop(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
     [tox]
     envlist = py27
 
     [testenv]
     usedevelop = True
-    """))
+    """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
     import nox
 
 
     @nox.session(python='python2.7')
     def py27(session):
         session.install('-e', '.')
-    """).lstrip()
+    """
+        ).lstrip()
+    )
 
 
 def test_commands(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
     [tox]
     envlist = lint
 
@@ -102,9 +131,14 @@ def test_commands(makeconfig):
         flake8 \\
             --import-order-style=google \\
             google tests
-    """))
+    """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
     import nox
 
 
@@ -114,11 +148,15 @@ def test_commands(makeconfig):
         session.run('python', 'setup.py', 'check', '--metadata', \
 '--restructuredtext', '--strict')
         session.run('flake8', '--import-order-style=google', 'google', 'tests')
-    """).lstrip()
+    """
+        ).lstrip()
+    )
 
 
 def test_deps(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
     [tox]
     envlist = lint
 
@@ -127,9 +165,14 @@ def test_deps(makeconfig):
     deps =
       flake8
       gcp-devrel-py-tools>=0.0.3
-    """))
+    """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
     import nox
 
 
@@ -137,11 +180,15 @@ def test_deps(makeconfig):
     def lint(session):
         session.install('flake8', 'gcp-devrel-py-tools>=0.0.3')
         session.install('.')
-    """).lstrip()
+    """
+        ).lstrip()
+    )
 
 
 def test_env(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
     [tox]
     envlist = lint
 
@@ -150,9 +197,14 @@ def test_env(makeconfig):
     setenv =
         SPHINX_APIDOC_OPTIONS=members,inherited-members,show-inheritance
         TEST=meep
-    """))
+    """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
     import nox
 
 
@@ -162,20 +214,29 @@ def test_env(makeconfig):
 'members,inherited-members,show-inheritance'
         session.env['TEST'] = 'meep'
         session.install('.')
-    """).lstrip()
+    """
+        ).lstrip()
+    )
 
 
 def test_chdir(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
     [tox]
     envlist = lint
 
     [testenv:lint]
     basepython = python2.7
     changedir = docs
-    """))
+    """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
     import nox
 
 
@@ -183,57 +244,78 @@ def test_chdir(makeconfig):
     def lint(session):
         session.install('.')
         session.chdir('docs')
-    """).lstrip()
+    """
+        ).lstrip()
+    )
 
 
 def test_dash_in_envname(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
             [tox]
             envlist = test-with-dash
 
             [testenv:test-with-dash]
             basepython = python2.7
-            """))
+            """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
         import nox
 
 
         @nox.session(python='python2.7')
         def test_with_dash(session):
             session.install('.')
-        """).lstrip()
+        """
+        ).lstrip()
+    )
 
 
 def test_non_identifier_in_envname(makeconfig, capfd):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
             [tox]
             envlist = test-with-&
 
             [testenv:test-with-&]
             basepython = python2.7
-            """))
+            """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
         import nox
 
 
         @nox.session(python='python2.7')
         def test_with_&(session):
             session.install('.')
-        """).lstrip()
+        """
+        ).lstrip()
+    )
 
     out, _ = capfd.readouterr()
 
     assert (
-        out
-        == "Environment 'test_with_&' is not a valid nox session name.\n"
+        out == "Environment 'test_with_&' is not a valid nox session name.\n"
         "Manually update the session name in noxfile.py before running nox.\n"
     )
 
 
 def test_descriptions_into_docstrings(makeconfig):
-    result = makeconfig(textwrap.dedent("""
+    result = makeconfig(
+        textwrap.dedent(
+            """
             [tox]
             envlist = lint
 
@@ -242,9 +324,14 @@ def test_descriptions_into_docstrings(makeconfig):
             description =
                 runs the lint action
                 now with an unnecessary second line
-            """))
+            """
+        )
+    )
 
-    assert result == textwrap.dedent("""
+    assert (
+        result
+        == textwrap.dedent(
+            """
             import nox
 
 
@@ -252,4 +339,6 @@ def test_descriptions_into_docstrings(makeconfig):
             def lint(session):
                 \"\"\"runs the lint action now with an unnecessary second line\"\"\"
                 session.install('.')
-            """).lstrip()
+            """
+        ).lstrip()
+    )


### PR DESCRIPTION
I did this in two steps, to illustrate that ruff-format matched black in non-preview style.

See https://github.com/wntrblm/nox/pull/736. Also https://github.com/scientific-python/cookie/pull/299, which I've been mentioning whenever I make a PR moving to ruff-format.

- style: remove --preview from black
- chore: move to ruff-format
