### PR TITLE
Allow `--force-python` on unparametrized sessions

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -433,6 +433,7 @@ options.add_options(
     ),
     _option_set.Option(
         "force_pythons",
+        "-P",
         "--force-pythons",
         "--force-python",
         group=options.groups["python"],
@@ -441,6 +442,7 @@ options.add_options(
         help=(
             "Run sessions with the given interpreters instead of those listed in the"
             " Noxfile. This is a shorthand for ``--python=X.Y --extra-python=X.Y``."
+            " It will also work on sessions that don't have any interpreter parametrized."
         ),
         finalizer_func=_force_pythons_finalizer,
     ),

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -230,6 +230,10 @@ class Manifest:
                 # Otherwise, add the extra specified python.
                 assert isinstance(func.python, str)
                 func.python = _unique_list(func.python, *extra_pythons)
+            elif not func.python and self._config.force_pythons:
+                # If a python is forced by the user, but the underlying function
+                # has no version parametrised, add it as sole occupant to func.python
+                func.python = _unique_list(*extra_pythons)
 
         # If the func has the python attribute set to a list, we'll need
         # to expand them.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -49,6 +49,7 @@ def create_mock_config():
     cfg.force_venv_backend = None
     cfg.default_venv_backend = None
     cfg.extra_pythons = None
+    cfg.force_pythons = None
     cfg.posargs = []
     return cfg
 
@@ -274,6 +275,41 @@ def test_add_session_multiple_pythons():
 def test_extra_pythons(python, extra_pythons, expected):
     cfg = create_mock_config()
     cfg.extra_pythons = extra_pythons
+
+    manifest = Manifest({}, cfg)
+
+    def session_func():
+        pass
+
+    func = Func(session_func, python=python)
+    for session in manifest.make_session("my_session", func):
+        manifest.add_session(session)
+
+    assert expected == [session.func.python for session in manifest._all_sessions]
+
+
+@pytest.mark.parametrize(
+    "python,force_pythons,expected",
+    [
+        (None, [], [None]),
+        (None, ["3.8"], ["3.8"]),
+        (None, ["3.8", "3.9"], ["3.8", "3.9"]),
+        (False, [], [False]),
+        (False, ["3.8"], ["3.8"]),
+        (False, ["3.8", "3.9"], ["3.8", "3.9"]),
+        ("3.5", [], ["3.5"]),
+        ("3.5", ["3.8"], ["3.5", "3.8"]),
+        ("3.5", ["3.8", "3.9"], ["3.5", "3.8", "3.9"]),
+        (["3.5", "3.9"], [], ["3.5", "3.9"]),
+        (["3.5", "3.9"], ["3.8"], ["3.5", "3.9", "3.8"]),
+        (["3.5", "3.9"], ["3.8", "3.4"], ["3.5", "3.9", "3.8", "3.4"]),
+        (["3.5", "3.9"], ["3.5", "3.9"], ["3.5", "3.9"]),
+    ],
+)
+def test_force_pythons(python, force_pythons, expected):
+    cfg = create_mock_config()
+    cfg.force_pythons = force_pythons
+    cfg.extra_pythons = force_pythons
 
     manifest = Manifest({}, cfg)
 


### PR DESCRIPTION
Also adds the shorthand `-P` for the `--force-python` option.

Closes #623 