### PR TITLE
fix: support noxfile being a symlink

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -199,6 +199,16 @@ class Session:
         return venv
 
     @property
+    def noxfile(self) -> pathlib.Path:
+        """The path to the Noxfile that defines this session.
+
+        If the noxfile is a symlink, this does not resolve that last symlink; it
+        has been resolved up to that point. Use `session.noxfile.resolve()` to
+        get the original file path.
+        """
+        return pathlib.Path(self._runner.global_config.noxfile)
+
+    @property
     def venv_backend(self) -> str:
         """The venv_backend selected."""
         venv = self._runner.venv

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -199,16 +199,6 @@ class Session:
         return venv
 
     @property
-    def noxfile(self) -> pathlib.Path:
-        """The path to the Noxfile that defines this session.
-
-        If the noxfile is a symlink, this does not resolve that last symlink; it
-        has been resolved up to that point. Use `session.noxfile.resolve()` to
-        get the original file path.
-        """
-        return pathlib.Path(self._runner.global_config.noxfile)
-
-    @property
     def venv_backend(self) -> str:
         """The venv_backend selected."""
         venv = self._runner.venv

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -83,13 +83,15 @@ def load_nox_module(global_config: Namespace) -> types.ModuleType | int:
     # Be sure to expand variables
     global_config_noxfile = os.path.expandvars(global_config.noxfile)
 
+    # Make sure we only expand the parent dir just in case the noxfile is a symlink
+    noxfile_parent_dir = os.path.realpath(os.path.dirname(global_config_noxfile))
+
     # Save the absolute path to the Noxfile.
     # This will inoculate it if Nox changes paths because of an implicit
     # or explicit chdir (like the one below).
-    global_config.noxfile = os.path.realpath(global_config_noxfile)
-
-    # Make sure we only expand the parent dir just in case the noxfile is a symlink
-    noxfile_parent_dir = os.path.realpath(os.path.dirname(global_config.noxfile))
+    global_config.noxfile = os.path.join(
+        noxfile_parent_dir, os.path.basename(global_config_noxfile)
+    )
 
     try:
         # Check ``nox.needs_version`` by parsing the AST.

--- a/tests/resources/orig_dir/noxfile.py
+++ b/tests/resources/orig_dir/noxfile.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import nox
+
+DIR = Path(__file__).parent.resolve()
+
+
+@nox.session(venv_backend="none", default=False)
+def orig(session: nox.Session) -> None:
+    assert Path("orig_file.txt").exists()
+
+
+@nox.session(venv_backend="none", default=False)
+def sym(session: nox.Session) -> None:
+    assert Path("sym_file.txt").exists()
+
+    assert session.noxfile.resolve().parent.joinpath("orig_file.txt").exists()

--- a/tests/resources/orig_dir/noxfile.py
+++ b/tests/resources/orig_dir/noxfile.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import nox
 
-DIR = Path(__file__).parent.resolve()
+FILE = Path(__file__).resolve()
 
 
 @nox.session(venv_backend="none", default=False)
@@ -14,4 +14,4 @@ def orig(session: nox.Session) -> None:
 def sym(session: nox.Session) -> None:
     assert Path("sym_file.txt").exists()
 
-    assert session.noxfile.resolve().parent.joinpath("orig_file.txt").exists()
+    assert FILE.parent.joinpath("orig_file.txt").exists()

--- a/tests/resources/sym_dir/noxfile.py
+++ b/tests/resources/sym_dir/noxfile.py
@@ -1,0 +1,1 @@
+../orig_dir/noxfile.py

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import subprocess
 import sys
 from importlib import metadata
 from pathlib import Path
@@ -928,3 +929,25 @@ def test_noxfile_options_cant_be_set():
 def test_noxfile_options_cant_be_set_long():
     with pytest.raises(AttributeError, match="i_am_clearly_not_an_option"):
         nox.options.i_am_clearly_not_an_option = True
+
+
+def test_symlink_orig(monkeypatch):
+    monkeypatch.chdir(Path(RESOURCES) / "orig_dir")
+    subprocess.run([sys.executable, "-m", "nox", "-s", "orig"], check=True)
+
+
+def test_symlink_orig_not(monkeypatch):
+    monkeypatch.chdir(Path(RESOURCES) / "orig_dir")
+    res = subprocess.run([sys.executable, "-m", "nox", "-s", "sym"], check=False)
+    assert res.returncode == 1
+
+
+def test_symlink_sym(monkeypatch):
+    monkeypatch.chdir(Path(RESOURCES) / "sym_dir")
+    subprocess.run([sys.executable, "-m", "nox", "-s", "sym"], check=True)
+
+
+def test_symlink_sym_not(monkeypatch):
+    monkeypatch.chdir(Path(RESOURCES) / "sym_dir")
+    res = subprocess.run([sys.executable, "-m", "nox", "-s", "orig"], check=False)
+    assert res.returncode == 1


### PR DESCRIPTION
Fix #828.

If you need the non-symlinked file, it's easy to get with `__file__`, as can be seen in the tests.