### PR TITLE
fix: ensure 'uv' always works in a uv venv

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -557,8 +557,12 @@ class Session:
             return self._run_func(args[0], args[1:])  # type: ignore[unreachable]
 
         # Using `"uv"` when `uv` is the backend is guaranteed to work, even if it was co-installed with nox.
-        if self.virtualenv.venv_backend == "uv" and args[0] == "uv" and nox.virtualenv.UV != "uv":
-            args = (nox.virualenv.UV, *args[1:])
+        if (
+            self.virtualenv.venv_backend == "uv"
+            and args[0] == "uv"
+            and nox.virtualenv.UV != "uv"
+        ):
+            args = (nox.virtualenv.UV, *args[1:])
 
         # Combine the env argument with our virtualenv's env vars.
         if include_outer_env:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -43,7 +43,7 @@ import nox.virtualenv
 from nox._decorators import Func
 from nox.logger import logger
 from nox.popen import DEFAULT_INTERRUPT_TIMEOUT, DEFAULT_TERMINATE_TIMEOUT
-from nox.virtualenv import UV, CondaEnv, PassthroughEnv, ProcessEnv, VirtualEnv
+from nox.virtualenv import CondaEnv, PassthroughEnv, ProcessEnv, VirtualEnv
 
 if TYPE_CHECKING:
     from typing import IO
@@ -557,8 +557,8 @@ class Session:
             return self._run_func(args[0], args[1:])  # type: ignore[unreachable]
 
         # Using `"uv"` when `uv` is the backend is guaranteed to work, even if it was co-installed with nox.
-        if self.virtualenv.venv_backend == "uv" and args[0] == "uv" and UV != "uv":
-            args = (UV, *args[1:])
+        if self.virtualenv.venv_backend == "uv" and args[0] == "uv" and nox.virtualenv.UV != "uv":
+            args = (nox.virualenv.UV, *args[1:])
 
         # Combine the env argument with our virtualenv's env vars.
         if include_outer_env:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -556,6 +556,10 @@ class Session:
         if callable(args[0]):
             return self._run_func(args[0], args[1:])  # type: ignore[unreachable]
 
+        # Using `"uv"` when `uv` is the backend is guaranteed to work, even if it was co-installed with nox.
+        if self.virtualenv.venv_backend == "uv" and args[0] == "uv" and UV != "uv":
+            args = (UV, *args[1:])
+
         # Combine the env argument with our virtualenv's env vars.
         if include_outer_env:
             overlay_env = env or {}
@@ -769,7 +773,7 @@ class Session:
             silent = True
 
         if isinstance(venv, VirtualEnv) and venv.venv_backend == "uv":
-            cmd = [UV, "pip", "install"]
+            cmd = ["uv", "pip", "install"]
         else:
             cmd = ["python", "-m", "pip", "install"]
         self._run(

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -21,8 +21,8 @@ import hashlib
 import os
 import pathlib
 import re
-import subprocess
 import shutil
+import subprocess
 import sys
 import unicodedata
 from collections.abc import (
@@ -562,7 +562,7 @@ class Session:
             self.virtualenv.venv_backend == "uv"
             and args[0] == "uv"
             and nox.virtualenv.UV != "uv"
-            and shutil.which("uv", path=self.bin) is None
+            and shutil.which("uv", path=self.bin) is None  # Session uv takes priority
         ):
             args = (nox.virtualenv.UV, *args[1:])
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -22,6 +22,7 @@ import os
 import pathlib
 import re
 import subprocess
+import shutil
 import sys
 import unicodedata
 from collections.abc import (
@@ -561,6 +562,7 @@ class Session:
             self.virtualenv.venv_backend == "uv"
             and args[0] == "uv"
             and nox.virtualenv.UV != "uv"
+            and shutil.which("uv", path=self.bin) is None
         ):
             args = (nox.virtualenv.UV, *args[1:])
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -54,6 +54,8 @@ def find_uv() -> tuple[bool, str]:
 
         uv_bin = find_uv_bin()
 
+        # If the returned value is the same as calling "uv" already, don't
+        # expand (simpler logging)
         if uv_on_path and Path(uv_bin).samefile(uv_on_path):
             return True, "uv"
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -24,6 +24,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Callable, Mapping
+from pathlib import Path
 from socket import gethostbyname
 from typing import Any, ClassVar
 
@@ -45,17 +46,21 @@ _SYSTEM = platform.system()
 
 
 def find_uv() -> tuple[bool, str]:
+    uv_on_path = shutil.which("uv")
+
     # Look for uv in Nox's environment, to handle `pipx install nox[uv]`.
     with contextlib.suppress(ImportError, FileNotFoundError):
         from uv import find_uv_bin
 
-        return True, find_uv_bin()
+        uv_bin = find_uv_bin()
+
+        if uv_on_path and Path(uv_bin).samefile(uv_on_path):
+            return True, "uv"
+
+        return True, uv_bin
 
     # Fall back to PATH.
-    if shutil.which("uv") is not None:
-        return True, "uv"
-
-    return False, "uv"
+    return uv_on_path is not None, "uv"
 
 
 HAS_UV, UV = find_uv()

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -52,9 +52,8 @@ def find_uv() -> tuple[bool, str]:
         return True, find_uv_bin()
 
     # Fall back to PATH.
-    uv = shutil.which("uv")
-    if uv is not None:
-        return True, uv
+    if shutil.which("uv") is not None:
+        return True, "uv"
 
     return False, "uv"
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -849,7 +849,8 @@ class TestSession:
 
         assert run.called is run_called
 
-    def test_install_uv(self):
+    @pytest.mark.parametrize("uv", [None, "/some/uv"])
+    def test_install_uv(self, uv, monkeypatch):
         runner = nox.sessions.SessionRunner(
             name="test",
             signatures=["test"],
@@ -865,6 +866,9 @@ class TestSession:
             pass
 
         session = SessionNoSlots(runner=runner)
+
+        if uv is not None:
+            monkeypatch.setattr(nox.virtualenv, "UV", uv)
 
         with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3", silent=False)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -605,7 +605,7 @@ UV_IN_PIPX_VENV = "/home/user/.local/pipx/venvs/nox/bin/uv"
     ["which_result", "find_uv_bin_result", "expected"],
     [
         ("/usr/bin/uv", UV_IN_PIPX_VENV,   (True,  UV_IN_PIPX_VENV)),
-        ("/usr/bin/uv", FileNotFoundError, (True,  "/usr/bin/uv")),
+        ("/usr/bin/uv", FileNotFoundError, (True,  "uv")),
         (None,          UV_IN_PIPX_VENV,   (True,  UV_IN_PIPX_VENV)),
         (None,          FileNotFoundError, (False, "uv")),
     ],


### PR DESCRIPTION
It's necessary sometimes to use the backend tool (pip, uv, conda, mamba, micromamba) inside a virtual environment. We already have a bit of special casing for it, making sure it's not considered "external". This PR just makes sure that `.run("uv", ...)` is always supported if you are using the uv backend. All the other backends are already gaurenteed to be on the path if they are active, so no change is needed (yet, anyway - this mechanism could also enable using `pip` from outside instead of always installing it, might be worth investigating in the future).

Followup to and generalizes #795.
