### PR TITLE
chore: drop Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-13]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: macos-14
             python-version: "3.12"
@@ -32,7 +32,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Setup uv
         uses: yezz123/setup-uv@v4
-        if: matrix.python-version != '3.7'
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -41,16 +40,11 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
       - name: Install Nox-under-test (uv)
-        if: matrix.python-version != '3.7'
         run:  uv pip install --system .
-      - name: Install Nox-under-test (pip)
-        if: matrix.python-version == '3.7'
-        run: python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }} (tox <4)
         run: nox --non-interactive --error-on-missing-interpreter --session "tests(python='${{ matrix.python-version }}', tox_version='<4')" -- --full-trace
       - name: Run tox-to-nox tests on ${{ matrix.os }} (tox latest)
         run: nox --non-interactive --error-on-missing-interpreter --session "tests(python='${{ matrix.python-version }}', tox_version='latest')" -- tests/test_tox_to_nox.py --full-trace
-        if: matrix.python-version != '3.7'
       - name: Save coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -62,10 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Setup uv
         uses: yezz123/setup-uv@v4
       - name: Install Nox-under-test
@@ -84,10 +78,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
       - name: Install Nox-under-test
         run: python -m pip install --disable-pip-version-check .
       - name: Lint
@@ -96,10 +90,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
       - name: Setup uv
         uses: yezz123/setup-uv@v4
       - name: Install Nox-under-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,11 @@ To just check for lint errors, run:
 
 To run against a particular Python version:
 
-    nox --session tests-3.6
-    nox --session tests-3.7
     nox --session tests-3.8
     nox --session tests-3.9
+    nox --session tests-3.10
+    nox --session tests-3.11
+    nox --session tests-3.12
 
 When you send a pull request the CI will handle running everything, but it is
 recommended to test as much as possible locally before pushing.

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     - uses: actions/setup-python@v5
       id: localpython
       with:
-        python-version: "3.7 - 3.12"
+        python-version: "3.8 - 3.12"
         update-environment: false
 
     - name: "Validate input"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,11 +15,7 @@ from __future__ import annotations
 
 import os
 import sys
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
+from importlib import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -368,11 +368,11 @@ These two examples are equivalent:
 .. code-block:: python
 
     @nox.session
-    @nox.parametrize("python", ["3.6", "3.7", "3.8"])
+    @nox.parametrize("python", ["3.10", "3.11", "3.12"])
     def tests(session):
         ...
 
-    @nox.session(python=["3.6", "3.7", "3.8"])
+    @nox.session(python=["3.10", "3.11", "3.12"])
     def tests(session):
         ...
 
@@ -388,9 +388,9 @@ Pythons:
         "python,dependency",
         [
             (python, dependency)
-            for python in ("3.6", "3.7", "3.8")
+            for python in ("3.10", "3.11", "3.12")
             for dependency in ("1.0", "2.0")
-            if (python, dependency) != ("3.6", "2.0")
+            if (python, dependency) != ("3.10", "2.0")
         ],
     )
     def tests(session, dependency):

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -35,16 +35,16 @@ If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/n
 
     # setup nox with all active CPython and PyPY versions provided by
     # the GitHub Actions environment i.e.
-    # python-versions: "3.7, 3.8, 3.9, 3.10, pypy-3.7, pypy-3.8, pypy-3.9"
-    # this uses version 2022.8.7 but any Nox tag will work here
-    - uses: wntrblm/nox@2022.8.7
+    # python-versions: "3.8, 3.9, 3.10, 3.11, 3.12, pypy-3.8, pypy-3.9, pypy-3.10"
+    # Any Nox tag will work here
+    - uses: wntrblm/nox@2024.04.15
 
     # setup nox only for a given list of python versions
     # Limitations:
     # - Version specifiers shall be supported by actions/setup-python
