### PR TITLE
docs: clean up dev recipe

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -39,42 +39,24 @@ Enter the ``dev`` nox session:
 
 .. code-block:: python
 
-    import os
-    import pathlib
-
     import nox
+
 
     # It's a good idea to keep your dev session out of the default list
     # so it's not run twice accidentally
-    nox.options.sessions = [...] # Sessions other than 'dev'
-
-    # this VENV_DIR constant specifies the name of the dir that the `dev`
-    # session will create, containing the virtualenv;
-    # the `resolve()` makes it portable
-    VENV_DIR = pathlib.Path('./.venv').resolve()
-
-    @nox.session
+    @nox.session(default=False)
     def dev(session: nox.Session) -> None:
         """
-        Sets up a python development environment for the project.
-
-        This session will:
-        - Create a python virtualenv for the session
-        - Install the `virtualenv` cli tool into this environment
-        - Use `virtualenv` to create a global project virtual environment
-        - Invoke the python interpreter from the global project environment to install
-          the project and all it's development dependencies.
+        Set up a python development environment for the project at ".venv".
         """
 
         session.install("virtualenv")
-        # the VENV_DIR constant is explained above
-        session.run("virtualenv", os.fsdecode(VENV_DIR), silent=True)
 
-        python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
+        session.run("virtualenv", ".venv", silent=True)
 
         # Use the venv's interpreter to install the project along with
         # all it's dev dependencies, this ensures it's installed in the right way
-        session.run(python, "-m", "pip", "install", "-e", ".[dev]", external=True)
+        session.run(".venv/bin/pip", "install", "-e", ".[dev]", external=True)
 
 With this, a user can simply run ``nox -s dev`` and have their entire environment set up automatically!
 


### PR DESCRIPTION
This had a lot of cruft that is not needed with nox. First, the working directory is guaranteed to be the noxfile directory, so all the path stuff wasn't needed. Second, we now support default=False, so use that. Third, we don't support multiline help yet so all the extra stuff isn't visible unless you are looking at the code anyway. Finally, we can just use the correct path to pip. We could use external pip instead, and leave it out of the dev environment, but this seems fine as an example.
