### PR TITLE
feat: add venv_backend property

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -167,13 +167,18 @@ You can also specify that the virtualenv should *always* be reused instead of re
     def tests(session):
         pass
 
-You are not limited to virtualenv, there is a selection of backends you can choose from as venv, conda, mamba, or virtualenv (default):
+You are not limited to virtualenv, there is a selection of backends you can choose from as venv, uv, conda, mamba, or virtualenv (default):
 
 .. code-block:: python
 
     @nox.session(venv_backend='venv')
     def tests(session):
         pass
+
+You can chain together optional backends with ``|``, such as ``uv|virtualenv``
+or ``mamba|conda``, and the first available backend will be selected. You
+cannot put anything after a backend that can't be missing like ``venv`` or
+``virtualenv``.
 
 Finally, custom backend parameters are supported:
 
@@ -182,6 +187,9 @@ Finally, custom backend parameters are supported:
     @nox.session(venv_params=['--no-download'])
     def tests(session):
         pass
+
+If you need to check to see which backend was selected, you can access it via
+``session.venv_backend``.
 
 
 Passing arguments into sessions

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -165,6 +165,9 @@ Note that using this option does not change the backend for sessions where ``ven
 
 Backends that could be missing (``uv``, ``conda``, and ``mamba``) can have a fallback using ``|``, such as ``uv|virtualenv`` or ``mamba|conda``. This will use the first item that is available on the users system.
 
+If you need to check to see which backend was selected, you can access it via
+``session.venv_backend`` in your noxfile.
+
 .. _opt-force-venv-backend:
 
 Forcing the sessions backend

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -194,6 +194,14 @@ class Session:
         return venv
 
     @property
+    def venv_backend(self) -> str:
+        """The venv_backend selected."""
+        venv = self._runner.venv
+        if venv is None:
+            return "none"
+        return venv.venv_backend
+
+    @property
     def python(self) -> str | Sequence[str] | bool | None:
         """The python version passed into ``@nox.session``."""
         return self._runner.func.python

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -641,6 +641,8 @@ class TestSession:
 
         session = SessionNoSlots(runner=runner)
 
+        assert session.venv_backend == "venv"
+
         with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3")
             run.assert_called_once_with(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -135,6 +135,8 @@ class TestSession:
         with pytest.raises(ValueError, match="virtualenv"):
             _ = session.virtualenv
 
+        assert session.venv_backend == "none"
+
     def test_interactive(self):
         session, runner = self.make_session_and_runner()
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -498,7 +498,7 @@ def test_stale_environment(make_one, frm, to, result, monkeypatch):
 
 
 def test_passthrough_environment_venv_backend(make_one):
-    venv, _ = make_one(reuse_existing=True, venv_backend="none")
+    venv, _ = make_one(venv_backend="none")
     venv.create()
     assert venv.venv_backend == "none"
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -56,7 +56,9 @@ def make_one(tmpdir):
         try:
             venv_fn = nox.virtualenv.ALL_VENVS[venv_backend]
         except KeyError:
-            venv_fn = functools.partial(nox.virtualenv.VirtualEnv, venv_backend=venv_backend)
+            venv_fn = functools.partial(
+                nox.virtualenv.VirtualEnv, venv_backend=venv_backend
+            )
         venv = venv_fn(location.strpath, *args, **kwargs)
         return (venv, location)
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -497,7 +497,7 @@ def test_stale_environment(make_one, frm, to, result, monkeypatch):
     assert reused == result
 
 
-def test_passthrough_environment_venv_backend():
+def test_passthrough_environment_venv_backend(make_one):
     venv, _ = make_one(reuse_existing=True, venv_backend="none")
     venv.create()
     assert venv.venv_backend == "none"

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -490,9 +490,11 @@ def test_stale_environment(make_one, frm, to, result, monkeypatch):
     monkeypatch.setenv("NOX_ENABLE_STALENESS_CHECK", "1")
     venv, _ = make_one(reuse_existing=True, venv_backend=frm)
     venv.create()
+    assert venv.venv_backend == frm
 
     venv, _ = make_one(reuse_existing=True, venv_backend=to)
     reused = venv._check_reused_environment_type()
+    assert venv.venv_backend == to
 
     assert reused == result
 


### PR DESCRIPTION
The venv property is also called `venv_backend` (matching the original property on the Venv subclass).

Closes #796.
