### PR TITLE
Bump minimum virtualenv to 20.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   'importlib-metadata; python_version < "3.8"',
   "packaging>=20.9",
   'typing-extensions>=3.7.4; python_version < "3.8"',
-  "virtualenv>=14",
+  "virtualenv>=20.14.1",
 ]
 [project.optional-dependencies]
 tox_to_nox = [

--- a/requirements-conda-test.txt
+++ b/requirements-conda-test.txt
@@ -3,4 +3,4 @@ colorlog >=2.6.1,<7.0.0
 jinja2
 pytest
 tox<4.0.0
-virtualenv >=14.0.0
+virtualenv >=20.14.1


### PR DESCRIPTION
`virtualenv` dependencies, for example

- https://github.com/pypa/virtualenv/issues/2666

can cause dependency resolution of `virtualenv` to drop to an older version (for example `20.4.7`) that can cause `nox` to fail due to using deprecated `setuptools` behavior. For example:

- https://github.com/johnthagen/python-blueprint/actions/runs/6834646086/job/18587635299

Bump nox's minimum `virtualenv` version to avoid dependency resolution selecting a very outdated `virtualenv`, which isn't tested and can fail.

[virtualenv 20.14.1](https://virtualenv.pypa.io/en/latest/changelog.html#v20-14-1-2022-04-11) was released 2022-04-11.