### PR TITLE
feat: allow setting tags on parametrized sessions

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -496,6 +496,8 @@ read more about parametrization and see more examples over at
 .. _pytest's parametrize: https://pytest.org/latest/parametrize.html#_pytest.python.Metafunc.parametrize
 
 
+.. _session tags:
+
 Session tags
 ------------
 

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -128,7 +128,7 @@ class Call(Func):
             func.venv_backend,
             func.venv_params,
             func.should_warn,
-            func.tags,
+            func.tags + param_spec.tags,
             default=func.default,
         )
         self.call_spec = call_spec

--- a/tests/resources/noxfile_tags.py
+++ b/tests/resources/noxfile_tags.py
@@ -16,3 +16,10 @@ def one_tag(unused_session):
 @nox.session(tags=["tag1", "tag2", "tag3"])
 def more_tags(unused_session):
     print("Some more tags here.")
+
+
+@nox.session(tags=["tag4"])
+@nox.parametrize("foo", [nox.param(1, tags=["tag5", "tag6"])])
+@nox.parametrize("bar", [2, 3], tags=[["tag7"]])
+def parametrized_tags(unused_session):
+    print("Parametrized tags here.")

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -127,5 +127,5 @@ class TestOptionSet:
             prefix=None, parsed_args=parsed_args
         )
 
-        expected_tags = {"tag1", "tag2", "tag3"}
+        expected_tags = {f"tag{n}" for n in range(1, 8)}
         assert expected_tags == set(actual_tags_from_file)

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -197,7 +197,7 @@ def test_generate_calls_simple():
 
 
 def test_generate_calls_multiple_args():
-    f = mock.Mock(should_warn=None, tags=None)
+    f = mock.Mock(should_warn=None, tags=[])
     f.__name__ = "f"
 
     arg_names = ("foo", "abc")
@@ -242,6 +242,44 @@ def test_generate_calls_ids():
     f.assert_called_with(foo=1)
     calls[1]()
     f.assert_called_with(foo=2)
+
+
+def test_generate_calls_tags():
+    f = mock.Mock(should_warn={}, tags=[])
+    f.__name__ = "f"
+
+    arg_names = ("foo",)
+    call_specs = [
+        _parametrize.Param(1, arg_names=arg_names, tags=["tag3"]),
+        _parametrize.Param(1, arg_names=arg_names),
+        _parametrize.Param(2, arg_names=arg_names, tags=["tag4", "tag5"]),
+    ]
+
+    calls = _decorators.Call.generate_calls(f, call_specs)
+
+    assert len(calls) == 3
+    assert calls[0].tags == ["tag3"]
+    assert calls[1].tags == []
+    assert calls[2].tags == ["tag4", "tag5"]
+
+
+def test_generate_calls_merge_tags():
+    f = mock.Mock(should_warn={}, tags=["tag1", "tag2"])
+    f.__name__ = "f"
+
+    arg_names = ("foo",)
+    call_specs = [
+        _parametrize.Param(1, arg_names=arg_names, tags=["tag3"]),
+        _parametrize.Param(1, arg_names=arg_names),
+        _parametrize.Param(2, arg_names=arg_names, tags=["tag4", "tag5"]),
+    ]
+
+    calls = _decorators.Call.generate_calls(f, call_specs)
+
+    assert len(calls) == 3
+    assert calls[0].tags == ["tag1", "tag2", "tag3"]
+    assert calls[1].tags == ["tag1", "tag2"]
+    assert calls[2].tags == ["tag1", "tag2", "tag4", "tag5"]
 
 
 def test_generate_calls_session_python():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -254,13 +254,14 @@ def test_filter_manifest_keywords_syntax_error():
 @pytest.mark.parametrize(
     "tags,session_count",
     [
-        (None, 4),
-        (["foo"], 3),
-        (["bar"], 3),
-        (["baz"], 1),
-        (["foo", "bar"], 4),
-        (["foo", "baz"], 3),
-        (["foo", "bar", "baz"], 4),
+        (None, 8),
+        (["foo"], 7),
+        (["bar"], 5),
+        (["baz"], 3),
+        (["foo", "bar"], 8),
+        (["foo", "baz"], 7),
+        (["bar", "baz"], 6),
+        (["foo", "bar", "baz"], 8),
     ],
 )
 def test_filter_manifest_tags(tags, session_count):
@@ -280,6 +281,12 @@ def test_filter_manifest_tags(tags, session_count):
     def corge():
         pass
 
+    @nox.session(tags=["foo"])
+    @nox.parametrize("a", [1, nox.param(2, tags=["bar"])])
+    @nox.parametrize("b", [3, 4], tags=[["baz"]])
+    def grault():
+        pass
+
     config = _options.options.namespace(
         sessions=None, pythons=(), posargs=[], tags=tags
     )
@@ -289,6 +296,7 @@ def test_filter_manifest_tags(tags, session_count):
             "quux": quux,
             "quuz": quuz,
             "corge": corge,
+            "grault": grault,
         },
         config,
     )


### PR DESCRIPTION
To allow more fine-grained session selection, allow tags to be set on individual parametrized sessions via either a tags argument to the `@nox.parametrize()` decorator, or a tags argument to `nox.param()` (similar to how parametrized session IDs can be specified). Any tags specified this way will be added to any tags passed to the `@nox.session()` decorator.

A couple of examples of how this could be used:

    @nox.session
    @nox.parametrize(
        "db_engine", [
            nox.param("sqlite", tags=["sqlite"])
            nox.param("mysql", tags=["mysql"])
            nox.param("postgresql", tags=["psql"])
        ]
    )
    @nox.parametrize(
        "django", [
            nox.param(">=3,<4", tags=["django3"])
            nox.param(">=4,<5", tags=["django4"])
            nox.param(">=5,<6", tags=["django5"])
        ]
    )
    def test(session, db_engine, django):
        pass

In this case, a developer could run `nox -t sqlite` to run just the tests with all versions of Django but only using the SQLite backend.

Here's a more complex example:

    def generate_params():
        for python in ["3.10", "3.11", 3.12"]:
            for django in [3, 4, 5]:
                tags = []
                if python == "3.12" and django == 5:
                    tags.append("quick")
                if python == "3.12" or django == 5:
                    tags.append("standard")
                yield nox.param([python, django], tags)

    @nox.session
    @nox.parametrize(
        ["python", "django"], generate_params(),
    )
    def test(session, django):
        pass

This tags the Python 3.12/Django 5 combination with the `quick` tag, allowing the developer to run a quick sanity check on the code using a single entry from the test matrix. It also tags any combination of Python 3.12 *or* Django 5 with the `standard` tag, allowing the developer to run the tests using Python 3.12 with all versions of Django along with all versions of Python with Django 5, which should give fairly comprehensive test coverage while only having to run five entries from the test matrix instead of nine.
