### PR TITLE
chore: use uv if available in action

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -31,6 +31,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
+      - uses: yezz123/setup-uv@v4
       - uses: ./
       - run: nox --non-interactive --error-on-missing-interpreter --session github_actions_default_tests
 

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,10 @@ runs:
             def post_setup(self, context):
                 super().post_setup(context)
                 self.bin_path = Path(context.env_exe).parent
-                run([sys.executable, "-m", "pip", "--python", context.env_exe, "install", r"${{ github.action_path }}"], check=True)
+                if shutil.which("uv") is None:
+                    run([sys.executable, "-m", "pip", "--python", context.env_exe, "install", r"${{ github.action_path }}"], check=True)
+                else:
+                    run(["uv", "pip", "install", "--python", context.env_exe, r"${{ github.action_path }}"], check=True)
 
 
         print("::group::Install nox")


### PR DESCRIPTION
If uv has been installed before the nox action, use it to speed up the install of nox. Should save ~10 seconds or so.
