### PR TITLE
fix: missing f-string in --help message

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -424,7 +424,7 @@ options.add_options(
         merge_func=_default_venv_backend_merge_func,
         help=(
             "Virtual environment backend to use by default for Nox sessions, this is"
-            " ``'virtualenv'`` by default but any of ``{list(ALL_VENVS)!r}`` are accepted."
+            f" ``'virtualenv'`` by default but any of ``{list(ALL_VENVS)!r}`` are accepted."
         ),
         choices=list(ALL_VENVS),
     ),
@@ -438,7 +438,7 @@ options.add_options(
         help=(
             "Virtual environment backend to force-use for all Nox sessions in this run,"
             " overriding any other venv backend declared in the Noxfile and ignoring"
-            " the default backend. Any of ``{list(ALL_VENVS)!r}`` are accepted."
+            f" the default backend. Any of ``{list(ALL_VENVS)!r}`` are accepted."
         ),
         choices=list(ALL_VENVS),
     ),


### PR DESCRIPTION
Quick fix for the missing f-string in the `--help` message for `-db` and `-fb`:

```
  -db {conda,mamba,virtualenv,venv,uv,none}, --default-venv-backend {conda,mamba,virtualenv,venv,uv,none}
                        Virtual environment backend to use by default for Nox sessions, this is ``'virtualenv'`` by default but any of ``{list(ALL_VENVS)!r}`` are accepted.
  -fb {conda,mamba,virtualenv,venv,uv,none}, --force-venv-backend {conda,mamba,virtualenv,venv,uv,none}
                        Virtual environment backend to force-use for all Nox sessions in this run, overriding any other venv backend declared in the Noxfile and ignoring the default backend. Any of ``{list(ALL_VENVS)!r}`` are accepted.
```

In the long run, it would be nice to clean the `--help` message up some more. Like those quotes with double backtick and single quote, and the repetition of valid choices.