### PR TITLE
chore: PyPy no longer supports 3.9, so drop from action default list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-versions:
     description: "comma-separated list of python versions to install"
     required: false
-    default: "3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy-3.9, pypy-3.10"
+    default: "3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy-3.10"
 branding:
   icon: package
   color: blue


### PR DESCRIPTION
Drop this from the default activation.