-    # - There can only be one "major.minor" per interpreter i.e. "3.7.0, 3.7.1" is invalid
-    # this uses version 2022.8.7 but any Nox tag will work here
-    - uses: wntrblm/nox@2022.8.7
+    # - There can only be one "major.minor" per interpreter i.e. "3.12.0, 3.12.1" is invalid
+    # Any Nox tag will work here
+    - uses: wntrblm/nox@2024.04.15
       with:
           python-versions: "2.7, 3.5, 3.11, pypy-3.9"
 
@@ -388,7 +388,7 @@ If you want your session to specifically run against a single version of Python 
 
 .. code-block:: python
 
-    @nox.session(python="3.7")
+    @nox.session(python="3.12")
     def test(session):
         ...
 
@@ -396,7 +396,7 @@ If you want your session to run against multiple versions of Python:
 
 .. code-block:: python
 
-    @nox.session(python=["2.7", "3.6", "3.7"])
+    @nox.session(python=["3.10", "3.11", "3.12"])
     def test(session):
         ...
 
@@ -407,13 +407,13 @@ been expanded into three distinct sessions:
 
     Sessions defined in noxfile.py:
 
-    * test-2.7
-    * test-3.6
-    * test-3.7
+    * test-3.10
+    * test-3.11
+    * test-3.12
 
 You can run all of the ``test`` sessions using ``nox --sessions test`` or run
 an individual one using the full name as displayed in the list, for example,
-``nox --sessions test-3.5``. More details on selecting sessions can be found
+``nox --sessions test-3.12``. More details on selecting sessions can be found
 over in the :doc:`usage` documentation.
 
 You can read more about configuring the virtual environment used by your

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -79,13 +79,13 @@ If you have a :ref:`configured session's virtualenv <virtualenv config>`, you ca
 
    .. code-tab:: console CLI options
 
-         nox --python 3.8
-         nox -p 3.7 3.8
+         nox --python 3.12
+         nox -p 3.11 3.12
 
    .. code-tab:: console Environment variables
 
-         NOXPYTHON=3.8 nox
-         NOXPYTHON=3.7,3.8 nox
+         NOXPYTHON=3.12 nox
+         NOXPYTHON=3.11,3.12 nox
 
 You can also use `pytest-style keywords`_ using ``-k`` or ``--keywords``, and
 tags using ``-t`` or ``--tags`` to filter test sessions:
@@ -377,7 +377,7 @@ Would run both ``install`` commands, but skip the ``run`` command:
 .. code-block:: console
 
     nox > Running session tests
-    nox > Creating virtualenv using python3.7 in ./.nox/tests
+    nox > Creating virtualenv using python3.12 in ./.nox/tests
     nox > python -m pip install pytest
     nox > python -m pip install .
     nox > Skipping pytest run, as --install-only is set.

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -20,18 +20,13 @@ import itertools
 import os
 import sys
 from collections.abc import Iterable
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Literal, Sequence
 
 import argcomplete
 
 from nox import _option_set
 from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 from nox.virtualenv import ALL_VENVS
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal
 
 ReuseVenvType = Literal["no", "yes", "never", "always"]
 

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -16,15 +16,10 @@ from __future__ import annotations
 
 import ast
 import contextlib
-import sys
+from importlib import metadata
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 class VersionCheckFailed(Exception):
@@ -42,10 +37,7 @@ def get_nox_version() -> str:
 
 def _parse_string_constant(node: ast.AST) -> str | None:  # pragma: no cover
     """Return the value of a string constant."""
-    if sys.version_info < (3, 8):
-        if isinstance(node, ast.Str) and isinstance(node.s, str):
-            return node.s
-    elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
     return None
 

--- a/nox/command.py
+++ b/nox/command.py
@@ -20,14 +20,10 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Iterable, Mapping, Sequence
+from typing import Literal
 
 from nox.logger import logger
 from nox.popen import DEFAULT_INTERRUPT_TIMEOUT, DEFAULT_TERMINATE_TIMEOUT, popen
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal
 
 TYPE_CHECKING = False
 

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -20,19 +20,14 @@ import argparse
 import os
 import pkgutil
 import re
-import sys
 from configparser import ConfigParser
