### PR TITLE
tests: support running when the Python launcher for UNIX is present

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -103,7 +103,7 @@ def test_process_env_constructor():
     with pytest.raises(
         ValueError, match=r"^The environment does not have a bin directory\.$"
     ):
-        penv.bin  # noqa: B018
+        print(penv.bin)
 
     penv = nox.virtualenv.ProcessEnv(env={"SIGIL": "123"})
     assert penv.env["SIGIL"] == "123"
@@ -561,7 +561,7 @@ def test__resolved_interpreter_invalid_numerical_id(which, make_one, input_):
     venv, _ = make_one(interpreter=input_)
 
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
 
     which.assert_called_once_with(input_)
 
@@ -572,7 +572,7 @@ def test__resolved_interpreter_32_bit_non_windows(which, make_one):
     venv, _ = make_one(interpreter="3.6-32")
 
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
     which.assert_called_once_with("3.6-32")
 
 
@@ -654,7 +654,7 @@ def test__resolved_interpreter_windows_pyexe_fails(which, run, make_one):
 
     # Okay now run the test.
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
 
     which.assert_has_calls([mock.call("python3.6"), mock.call("py")])
 
@@ -700,7 +700,7 @@ def test__resolved_interpreter_windows_path_and_version_fails(
     patch_sysfind(("python", "python.exe"), sysfind_result, sysexec_result)
 
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
 
 
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
@@ -715,17 +715,18 @@ def test__resolved_interpreter_not_found(which, make_one):
 
     # Run the test.
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
 
 
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
+@mock.patch("nox.virtualenv.locate_via_py", new=lambda _: None)
 def test__resolved_interpreter_nonstandard(make_one):
     # Establish that we do not try to resolve non-standard locations
     # on Windows.
     venv, _ = make_one(interpreter="goofy")
 
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
 
 
 @mock.patch("nox.virtualenv._SYSTEM", new="Linux")
@@ -749,12 +750,12 @@ def test__resolved_interpreter_cache_failure(which, make_one):
 
     assert venv._resolved is None
     with pytest.raises(nox.virtualenv.InterpreterNotFound) as exc_info:
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
     caught = exc_info.value
 
     which.assert_called_once_with("3.7-32")
     # Check the cache and call again to make sure it is used.
     assert venv._resolved is caught
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        venv._resolved_interpreter  # noqa: B018
+        print(venv._resolved_interpreter)
     assert which.call_count == 1


### PR DESCRIPTION
I can't run the tests locally and see coverage because it fails on one test - if you have `py` (the Python launcher for UNIX) installed, it breaks the assumptions of this test. Fixed and used print instead of noqa to make it easier to debug in the future.
