### PR TITLE
fix: don't add a handler if there's already one

### DIFF
--- a/nox/logger.py
+++ b/nox/logger.py
@@ -120,6 +120,9 @@ def setup_logging(
             colorlog. Otherwise, it will be plaintext.
     """
     root_logger = logging.getLogger()
+    if root_logger.hasHandlers():
+        return
+
     if verbose:
         root_logger.setLevel(OUTPUT)
     else:

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -120,14 +120,15 @@ def setup_logging(
             colorlog. Otherwise, it will be plaintext.
     """
     root_logger = logging.getLogger()
-    if root_logger.hasHandlers():
-        return
 
     if verbose:
         root_logger.setLevel(OUTPUT)
     else:
         root_logger.setLevel(logging.DEBUG)
     handler = logging.StreamHandler()
+
+    if root_logger.hasHandlers():
+        return
 
     handler.setFormatter(_get_formatter(color, add_timestamp))
     root_logger.addHandler(handler)


### PR DESCRIPTION
This might help the logger bug we see when nox runs itself, like in https://github.com/wntrblm/nox/issues/803.
