### PR TITLE
chore: cleanup Ruff a bit

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import os
 import sys
 
 try:
-    import importlib.metadata as metadata
+    from importlib import metadata
 except ImportError:
     import importlib_metadata as metadata
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 import os
 import sys
 
-try:
+if sys.version_info >= (3, 8):
     from importlib import metadata
-except ImportError:
+else:
     import importlib_metadata as metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import argparse
 import collections
 import functools
-from argparse import ArgumentError as ArgumentError
+from argparse import ArgumentError as ArgumentError  # noqa: PLC0414
 from argparse import ArgumentParser, Namespace
 from collections.abc import Callable, Iterable
 from typing import Any

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -128,10 +128,8 @@ def _force_venv_backend_merge_func(
             raise ValueError(
                 "You can not use `--no-venv` with a non-none `--force-venv-backend`"
             )
-        else:
-            return "none"
-    else:
-        return command_args.force_venv_backend or noxfile_args.force_venv_backend  # type: ignore[no-any-return]
+        return "none"
+    return command_args.force_venv_backend or noxfile_args.force_venv_backend  # type: ignore[no-any-return]
 
 
 def _envdir_merge_func(

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -168,7 +168,7 @@ def update_param_specs(
     combined_specs = []
     for new_spec in new_specs:
         for spec in param_specs:
-            spec = spec.copy()
-            spec.update(new_spec)
-            combined_specs.append(spec)
+            spec_copy = spec.copy()
+            spec_copy.update(new_spec)
+            combined_specs.append(spec_copy)
     return combined_specs

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -22,7 +22,7 @@ from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 if sys.version_info >= (3, 8):
-    import importlib.metadata as metadata
+    from importlib import metadata
 else:
     import importlib_metadata as metadata
 

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -27,13 +27,12 @@ def _get_format(colorlog: bool, add_timestamp: bool) -> str:
     if colorlog:
         if add_timestamp:
             return "%(cyan)s%(name)s > [%(asctime)s] %(log_color)s%(message)s"
-        else:
-            return "%(cyan)s%(name)s > %(log_color)s%(message)s"
-    else:
-        if add_timestamp:
-            return "%(name)s > [%(asctime)s] %(message)s"
-        else:
-            return "%(name)s > %(message)s"
+        return "%(cyan)s%(name)s > %(log_color)s%(message)s"
+
+    if add_timestamp:
+        return "%(name)s > [%(asctime)s] %(message)s"
+
+    return "%(name)s > %(message)s"
 
 
 class NoxFormatter(logging.Formatter):

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -562,7 +562,7 @@ class Session:
             raise ValueError("At least one argument required to install().")
 
         if self._runner.global_config.no_install and venv._reused:
-            return None
+            return
 
         # Escape args that should be (conda-specific; pip install does not need this)
         args = _dblquote_pkg_install_args(args)
@@ -645,7 +645,7 @@ class Session:
             raise ValueError("At least one argument required to install().")
 
         if self._runner.global_config.no_install and venv._reused:
-            return None
+            return
 
         if "silent" not in kwargs:
             kwargs["silent"] = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,19 +74,20 @@ extend-select = [
   "C4",          # flake8-comprehensions
   "ICN",         # flake8-import-conventions
   "ISC",         # flake8-implicit-str-concat
+  "PL",          # pylint
   "PGH",         # pygrep-hooks
   "PIE",         # flake8-pie
   "RUF",         # Ruff-specific
   "SIM",         # flake8-simplify
   "UP",          # pyupgrade
   "YTT",         # flake8-2020
+  "EXE",         # flake8-executable
 ]
 ignore = [
-  "ISC001", # Conflicts with formatter
+  "ISC001",  # Conflicts with formatter
+  "PLR09",   # Too many X
+  "PLR2004", # Magic value used in comparison
 ]
-
-[tool.ruff]
-target-version = "py37"
 
 [tool.isort]
 profile = "black"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,7 +29,7 @@ import nox.registry
 import nox.sessions
 
 try:
-    import importlib.metadata as metadata
+    from importlib import metadata
 except ImportError:
     import importlib_metadata as metadata
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,9 +28,9 @@ import nox._options
 import nox.registry
 import nox.sessions
 
-try:
+if sys.version_info >= (3, 8):
     from importlib import metadata
-except ImportError:
+else:
     import importlib_metadata as metadata
 
 


### PR DESCRIPTION
Just a few minor cleanups. Ruff doesn't need the target version if you use PEP 621 metadata. Added the pylint checks (minus a few). Did just a bit of cleanup.
