### PR TITLE
chore(ci): use default action tests for macos-14

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,6 +27,7 @@ jobs:
             macos-11,
             macos-12,
             macos-13,
+            macos-14,
           ]
     steps:
       - uses: actions/checkout@v4
@@ -44,12 +45,3 @@ jobs:
         with:
           python-versions: "3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10"
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_all_tests
-
-  action-macos14-tests:
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-        with:
-          python-versions: "3.10, 3.11, 3.12, pypy-3.8, pypy-3.9, pypy-3.10"
-      - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_macos_14

--- a/noxfile.py
+++ b/noxfile.py
@@ -217,19 +217,3 @@ def github_actions_default_tests(session: nox.Session) -> None:
 def github_actions_all_tests(session: nox.Session) -> None:
     """Check all versions installed by the nox GHA Action"""
     _check_python_version(session)
-
-
-@nox.session(
-    python=[
-        "3.10",
-        "3.11",
-        "3.12",
-        "pypy3.8",
-        "pypy3.9",
-        "pypy3.10",
-    ]
-)
-def github_actions_macos_14(session: nox.Session) -> None:
-    """Check default versions installed by the nox GHA Action"""
-    assert sys.version_info[:2] == (3, 11)
-    _check_python_version(session)


### PR DESCRIPTION
Python 3.8 & 3.9 are now supported on macOS-14.