### PR TITLE
fix: error with helpful message if invalid option is set via nox.options

### DIFF
--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -20,29 +20,49 @@ from __future__ import annotations
 
 import argparse
 import collections
-import difflib
+import dataclasses
 import functools
 from argparse import ArgumentError as ArgumentError  # noqa: PLC0414
 from argparse import ArgumentParser, Namespace
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import Any, Literal
 
 import argcomplete
 
 
-class RestrictedNamespace(Namespace):
-    def __init__(self, **kwargs: object):
-        for key, value in kwargs.items():
-            object.__setattr__(self, key, value)
-
-    def __setattr__(self, key: str, value: object) -> None:
-        if not hasattr(self, key):
-            msg = f"{key} is not a known noxfile option!"
-            suggestions = difflib.get_close_matches(key, self.__dict__, n=2)
-            if suggestions:
-                msg += f" Perhaps you meant {' or '.join(suggestions)}?"
-            raise AttributeError(msg)
-        super().__setattr__(key, value)
+# Python 3.10+ has slots=True (or attrs does), also kwonly=True
+@dataclasses.dataclass
+class NoxOptions:
+    __slots__ = (
+        "default_venv_backend",
+        "envdir",
+        "error_on_external_run",
+        "error_on_missing_interpreters",
+        "force_venv_backend",
+        "keywords",
+        "pythons",
+        "report",
+        "reuse_existing_virtualenvs",
+        "reuse_venv",
+        "sessions",
+        "stop_on_first_error",
+        "tags",
+        "verbose",
+    )
+    default_venv_backend: None | str
+    envdir: None | str
+    error_on_external_run: bool
+    error_on_missing_interpreters: bool
+    force_venv_backend: None | str
+    keywords: None | list[str]
+    pythons: None | list[str]
+    report: None | str
+    reuse_existing_virtualenvs: bool
+    reuse_venv: None | Literal["no", "yes", "never", "always"]
+    sessions: None | list[str]
+    stop_on_first_error: bool
+    tags: None | list[str]
+    verbose: bool
 
 
 class OptionGroup:
@@ -75,7 +95,7 @@ class Option:
         help (str): The help string pass to argparse.
         noxfile (bool): Whether or not this option can be set in the
             configuration file.
-        merge_func (Callable[[Namespace, Namespace], Any]): A function that
+        merge_func (Callable[[Namespace, NoxOptions], Any]): A function that
             can define custom behavior when merging the command-line options
             with the configuration file options. The first argument is the
             command-line options, the second is the configuration file options.
@@ -100,7 +120,7 @@ class Option:
         group: OptionGroup | None,
         help: str | None = None,
         noxfile: bool = False,
