### PR TITLE
fix: always pull versions from metadata

### DIFF
--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -20,6 +20,7 @@ import argparse
 import os
 import pkgutil
 import re
+import sys
 from configparser import ConfigParser
 from pathlib import Path
 from subprocess import check_output
@@ -27,9 +28,15 @@ from typing import Any, Iterable
 
 import jinja2
 import tox.config
-from tox import __version__ as TOX_VERSION
 
-TOX4 = TOX_VERSION[0] == "4"
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
+
+TOX_VERSION = metadata.version("tox")
+
+TOX4 = int(TOX_VERSION.split(".")[0]) >= 4
 
 if TOX4:
     _TEMPLATE = jinja2.Template(

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -18,11 +18,10 @@ import sys
 import textwrap
 
 import pytest
-from tox import __version__ as TOX_VERSION
 
 tox_to_nox = pytest.importorskip("nox.tox_to_nox")
 
-TOX4 = TOX_VERSION[0] == "4"
+TOX4 = tox_to_nox.TOX4
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 PYTHON_VERSION_NODOT = PYTHON_VERSION.replace(".", "")
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -24,16 +24,20 @@ from typing import NamedTuple
 from unittest import mock
 
 import pytest
-import virtualenv
 from packaging import version
 
 import nox.virtualenv
+
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
 
 IS_WINDOWS = nox.virtualenv._SYSTEM == "Windows"
 HAS_CONDA = shutil.which("conda") is not None
 HAS_UV = shutil.which("uv") is not None
 RAISE_ERROR = "RAISE_ERROR"
-VIRTUALENV_VERSION = virtualenv.__version__
+VIRTUALENV_VERSION = metadata.version("virtualenv")
 
 
 class TextProcessResult(NamedTuple):


### PR DESCRIPTION
Close #779. A random attribute can move around, but we can always ask for the metadata version.
