### PR TITLE
feat: added venv_location option to specify virtualenv location

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -175,13 +175,23 @@ You are not limited to virtualenv, there is a selection of backends you can choo
     def tests(session):
         pass
 
-Finally, custom backend parameters are supported:
+Custom backend parameters are supported:
 
 .. code-block:: python
 
     @nox.session(venv_params=['--no-download'])
     def tests(session):
         pass
+
+Finally, you can specify the exact location of an environment:
+
+.. code-block:: python
+
+   @nox.session(venv_location=".venv")
+   def dev(session):
+       pass
+
+This places the environment in the folder ``./.venv`` instead of the default ``./.nox/dev``.
 
 
 Passing arguments into sessions

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -47,33 +47,12 @@ Enter the ``dev`` nox session:
     # so it's not run twice accidentally
     nox.options.sessions = [...] # Sessions other than 'dev'
 
-    # this VENV_DIR constant specifies the name of the dir that the `dev`
-    # session will create, containing the virtualenv;
-    # the `resolve()` makes it portable
-    VENV_DIR = pathlib.Path('./.venv').resolve()
+    VENV_DIR = "./.venv"
 
-    @nox.session
+    @nox.session(venv_location=VENV_DIR)
     def dev(session: nox.Session) -> None:
-        """
-        Sets up a python development environment for the project.
-
-        This session will:
-        - Create a python virtualenv for the session
-        - Install the `virtualenv` cli tool into this environment
-        - Use `virtualenv` to create a global project virtual environment
-        - Invoke the python interpreter from the global project environment to install
-          the project and all it's development dependencies.
-        """
-
-        session.install("virtualenv")
-        # the VENV_DIR constant is explained above
-        session.run("virtualenv", os.fsdecode(VENV_DIR), silent=True)
-
-        python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
-
-        # Use the venv's interpreter to install the project along with
-        # all it's dev dependencies, this ensures it's installed in the right way
-        session.run(python, "-m", "pip", "install", "-e", ".[dev]", external=True)
+        """Sets up a python development environment for the project."""
+        session.install("-e", ".[dev]")
 
 With this, a user can simply run ``nox -s dev`` and have their entire environment set up automatically!
 

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -67,6 +67,7 @@ class Func(FunctionDecorator):
         name: str | None = None,
         venv_backend: Any = None,
         venv_params: Any = None,
+        venv_location: str | None = None,
         should_warn: Mapping[str, Any] | None = None,
         tags: Sequence[str] | None = None,
     ) -> None:
@@ -76,6 +77,7 @@ class Func(FunctionDecorator):
         self.name = name
         self.venv_backend = venv_backend
         self.venv_params = venv_params
+        self.venv_location = venv_location
         self.should_warn = dict(should_warn or {})
         self.tags = list(tags or [])
 
@@ -92,6 +94,7 @@ class Func(FunctionDecorator):
             name,
             self.venv_backend,
             self.venv_params,
+            self.venv_location,
             self.should_warn,
             self.tags,
         )
@@ -123,6 +126,7 @@ class Call(Func):
             None,
             func.venv_backend,
             func.venv_params,
+            func.venv_location,
             func.should_warn,
             func.tags,
         )

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -64,10 +64,10 @@ class Func(FunctionDecorator):
         func: Callable[..., Any],
         python: _typing.Python = None,
         reuse_venv: bool | None = None,
-        name: str | None = None,
+        name: _typing.StrPath | None = None,
         venv_backend: Any = None,
         venv_params: Any = None,
-        venv_location: str | None = None,
+        venv_location: _typing.StrPath | None = None,
         should_warn: Mapping[str, Any] | None = None,
         tags: Sequence[str] | None = None,
     ) -> None:

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -14,8 +14,11 @@
 
 from __future__ import annotations
 
-__all__ = ["Python"]
+import os
+
+__all__ = ["Python", "StrPath"]
 
 from typing import Sequence, Union
 
 Python = Union[str, Sequence[str], bool, None]
+StrPath = Union[str, os.PathLike[str]]

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -21,4 +21,4 @@ __all__ = ["Python", "StrPath"]
 from typing import Sequence, Union
 
 Python = Union[str, Sequence[str], bool, None]
-StrPath = Union[str, os.PathLike[str]]
+StrPath = Union[str, "os.PathLike[str]"]

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -21,7 +21,7 @@ from collections.abc import Sequence
 from typing import Any, Callable, TypeVar, overload
 
 from ._decorators import Func
-from ._typing import Python
+from ._typing import Python, StrPath
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -42,7 +42,7 @@ def session_decorator(
     name: str | None = ...,
     venv_backend: Any | None = ...,
     venv_params: Any | None = ...,
-    venv_location: str | None = ...,
+    venv_location: StrPath | None = ...,
     tags: Sequence[str] | None = ...,
 ) -> Callable[[F], F]:
     ...
@@ -56,7 +56,7 @@ def session_decorator(
     name: str | None = None,
     venv_backend: Any | None = None,
     venv_params: Any | None = None,
-    venv_location: str | None = None,
+    venv_location: StrPath | None = None,
     tags: Sequence[str] | None = None,
 ) -> F | Callable[[F], F]:
     """Designate the decorated function as a session."""

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -42,6 +42,7 @@ def session_decorator(
     name: str | None = ...,
     venv_backend: Any | None = ...,
     venv_params: Any | None = ...,
+    venv_location: str | None = ...,
     tags: Sequence[str] | None = ...,
 ) -> Callable[[F], F]:
     ...
