### PR TITLE
fix: rebuild env if making an incompatible change

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -384,7 +384,17 @@ class VirtualEnv(ProcessEnv):
         return False
 
     def _check_reused_environment_interpreter(self) -> bool:
-        """Check if reused environment interpreter is the same."""
+        """
+        Check if reused environment interpreter is the same. Currently only checks if
+        NOX_ENABLE_STALENESS_CHECK is set in the environment. See
+
+        * https://github.com/wntrblm/nox/issues/449#issuecomment-860030890
+        * https://github.com/wntrblm/nox/issues/441
+        * https://github.com/pypa/virtualenv/issues/2130
+        """
+        if not os.environ.get("NOX_ENABLE_STALENESS_CHECK", ""):
+            return True
+
         original = self._read_base_prefix_from_pyvenv_cfg()
         program = (
             "import sys; sys.stdout.write(getattr(sys, 'real_prefix', sys.base_prefix))"

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -36,7 +36,7 @@ RAISE_ERROR = "RAISE_ERROR"
 VIRTUALENV_VERSION = virtualenv.__version__
 
 has_uv = pytest.mark.skipif(not HAS_UV, reason="Missing uv command.")
-has_conda = pytest.mark.skipif(not HAS_UV, reason="Missing conda command.")
+has_conda = pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
 
 
 class TextProcessResult(NamedTuple):

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -474,6 +474,7 @@ def test_create_reuse_venv_environment(make_one):
     assert reused
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="Avoid 'No pyvenv.cfg file' error on Windows.")
 def test_create_reuse_oldstyle_virtualenv_environment(make_one):
     venv, location = make_one(reuse_existing=True)
     venv.create()
@@ -491,6 +492,7 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
     assert reused
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="Avoid 'No pyvenv.cfg file' error on Windows.")
 def test_inner_functions_reusing_venv(make_one):
     venv, location = make_one(reuse_existing=True)
     venv.create()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -585,7 +585,7 @@ def test_inner_functions_reusing_venv(make_one, monkeypatch):
     """
     location.join("pyvenv.cfg").write(dedent(pyvenv_cfg))
 
-    base_prefix = venv._read_base_prefix_from_pyvenv_cfg()
+    base_prefix = venv._read_pyvenv_cfg()["base-prefix"]
     assert base_prefix == "foo"
 
     reused_interpreter = venv._check_reused_environment_interpreter()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -574,7 +574,8 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="Avoid 'No pyvenv.cfg file' error on Windows.")
-def test_inner_functions_reusing_venv(make_one):
+def test_inner_functions_reusing_venv(make_one, monkeypatch):
+    monkeypatch.setenv("NOX_ENABLE_STALENESS_CHECK", "1")
     venv, location = make_one(reuse_existing=True)
     venv.create()
 


### PR DESCRIPTION
This is a followup to #762. Switching environments is likely to be a bit more common, so let's handle it correctly. This has a key path comparison fix that I think was stopping this from being the default before, and instead available via a secret environment variable used in tests.

This is also now "smart" about switching between compatible backends. Switching from venv to virtualenv or back won't trigger a rebuild.

@slafs, could you check this?