-        merge_func: Callable[[Namespace, Namespace], Any] | None = None,
+        merge_func: Callable[[Namespace, NoxOptions], Any] | None = None,
         finalizer_func: Callable[[Any, Namespace], Any] | None = None,
         default: (
             bool | str | None | list[str] | Callable[[], bool | str | None | list[str]]
@@ -133,7 +153,7 @@ def flag_pair_merge_func(
     enable_default: bool | Callable[[], bool],
     disable_name: str,
     command_args: Namespace,
-    noxfile_args: Namespace,
+    noxfile_args: NoxOptions,
 ) -> bool:
     """Merge function for flag pairs. If the flag is set in the Noxfile or
     the command line params, return ``True`` *unless* the disable flag has been
@@ -321,19 +341,19 @@ class OptionSet:
 
         return argparse.Namespace(**args)
 
-    def noxfile_namespace(self) -> RestrictedNamespace:
+    def noxfile_namespace(self) -> NoxOptions:
         """Returns a namespace of options that can be set in the configuration
         file."""
-        return RestrictedNamespace(
+        return NoxOptions(
             **{
                 option.name: option.default
                 for option in self.options.values()
                 if option.noxfile
-            }
+            }  # type: ignore[arg-type]
         )
 
     def merge_namespaces(
-        self, command_args: Namespace, noxfile_args: Namespace
+        self, command_args: Namespace, noxfile_args: NoxOptions
     ) -> None:
         """Merges the command-line options with the Noxfile options."""
         command_args_copy = Namespace(**vars(command_args))

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Literal, Sequence
 import argcomplete
 
 from nox import _option_set
+from nox._option_set import NoxOptions
 from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 from nox.virtualenv import ALL_VENVS
 
@@ -72,7 +73,7 @@ options.add_groups(
 
 
 def _sessions_merge_func(
-    key: str, command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+    key: str, command_args: argparse.Namespace, noxfile_args: NoxOptions
 ) -> list[str]:
     """Only return the Noxfile value for sessions/keywords if neither sessions,
     keywords or tags are specified on the command-line.
@@ -83,7 +84,7 @@ def _sessions_merge_func(
             same function for both options.
         command_args (_option_set.Namespace): The options specified on the
             command-line.
-        noxfile_Args (_option_set.Namespace): The options specified in the
+        noxfile_Args (NoxOptions): The options specified in the
             Noxfile."""
     if (
         not command_args.sessions
@@ -95,14 +96,14 @@ def _sessions_merge_func(
 
 
 def _default_venv_backend_merge_func(
-    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+    command_args: argparse.Namespace, noxfile_args: NoxOptions
 ) -> str:
     """Merge default_venv_backend from command args and Noxfile. Default is "virtualenv".
 
     Args:
         command_args (_option_set.Namespace): The options specified on the
             command-line.
-        noxfile_Args (_option_set.Namespace): The options specified in the
+        noxfile_Args (NoxOptions): The options specified in the
             Noxfile.
     """
     return (
@@ -113,14 +114,14 @@ def _default_venv_backend_merge_func(
 
 
 def _force_venv_backend_merge_func(
-    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+    command_args: argparse.Namespace, noxfile_args: NoxOptions
 ) -> str:
     """Merge force_venv_backend from command args and Noxfile. Default is None.
 
     Args:
         command_args (_option_set.Namespace): The options specified on the
             command-line.
-        noxfile_Args (_option_set.Namespace): The options specified in the
+        noxfile_Args (NoxOptions): The options specified in the
             Noxfile.
     """
     if command_args.no_venv:
@@ -132,25 +133,25 @@ def _force_venv_backend_merge_func(
                 "You can not use `--no-venv` with a non-none `--force-venv-backend`"
             )
         return "none"
-    return command_args.force_venv_backend or noxfile_args.force_venv_backend  # type: ignore[no-any-return]
+    return command_args.force_venv_backend or noxfile_args.force_venv_backend  # type: ignore[return-value]
 
 
 def _envdir_merge_func(
-    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+    command_args: argparse.Namespace, noxfile_args: NoxOptions
 ) -> str:
     """Ensure that there is always some envdir.
 
     Args:
         command_args (_option_set.Namespace): The options specified on the
             command-line.
-        noxfile_Args (_option_set.Namespace): The options specified in the
+        noxfile_Args (NoxOptions): The options specified in the
             Noxfile.
     """
     return command_args.envdir or noxfile_args.envdir or ".nox"
 
 
 def _reuse_venv_merge_func(
-    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+    command_args: argparse.Namespace, noxfile_args: NoxOptions
 ) -> ReuseVenvType:
     """Merge reuse_venv from command args and Noxfile while maintaining
     backwards compatibility with reuse_existing_virtualenvs. Default is "no".
@@ -158,7 +159,7 @@ def _reuse_venv_merge_func(
     Args:
         command_args (_option_set.Namespace): The options specified on the
             command-line.
-        noxfile_Args (_option_set.Namespace): The options specified in the
+        noxfile_Args (NoxOptions): The options specified in the
             Noxfile.
     """
     # back-compat scenario with no_reuse_existing_virtualenvs/reuse_existing_virtualenvs

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -398,6 +398,7 @@ options.add_options(
         "--verbose",
         group=options.groups["reporting"],
         action="store_true",
+        default=False,
         help="Logs the output of all commands run including commands marked silent.",
         noxfile=True,
     ),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import sys
 from importlib import metadata
 from pathlib import Path
@@ -860,3 +861,9 @@ def test_main_noxfile_options_reuse_venv_compat_check(
             nox.__main__.main()
         config = honor_list_request.call_args[1]["global_config"]
     assert config.reuse_venv == expected
+
+
+def test_noxfile_options_cant_be_set():
+    msg = "reuse_venvs is not a known noxfile option! Perhaps you meant reuse_venv?"
+    with pytest.raises(AttributeError, match=re.escape(msg)):
+        nox.options.reuse_venvs = True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -867,3 +867,9 @@ def test_noxfile_options_cant_be_set():
     msg = "reuse_venvs is not a known noxfile option! Perhaps you meant reuse_venv?"
     with pytest.raises(AttributeError, match=re.escape(msg)):
         nox.options.reuse_venvs = True
+
+
+def test_noxfile_options_cant_be_set_long():
+    msg = "i_am_clearly_not_an_option is not a known noxfile option!"
+    with pytest.raises(AttributeError, match=re.escape(msg)):
+        nox.options.i_am_clearly_not_an_option = True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-import re
 import sys
 from importlib import metadata
 from pathlib import Path
@@ -864,12 +863,10 @@ def test_main_noxfile_options_reuse_venv_compat_check(
 
 
 def test_noxfile_options_cant_be_set():
-    msg = "reuse_venvs is not a known noxfile option! Perhaps you meant reuse_venv?"
-    with pytest.raises(AttributeError, match=re.escape(msg)):
+    with pytest.raises(AttributeError, match="reuse_venvs"):
         nox.options.reuse_venvs = True
 
 
 def test_noxfile_options_cant_be_set_long():
-    msg = "i_am_clearly_not_an_option is not a known noxfile option!"
-    with pytest.raises(AttributeError, match=re.escape(msg)):
+    with pytest.raises(AttributeError, match="i_am_clearly_not_an_option"):
         nox.options.i_am_clearly_not_an_option = True


### PR DESCRIPTION
Fix part of #869 - make sure only valid options are set.

The most recent commit also adds static typing for `nox.options`.