@@ -55,6 +56,7 @@ def session_decorator(
     name: str | None = None,
     venv_backend: Any | None = None,
     venv_params: Any | None = None,
+    venv_location: str | None = None,
     tags: Sequence[str] | None = None,
 ) -> F | Callable[[F], F]:
     """Designate the decorated function as a session."""
@@ -74,6 +76,7 @@ def session_decorator(
             name=name,
             venv_backend=venv_backend,
             venv_params=venv_params,
+            venv_location=venv_location,
             tags=tags,
         )
 
@@ -88,7 +91,14 @@ def session_decorator(
 
     final_name = name or func.__name__
     fn = Func(
-        func, python, reuse_venv, final_name, venv_backend, venv_params, tags=tags
+        func,
+        python,
+        reuse_venv,
+        final_name,
+        venv_backend,
+        venv_params,
+        venv_location=venv_location,
+        tags=tags,
     )
     _REGISTRY[final_name] = fn
     return fn

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -754,7 +754,9 @@ class SessionRunner:
 
     @property
     def envdir(self) -> str:
-        return _normalize_path(self.global_config.envdir, self.friendly_name)
+        return self.func.venv_location or _normalize_path(
+            self.global_config.envdir, self.friendly_name
+        )
 
     def _create_venv(self) -> None:
         backend = (

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -754,8 +754,11 @@ class SessionRunner:
 
     @property
     def envdir(self) -> str:
-        return self.func.venv_location or _normalize_path(
-            self.global_config.envdir, self.friendly_name
+        if self.func.venv_location:
+            return os.path.expanduser(self.func.venv_location)
+        return _normalize_path(
+            self.global_config.envdir,
+            self.friendly_name,
         )
 
     def _create_venv(self) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -192,3 +192,9 @@ def github_actions_default_tests(session: nox.Session) -> None:
 def github_actions_all_tests(session: nox.Session) -> None:
     """Check all versions installed by the nox GHA Action"""
     _check_python_version(session)
+
+
+@nox.session(venv_location=".venv")
+def dev(session: nox.Session) -> None:
+    """Create development environment `./.venv` using `nox -s dev`"""
+    session.install("-r", "requirements-dev.txt")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -152,6 +152,8 @@ class TestSession:
         [
             ("my-location", "my-location"),
             ("~/my-location", os.path.expanduser("~/my-location")),
+            (Path("my-location"), "my-location"),
+            (Path("~/my-location"), os.path.expanduser("~/my-location")),
         ],
     )
     def test_envdir(self, venv_location, envdir):
@@ -989,7 +991,9 @@ class TestSessionRunner:
         assert runner.venv.interpreter is None
         assert runner.venv.reuse_existing is False
 
-    @pytest.mark.parametrize("venv_location", [None, "my-location"])
+    @pytest.mark.parametrize(
+        "venv_location", [None, "my-location", Path("my-location")]
+    )
     @pytest.mark.parametrize(
         "create_method,venv_backend,expected_backend",
         [

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -126,6 +126,22 @@ class TestSession:
             )
             assert session.env["TMPDIR"] == os.path.abspath(tmpdir)
 
+    @pytest.mark.parametrize("pre_run", [0, 1])
+    def test_create_tmp_with_venv_location_home_path(self, change_to_tmp_path, pre_run):
+        """Test that this works with absolute path..."""
+        session, runner = self.make_session_and_runner(venv_location="~/my-location")
+        # for testing, also set envdir
+        with tempfile.TemporaryDirectory() as root:
+            runner.global_config.envdir = root
+            for _ in range(pre_run):
+                session.create_tmp()
+
+            tmpdir = session.create_tmp()
+
+            assert tmpdir == os.path.join(os.path.expanduser("~/my-location"), "tmp")
+            assert tmpdir == os.path.abspath(tmpdir)
+            assert session.env["TMPDIR"] == os.path.abspath(tmpdir)
+
     def test_properties(self):
         session, runner = self.make_session_and_runner()
         with tempfile.TemporaryDirectory() as root:
@@ -957,7 +973,7 @@ class TestSessionRunner:
         assert runner.venv.interpreter is None
         assert runner.venv.reuse_existing is False
 
-    @pytest.mark.parametrize("venv_location", [None, "my-location"])
+    @pytest.mark.parametrize("venv_location", [None, "my-location", "~/my-location"])
     @pytest.mark.parametrize(
         "create_method,venv_backend,expected_backend",
         [
@@ -988,12 +1004,20 @@ class TestSessionRunner:
         assert runner.venv.interpreter == "coolpython"
         assert runner.venv.reuse_existing is True
 
-        location_name = venv_location or nox.sessions._normalize_path(
-            runner.global_config.envdir, runner.friendly_name
+        location_name = (
+            os.path.expanduser(venv_location)
+            if venv_location
+            else nox.sessions._normalize_path(
+                runner.global_config.envdir, runner.friendly_name
+            )
         )
+
         assert runner.venv.location_name == location_name
         assert runner.venv.location == os.path.abspath(location_name)
         assert runner.envdir == location_name
+
+        if venv_location and "~/" in venv_location:
+            assert runner.venv.location_name == runner.venv.location
 
     def test__create_venv_unexpected_venv_backend(self):
         runner = self.make_runner()


### PR DESCRIPTION
This PR adds the option `venv_location` to specify the location for virtualenv creation and a per session basis, and is a follow up to #753.

 The use case is quickly defining development environments:


```python
@nox.session(venv_location=".venv")
def dev(session):
    ....
```

