### PR TITLE
fix: add missing cookbook recipe snippet imports

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -89,7 +89,6 @@ Even more so with a sprinkling of Nox:
 .. code-block:: python
 
     import argparse
-    
     import nox
 
     @nox.session

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -40,6 +40,7 @@ Enter the ``dev`` nox session:
 .. code-block:: python
 
     import os
+    import pathlib
 
     import nox
 
@@ -87,6 +88,8 @@ Even more so with a sprinkling of Nox:
 
 .. code-block:: python
 
+    import argparse
+    
     import nox
 
     @nox.session


### PR DESCRIPTION
# What
Add missing cookbook recipe imports.

closes #852