### PR TITLE
Update type annotation of `stderr` parameter to make it optional

### DIFF
--- a/nox/command.py
+++ b/nox/command.py
@@ -83,7 +83,7 @@ def run(
     log: bool = True,
     external: ExternalType = False,
     stdout: int | IO[str] | None = None,
-    stderr: int | IO[str] = subprocess.STDOUT,
+    stderr: int | IO[str] | None = subprocess.STDOUT,
     interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
     terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
 ) -> str | bool:

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -66,7 +66,7 @@ def popen(
     env: Mapping[str, str] | None = None,
     silent: bool = False,
     stdout: int | IO[str] | None = None,
-    stderr: int | IO[str] = subprocess.STDOUT,
+    stderr: int | IO[str] | None = subprocess.STDOUT,
     interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
     terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
 ) -> tuple[int, str]:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -294,7 +294,7 @@ class Session:
         log: bool = True,
         external: ExternalType | None = None,
         stdout: int | IO[str] | None = None,
-        stderr: int | IO[str] = subprocess.STDOUT,
+        stderr: int | IO[str] | None = subprocess.STDOUT,
         interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
         terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
     ) -> Any | None:
@@ -433,7 +433,7 @@ class Session:
         log: bool = True,
         external: ExternalType | None = None,
         stdout: int | IO[str] | None = None,
-        stderr: int | IO[str] = subprocess.STDOUT,
+        stderr: int | IO[str] | None = subprocess.STDOUT,
         interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
         terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
     ) -> Any | None:
@@ -515,7 +515,7 @@ class Session:
         log: bool = True,
         external: ExternalType | None = None,
         stdout: int | IO[str] | None = None,
-        stderr: int | IO[str] = subprocess.STDOUT,
+        stderr: int | IO[str] | None = subprocess.STDOUT,
         interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
         terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
     ) -> Any | None:
@@ -548,7 +548,7 @@ class Session:
         log: bool,
         external: ExternalType | None,
         stdout: int | IO[str] | None,
-        stderr: int | IO[str],
+        stderr: int | IO[str] | None,
         interrupt_timeout: float | None,
         terminate_timeout: float | None,
     ) -> Any:
@@ -611,7 +611,7 @@ class Session:
         success_codes: Iterable[int] | None = None,
         log: bool = True,
         stdout: int | IO[str] | None = None,
-        stderr: int | IO[str] = subprocess.STDOUT,
+        stderr: int | IO[str] | None = subprocess.STDOUT,
         interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
         terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
     ) -> None:
@@ -718,7 +718,7 @@ class Session:
         log: bool = True,
         external: ExternalType | None = None,
         stdout: int | IO[str] | None = None,
-        stderr: int | IO[str] = subprocess.STDOUT,
+        stderr: int | IO[str] | None = subprocess.STDOUT,
         interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
         terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
     ) -> None:


### PR DESCRIPTION
This is used, for example, by nox-poetry: https://github.com/cjolowicz/nox-poetry/blob/fb20b69892d394e8a4b97ae4d1f1d06cf811d32f/src/nox_poetry/poetry.py#L91