### PR TITLE
chore: drop uneeded config option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ exclude_lines = [ "pragma: no cover", "if TYPE_CHECKING:", "@overload" ]
 [tool.mypy]
 files = [ "nox/**/*.py", "noxfile.py" ]
 python_version = "3.7"
-show_error_codes = true
 strict = true
 warn_unreachable = true
 enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]


### PR DESCRIPTION
This has been deprecated and unneeded since before mypy 1.
