### PR TITLE
feat: add a uv backend

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -126,17 +126,35 @@ Then running ``nox --session tests`` will actually run all parametrized versions
 Changing the sessions default backend
 -------------------------------------
 
-By default Nox uses ``virtualenv`` as the virtual environment backend for the sessions, but it also supports ``conda``, ``mamba``, and ``venv`` as well as no backend (passthrough to whatever python environment Nox is running on). You can change the default behaviour by using ``-db <backend>`` or ``--default-venv-backend <backend>``. Supported names are ``('none', 'virtualenv', 'conda', 'mamba', 'venv')``.
+By default Nox uses ``virtualenv`` as the virtual environment backend for the sessions, but it also supports ``uv``, ``conda``, ``mamba``, and ``venv`` as well as no backend (passthrough to whatever python environment Nox is running on). You can change the default behaviour by using ``-db <backend>`` or ``--default-venv-backend <backend>``. Supported names are ``('none', 'uv', 'virtualenv', 'conda', 'mamba', 'venv')``.
 
 .. code-block:: console
 
     nox -db conda
     nox --default-venv-backend conda
 
+.. note::
+
+   The ``uv``, ``conda``, and ``mamba`` backends require their respective
+   programs be pre-installed. ``uv`` is distributed as a Python package
+   and can be installed with the ``nox[uv]`` extra.
 
 You can also set this option in the Noxfile with ``nox.options.default_venv_backend``. In case both are provided, the commandline argument takes precedence.
 
 Note that using this option does not change the backend for sessions where ``venv_backend`` is explicitly set.
+
+.. warning::
+
+   The ``uv`` backend does not install anything by default, including ``pip``,
+   as ``uv pip`` is used to install programs instead. If you need to manually
+   interact with pip, you should install it with ``session.install("pip")``.
+
+.. warning::
+
+   Currently the ``uv`` backend requires the ``<program name> @ .`` syntax to
+   install a local folder in non-editable mode; it does not (yet) compute the
+   name from the install process like pip does if the name is omitted. Editable
+   installs do not require a name.
 
 
 .. _opt-force-venv-backend:
@@ -144,7 +162,7 @@ Note that using this option does not change the backend for sessions where ``ven
 Forcing the sessions backend
 ----------------------------
 
-You might work in a different environment than a project's default continuous integration settings, and might wish to get a quick way to execute the same tasks but on a different venv backend. For this purpose, you can temporarily force the backend used by **all** sessions in the current Nox execution by using ``-fb <backend>`` or ``--force-venv-backend <backend>``. No exceptions are made, the backend will be forced for all sessions run whatever the other options values and Noxfile configuration. Supported names are ``('none', 'virtualenv', 'conda', 'venv')``.
+You might work in a different environment than a project's default continuous integration settings, and might wish to get a quick way to execute the same tasks but on a different venv backend. For this purpose, you can temporarily force the backend used by **all** sessions in the current Nox execution by using ``-fb <backend>`` or ``--force-venv-backend <backend>``. No exceptions are made, the backend will be forced for all sessions run whatever the other options values and Noxfile configuration. Supported names are ``('none', 'uv', 'virtualenv', 'conda', 'mamba', 'venv')``.
 
 .. code-block:: console
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -383,10 +383,10 @@ options.add_options(
         merge_func=_default_venv_backend_merge_func,
         help=(
             "Virtual environment backend to use by default for Nox sessions, this is"
-            " ``'virtualenv'`` by default but any of ``('virtualenv', 'conda', 'mamba',"
-            " 'venv')`` are accepted."
+            " ``'virtualenv'`` by default but any of ``('uv, 'virtualenv',"
+            " 'conda', 'mamba', 'venv')`` are accepted."
         ),
-        choices=["none", "virtualenv", "conda", "mamba", "venv"],
+        choices=["none", "virtualenv", "conda", "mamba", "venv", "uv"],
     ),
     _option_set.Option(
         "force_venv_backend",
@@ -398,10 +398,10 @@ options.add_options(
         help=(
             "Virtual environment backend to force-use for all Nox sessions in this run,"
             " overriding any other venv backend declared in the Noxfile and ignoring"
-            " the default backend. Any of ``('virtualenv', 'conda', 'mamba', 'venv')``"
-            " are accepted."
+            " the default backend. Any of ``('uv', 'virtualenv', 'conda', 'mamba',"
+            " 'venv')`` are accepted."
         ),
-        choices=["none", "virtualenv", "conda", "mamba", "venv"],
+        choices=["none", "virtualenv", "conda", "mamba", "venv", "uv"],
     ),
     _option_set.Option(
         "no_venv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ tox_to_nox = [
   "jinja2",
   "tox",
 ]
+uv = [
+  "uv",
+]
 [project.urls]
 bug-tracker = "https://github.com/wntrblm/nox/issues"
 documentation = "https://nox.thea.codes"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,4 +6,5 @@ pytest-cov
 sphinx>=3.0
 sphinx-autobuild
 sphinx-tabs
+uv; python_version>='3.8'
 witchhazel


### PR DESCRIPTION
UV just came out from the Ruff folks, and it's insanely fast - it makes venvs faster (25ms) than Python can start up (50ms). And much faster than virtualenv (400ms) and venv (nearly 5 seconds). The package install speeds are also unreal compared to pip.

There are some differences - namely `name @ .` is [required](https://github.com/astral-sh/uv/issues/1499) instead of `.` if an install is not editable (for now). But it's really nice to try it out!


https://github.com/wntrblm/nox/assets/4616906/1fe4c981-9d9a-4aaf-b19e-94c79daeebe7


Nox's docs build in 4 seconds instead of 22 seconds using the uv backend.

