### PR TITLE
fix: don't error if not installing to passthrough

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -565,7 +565,7 @@ class Session:
         prefix_args: tuple[str, ...] = ()
         if isinstance(venv, CondaEnv):
             prefix_args = ("--prefix", venv.location)
-        elif not isinstance(venv, PassthroughEnv):  # pragma: no cover
+        elif not isinstance(venv, PassthroughEnv):
             raise ValueError(
                 "A session without a conda environment can not install dependencies"
                 " from conda."
@@ -574,7 +574,9 @@ class Session:
         if not args:
             raise ValueError("At least one argument required to install().")
 
-        if self._runner.global_config.no_install and venv._reused:
+        if self._runner.global_config.no_install and (
+            isinstance(venv, PassthroughEnv) or venv._reused
+        ):
             return
 
         # Escape args that should be (conda-specific; pip install does not need this)
@@ -648,6 +650,8 @@ class Session:
                 "A session without a virtualenv can not install dependencies."
             )
         if isinstance(venv, PassthroughEnv):
+            if self._runner.global_config.no_install:
+                return
             raise ValueError(
                 f"Session {self.name} does not have a virtual environment, so use of"
                 " session.install() is no longer allowed since it would modify the"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -374,6 +374,20 @@ class TestSession:
         exc_args = exc_info.value.args
         assert exc_args == ("At least one argument required to run_install().",)
 
+    def test_run_no_install_passthrough(self):
+        session, runner = self.make_session_and_runner()
+        runner.venv = nox.virtualenv.PassthroughEnv()
+        runner.global_config.no_install = True
+
+        session.install("numpy")
+        session.conda_install("numpy")
+
+    def test_run_no_conda_install(self):
+        session, runner = self.make_session_and_runner()
+
+        with pytest.raises(ValueError, match="A session without a conda"):
+            session.conda_install("numpy")
+
     def test_run_install_success(self):
         session, _ = self.make_session_and_runner()
 


### PR DESCRIPTION
If you have a passthrough environment and have passed `--no-install`, don't error because there's an `install` command that's not going to do anything.

Fixes #739. This fixes the underlying problem in #693 - that was asking for a way to detect `run("pip", "install", ...)` precisely because this bug kept `.install(...)` from being usable.
