### PR TITLE
fix: avoid mixing venv and conda from environment

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -364,8 +364,14 @@ def test_bin_windows(make_one):
 
 
 def test_create(monkeypatch, make_one):
+    monkeypatch.setenv("CONDA_PREFIX", "no-prefix-allowed")
+    monkeypatch.setenv("NOT_CONDA_PREFIX", "something-else")
+
     venv, dir_ = make_one()
     venv.create()
+
+    assert "CONDA_PREFIX" not in venv.env
+    assert "NOT_CONDA_PREFIX" in venv.env
 
     if IS_WINDOWS:
         assert dir_.join("Scripts", "python.exe").check()


### PR DESCRIPTION
Fix #801.

Needs a test were we manually set one variable and make sure it isn't present. It might be the parent `run` overrides it.

I'd like to allow this at the user level, too; setting `env={"UNSET_ME": None}` would be a good way to provide an "unset" list. You can set to an empty string, but that's not always the same as not having the variable in the first place.
