### PR TITLE
feat(action): do not depend on pipx in Nox action

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,6 +27,7 @@ jobs:
             macos-11,
             macos-12,
             macos-13,
+            macos-14,
           ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,12 +27,12 @@ jobs:
             macos-11,
             macos-12,
             macos-13,
-            macos-14,
           ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_default_tests
+
   action-all-tests:
     runs-on: windows-latest
     steps:
@@ -44,3 +44,12 @@ jobs:
         with:
           python-versions: "3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10"
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_all_tests
+
+  action-macos14-tests:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          python-versions: "3.10, 3.11, 3.12, pypy-3.8, pypy-3.9, pypy-3.10"
+      - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_macos_14

--- a/action.yml
+++ b/action.yml
@@ -72,4 +72,4 @@ runs:
         with open(os.environ["GITHUB_PATH"], "at") as f:
             f.write(f"{nox_bin_path}\n")
         print("::endgroup::")
-      shell: "${{ steps.localpython.outputs.python-path }}" -u
+      shell: "${{ steps.localpython.outputs.python-path }} -u"

--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,48 @@ runs:
         allow-prereleases: true
 
     - name: "Install nox"
-      run: pipx install --python "${{ steps.allpython.outputs.python-path }}" '${{ github.action_path }}'
+      run: |
+        # Install nox
+        "${{ steps.allpython.outputs.python-path }}" -u << "EOF"
+        import os
+        import shutil
+        import sys
+        import venv
+
+        from pathlib import Path
+        from subprocess import run
+
+
+        class EnvBuilder(venv.EnvBuilder):
+            def __init__(self):
+                super().__init__()
+
+            def setup_scripts(self, context):
+                pass
+
+            def post_setup(self, context):
+                super().post_setup(context)
+                self.bin_path = Path(context.env_exe).parent
+                run([sys.executable, "-m", "pip", "--python", context.env_exe, "install", r"${{ github.action_path }}"], check=True)
+
+
+        print("::group::Install nox")
+        nox_bin_path = Path(r"${{ runner.temp }}") / "nox"
+        if nox_bin_path.exists():
+            shutil.rmtree(nox_bin_path)
+        venv_path = Path(r"${{ runner.temp }}") / "nox-venv"
+        if venv_path.exists():
+            shutil.rmtree(venv_path)
+        builder = EnvBuilder()
+        builder.create(venv_path)
+        nox_path = [path for path in builder.bin_path.glob("nox*") if path.stem == "nox"][0]
+        nox_bin_path.mkdir()
+        try:
+            os.symlink(nox_path, nox_bin_path / nox_path.name)
+        except OSError:
+            shutil.copyfile(nox_path, nox_bin_path / nox_path.name)
+        with open(os.environ["GITHUB_PATH"], "at") as f:
+            f.write(f"{nox_bin_path}\n")
+        print("::endgroup::")
+        EOF
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -72,4 +72,4 @@ runs:
         with open(os.environ["GITHUB_PATH"], "at") as f:
             f.write(f"{nox_bin_path}\n")
         print("::endgroup::")
-      shell: "${{ steps.localpython.outputs.python-path }} -u"
+      shell: "${{ steps.localpython.outputs.python-path }} -u {0}"

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,6 @@ runs:
 
     - name: "Install nox"
       run: |
-        # Install nox
-        "${{ steps.allpython.outputs.python-path }}" -u << "EOF"
         import os
         import shutil
         import sys
@@ -74,5 +72,4 @@ runs:
         with open(os.environ["GITHUB_PATH"], "at") as f:
             f.write(f"{nox_bin_path}\n")
         print("::endgroup::")
-        EOF
-      shell: bash
+      shell: "${{ steps.localpython.outputs.python-path }}" -u

--- a/action.yml
+++ b/action.yml
@@ -72,4 +72,4 @@ runs:
         with open(os.environ["GITHUB_PATH"], "at") as f:
             f.write(f"{nox_bin_path}\n")
         print("::endgroup::")
-      shell: "${{ steps.localpython.outputs.python-path }} -u {0}"
+      shell: "${{ steps.allpython.outputs.python-path }} -u {0}"

--- a/noxfile.py
+++ b/noxfile.py
@@ -174,7 +174,6 @@ def github_actions_default_tests(session: nox.Session) -> None:
     _check_python_version(session)
 
 
-# The following sessions are only to be run in CI to check the nox GHA action
 @nox.session(
     python=[
         "3.7",
@@ -191,4 +190,20 @@ def github_actions_default_tests(session: nox.Session) -> None:
 )
 def github_actions_all_tests(session: nox.Session) -> None:
     """Check all versions installed by the nox GHA Action"""
+    _check_python_version(session)
+
+
+@nox.session(
+    python=[
+        "3.10",
+        "3.11",
+        "3.12",
+        "pypy3.8",
+        "pypy3.9",
+        "pypy3.10",
+    ]
+)
+def github_actions_macos_14(session: nox.Session) -> None:
+    """Check default versions installed by the nox GHA Action"""
+    assert sys.version_info[:2] == (3, 11)
     _check_python_version(session)


### PR DESCRIPTION
pipx is being re-added in https://github.com/actions/runner-images/pull/9474

blocked by https://github.com/actions/runner-images/issues/9256 (`temp: don't use pipx` commit)
blocked by https://github.com/actions/setup-python/issues/808 (`temp: python 3.8 & 3.9 missing on macos-14` commit)