### PR TITLE
chore(ci): allow manual runs on branches without a PR

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -9,6 +9,8 @@ on:
       - ".github/workflows/action.yml"
       - ".github/action_helper.py"
       - "action.yml"
+  workflow_dispatch:
+    # allow manual runs on branches without a PR
 env:
   FORCE_COLOR: "1"
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    # allow manual runs on branches without a PR
 
 env:
   FORCE_COLOR: "1"


### PR DESCRIPTION
This is useful to run workflows on branches in forks before a PR is opened here.