### PR TITLE
fix: remove add_timestamp from noxfile.options

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -407,7 +407,6 @@ options.add_options(
         group=options.groups["reporting"],
         action="store_true",
         help="Adds a timestamp to logged output.",
-        noxfile=True,
     ),
     _option_set.Option(
         "default_venv_backend",


### PR DESCRIPTION
logging is setup before all tasks,
so it's not possible to use it as noxfile.option.

we could add it after tasks.merge_noxfile_options, but in this case the logger wouldn't setup early for tasks.load_nox_module