+from importlib import metadata
 from pathlib import Path
 from subprocess import check_output
 from typing import Any, Iterable
 
 import jinja2
 import tox.config
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
 
 TOX_VERSION = metadata.version("tox")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,17 +40,13 @@ if shutil.which("micromamba"):
     nox.options.sessions.append("micromamba_tests")
 
 
-# Because there is a dependency conflict between argcomplete and the latest tox
-# (both depend on a different version of importlibmetadata for Py 3.7) pip
-# installs tox 3 as the latest one for Py 3.7.
 @nox.session
 @nox.parametrize(
     "python, tox_version",
     [
         (python, tox_version)
-        for python in ("3.7", "3.8", "3.9", "3.10", "3.11", "3.12")
+        for python in ("3.8", "3.9", "3.10", "3.11", "3.12")
         for tox_version in ("latest", "<4")
-        if (python, tox_version) != ("3.7", "latest")
     ],
 )
 def tests(session: nox.Session, tox_version: str) -> None:
@@ -125,7 +121,7 @@ def cover(session: nox.Session) -> None:
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.12")
 def lint(session: nox.Session) -> None:
     """Run pre-commit linting."""
     session.install("pre-commit")
@@ -202,13 +198,11 @@ def github_actions_default_tests(session: nox.Session) -> None:
 
 @nox.session(
     python=[
-        "3.7",
         "3.8",
         "3.9",
         "3.10",
         "3.11",
         "3.12",
-        "pypy3.7",
         "pypy3.8",
         "pypy3.9",
         "pypy3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
   { name = "Alethea Katherine Flowers" },
   { email = "me@thea.codes" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -31,7 +31,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -42,10 +41,8 @@ classifiers = [
 dependencies = [
   "argcomplete<4.0,>=1.9.4",
   "colorlog<7.0.0,>=2.6.1",
-  'importlib-metadata; python_version < "3.8"',
   "packaging>=20.9",
   'tomli>=1; python_version < "3.11"',
-  'typing-extensions>=3.7.4; python_version < "3.8"',
   "virtualenv>=20.14.1",
 ]
 [project.optional-dependencies]
@@ -112,7 +109,7 @@ exclude_also = [ "def __dir__()", "if TYPE_CHECKING:", "@overload" ]
 
 [tool.mypy]
 files = [ "nox/**/*.py", "noxfile.py" ]
-python_version = "3.7"
+python_version = "3.8"
 strict = true
 warn_unreachable = true
 enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
+from importlib import metadata
 from pathlib import Path
 from unittest import mock
 
@@ -27,12 +28,6 @@ import nox.__main__
 import nox._options
 import nox.registry
 import nox.sessions
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
-
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 VERSION = metadata.version("nox")

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import sys
 import types
+from importlib import metadata
 from pathlib import Path
 from textwrap import dedent
 from typing import NamedTuple
@@ -30,11 +31,6 @@ import pytest
 from packaging import version
 
 import nox.virtualenv
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
 
 IS_WINDOWS = nox.virtualenv._SYSTEM == "Windows"
 HAS_CONDA = shutil.which("conda") is not None
@@ -497,8 +493,7 @@ def test_micromamba_environment(make_one, monkeypatch):
     monkeypatch.setattr(nox.command, "run", run)
     venv.create()
     run.assert_called_once()
-    # .args requires Python 3.8+
-    ((args,), _) = run.call_args
+    (args,) = run.call_args.args
     assert args[0] == "micromamba"
     assert "--channel=conda-forge" in args
 
@@ -521,8 +516,7 @@ def test_micromamba_channel_environment(make_one, monkeypatch, params):
     venv.venv_params = params
     venv.create()
     run.assert_called_once()
-    # .args requires Python 3.8+
-    ((args,), _) = run.call_args
+    (args,) = run.call_args.args
     assert args[0] == "micromamba"
     for p in params:
         assert p in args


### PR DESCRIPTION
Dropping support for running with Python 3.7, which is well past EoL.
