### PR TITLE
feat: support PEP 723 noxfiles

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -597,8 +597,8 @@ the tags, so all three sessions:
     * flake8
 
 
-Running without the nox command
--------------------------------
+Running without the nox command or adding dependencies
+------------------------------------------------------
 
 With a few small additions to your noxfile, you can support running using only
 a generalized Python runner, such as ``pipx run noxfile.py``, ``uv run
@@ -618,6 +618,13 @@ And the following block of code:
    if __name__ == "__main__":
        nox.main()
 
+If this comment block is present, nox will also read it, and run a custom
+environment (``_nox_script_mode``) if the dependencies are not met in the
+current environment. This allows you to specify dependencies for your noxfile
+or a minimum version of nox here (``requires-python`` version setting not
+supported yet, but planned). You can control this with
+``--script-mode``/``NOX_SCRIPT_MODE``; ``none`` will deactivate it, and
+``fresh`` will rebuild it; the default is ``reuse``.
 
 Next steps
 ----------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -624,7 +624,9 @@ current environment. This allows you to specify dependencies for your noxfile
 or a minimum version of nox here (``requires-python`` version setting not
 supported yet, but planned). You can control this with
 ``--script-mode``/``NOX_SCRIPT_MODE``; ``none`` will deactivate it, and
-``fresh`` will rebuild it; the default is ``reuse``.
+``fresh`` will rebuild it; the default is ``reuse``. You can also set
+``--script-venv-backend``/``tool.nox.script-venv-backend``/``NOX_SCRIPT_VENV_BACKEND``
+to control the backend used; the default is ``"uv|virtualenv"``.
 
 Next steps
 ----------

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -16,12 +16,26 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+import os
+import shutil
+import subprocess
 import sys
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
 
+import packaging.requirements
+import packaging.utils
+
+import nox.command
+import nox.virtualenv
 from nox import _options, tasks, workflow
 from nox._version import get_nox_version
 from nox.logger import setup_logging
+from nox.project import load_toml
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 __all__ = ["execute_workflow", "main"]
 
@@ -51,6 +65,87 @@ def execute_workflow(args: Any) -> int:
     )
 
 
+def get_dependencies(
+    req: packaging.requirements.Requirement,
+) -> Generator[packaging.requirements.Requirement, None, None]:
+    """
+    Gets all dependencies. Raises ModuleNotFoundError if a package is not installed.
+    """
+    info = importlib.metadata.metadata(req.name)
+    yield req
+
+    dist_list = info.get_all("requires-dist") or []
+    extra_list = [packaging.requirements.Requirement(mk) for mk in dist_list]
+    for extra in req.extras:
+        for ireq in extra_list:
+            if ireq.marker and not ireq.marker.evaluate({"extra": extra}):
+                continue
+            yield from get_dependencies(ireq)
+
+
+def check_dependencies(dependencies: list[str]) -> bool:
+    """
+    Checks to see if a list of dependencies is currently installed.
+    """
+    itr_deps = (packaging.requirements.Requirement(d) for d in dependencies)
+    deps = [d for d in itr_deps if not d.marker or d.marker.evaluate()]
+
+    # Select the one nox dependency (required)
+    nox_dep = [d for d in deps if packaging.utils.canonicalize_name(d.name) == "nox"]
+    if not nox_dep:
+        msg = "Must have a nox dependency in TOML script dependencies"
+        raise ValueError(msg)
+
+    try:
+        expanded_deps = {d for req in deps for d in get_dependencies(req)}
+    except ModuleNotFoundError:
+        return False
+
+    for dep in expanded_deps:
+        if dep.specifier:
+            version = importlib.metadata.version(dep.name)
+            if not dep.specifier.contains(version):
+                return False
+
+    return True
+
+
+def run_script_mode(envdir: Path, *, reuse: bool, dependencies: list[str]) -> NoReturn:
+    envdir.mkdir(exist_ok=True)
+    noxenv = envdir.joinpath("_nox_script_mode")
+    venv = nox.virtualenv.get_virtualenv(
+        "uv",
+        "virtualenv",
+        reuse_existing=reuse,
+        envdir=str(noxenv),
+    )
+    venv.create()
+    env = {k: v for k, v in venv._get_env({}).items() if v is not None}
+    env["NOX_SCRIPT_MODE"] = "none"
+    cmd = (
+        [nox.virtualenv.UV, "pip", "install"]
+        if venv.venv_backend == "uv"
+        else ["pip", "install"]
+    )
+    subprocess.run([*cmd, *dependencies], env=env, check=True)
+    nox_cmd = shutil.which("nox", path=env["PATH"])
+    assert nox_cmd is not None, "Nox must be discoverable when installed"
+    # The os.exec functions don't work properly on Windows
+    if sys.platform.startswith("win"):
+        raise SystemExit(
+            subprocess.run(
+                [nox_cmd, *sys.argv[1:]],
+                env=env,
+                stdout=None,
+                stderr=None,
+                encoding="utf-8",
+                text=True,
+                check=False,
+            ).returncode
+        )
+    os.execle(nox_cmd, nox_cmd, *sys.argv[1:], env)  # pragma: nocover # noqa: S606
+
+
 def main() -> None:
     args = _options.options.parse_args()
 
@@ -65,6 +160,21 @@ def main() -> None:
     setup_logging(
         color=args.color, verbose=args.verbose, add_timestamp=args.add_timestamp
     )
+    nox_script_mode = os.environ.get("NOX_SCRIPT_MODE", "") or args.script_mode
+    if nox_script_mode not in {"none", "reuse", "fresh"}:
+        msg = f"Invalid NOX_SCRIPT_MODE: {nox_script_mode!r}, must be one of 'none', 'reuse', or 'fresh'"
+        raise SystemExit(msg)
+    if nox_script_mode != "none":
+        toml_config = load_toml(os.path.expandvars(args.noxfile), missing_ok=True)
+        dependencies = toml_config.get("dependencies")
+        if dependencies is not None:
+            valid_env = check_dependencies(dependencies)
+            # Coverage misses this, but it's covered via subprocess call
+            if not valid_env:  # pragma: nocover
+                envdir = Path(args.envdir or ".nox")
+                run_script_mode(
+                    envdir, reuse=nox_script_mode == "reuse", dependencies=dependencies
+                )
 
     exit_code = execute_workflow(args)
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -339,6 +339,13 @@ options.add_options(
         help="Show the Nox version and exit.",
     ),
     _option_set.Option(
+        "script_mode",
+        "--script-mode",
+        group=options.groups["general"],
+        choices=["none", "fresh", "reuse"],
+        default="reuse",
+    ),
+    _option_set.Option(
         "list_sessions",
         "-l",
         "--list-sessions",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -346,6 +346,11 @@ options.add_options(
         default="reuse",
     ),
     _option_set.Option(
+        "script_venv_backend",
+        "--script-venv-backend",
+        group=options.groups["general"],
+    ),
+    _option_set.Option(
         "list_sessions",
         "-l",
         "--list-sessions",

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -353,7 +353,7 @@ class CondaEnv(ProcessEnv):
             if self.reuse_existing and is_conda:
                 return False
             if not is_conda:
-                shutil.rmtree(self.location)
+                shutil.rmtree(self.location, ignore_errors=True)
             else:
                 cmd = [
                     self.conda_cmd,
@@ -365,8 +365,7 @@ class CondaEnv(ProcessEnv):
                 ]
                 nox.command.run(cmd, silent=True, log=False)
             # Make sure that location is clean
-            with contextlib.suppress(FileNotFoundError):
-                shutil.rmtree(self.location)
+            shutil.rmtree(self.location, ignore_errors=True)
 
         return True
 
@@ -493,7 +492,7 @@ class VirtualEnv(ProcessEnv):
                 and self._check_reused_environment_interpreter()
             ):
                 return False
-            shutil.rmtree(self.location)
+            shutil.rmtree(self.location, ignore_errors=True)
         return True
 
     def _read_pyvenv_cfg(self) -> dict[str, str] | None:

--- a/tests/resources/noxfile_script_mode.py
+++ b/tests/resources/noxfile_script_mode.py
@@ -1,0 +1,12 @@
+# /// script
+# dependencies = ["nox", "cowsay"]
+# ///
+
+import cowsay
+
+import nox
+
+
+@nox.session
+def example(session: nox.Session) -> None:
+    print(cowsay.cow("hello_world"))

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -1,0 +1,71 @@
+import importlib.metadata
+import importlib.util
+import sys
+
+import packaging.requirements
+import packaging.version
+import pytest
+
+import nox._cli
+
+
+def test_get_dependencies() -> None:
+    if importlib.util.find_spec("tox") is None:
+        with pytest.raises(ModuleNotFoundError):
+            list(
+                nox._cli.get_dependencies(
+                    packaging.requirements.Requirement("nox[tox_to_nox]")
+                )
+            )
+    else:
+        deps = nox._cli.get_dependencies(
+            packaging.requirements.Requirement("nox[tox_to_nox]")
+        )
+        dep_list = {
+            "argcomplete",
+            "attrs",
+            "colorlog",
+            "dependency-groups",
+            "jinja2",
+            "nox",
+            "packaging",
+            "tox",
+            "virtualenv",
+        }
+        if sys.version_info < (3, 9):
+            dep_list.add("importlib-resources")
+        if sys.version_info < (3, 11):
+            dep_list.add("tomli")
+        assert {d.name for d in deps} == dep_list
+
+
+def test_version_check() -> None:
+    current_version = packaging.version.Version(importlib.metadata.version("nox"))
+
+    assert nox._cli.check_dependencies([f"nox>={current_version}"])
+    assert not nox._cli.check_dependencies([f"nox>{current_version}"])
+
+    plus_one = packaging.version.Version(
+        f"{current_version.major}.{current_version.minor}.{current_version.micro + 1}"
+    )
+    assert not nox._cli.check_dependencies([f"nox>={plus_one}"])
+
+
+def test_nox_check() -> None:
+    with pytest.raises(ValueError, match="Must have a nox"):
+        nox._cli.check_dependencies(["packaging"])
+
+    with pytest.raises(ValueError, match="Must have a nox"):
+        nox._cli.check_dependencies([])
+
+
+def test_unmatched_specifier() -> None:
+    assert not nox._cli.check_dependencies(["packaging<1", "nox"])
+
+
+def test_invalid_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOX_SCRIPT_MODE", "invalid")
+    monkeypatch.setattr(sys, "argv", ["nox"])
+
+    with pytest.raises(SystemExit, match="Invalid NOX_SCRIPT_MODE"):
+        nox._cli.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1020,3 +1020,48 @@ def test_symlink_sym_not(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(Path(RESOURCES) / "sym_dir")
     res = subprocess.run([sys.executable, "-m", "nox", "-s", "orig"], check=False)
     assert res.returncode == 1
+
+
+def test_noxfile_script_mode() -> None:
+    job = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nox",
+            "-f",
+            Path(RESOURCES) / "noxfile_script_mode.py",
+            "-s",
+            "example",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    print(job.stdout)
+    print(job.stderr)
+    assert job.returncode == 0
+    assert "hello_world" in job.stdout
+
+
+def test_noxfile_no_script_mode() -> None:
+    env = os.environ.copy()
+    env["NOX_SCRIPT_MODE"] = "none"
+    job = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nox",
+            "-f",
+            Path(RESOURCES) / "noxfile_script_mode.py",
+            "-s",
+            "example",
+        ],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert job.returncode == 1
+    assert "No module named 'cowsay'" in job.stderr


### PR DESCRIPTION
I've started https://github.com/wntrblm/nox/issues/848. This allows you to write a noxfile like this:

```python
# /// script
# dependencies = ["nox>=1.2.3", "numpy"]
# ///

import nox
import numpy

@nox.session
def example(session: nox.Session) -> None:
    print(numpy.__file__)
```

Any dependencies, including version ranges and nox, will be checked. If not satisfied, nox will make a new `.nox/_nox_script_mode` environment, set it up with the above dependencies, and then pass control to the new nox environment. Requires-python is not respected yet, might need https://github.com/wntrblm/nox/issues/814. That can be added later, not a target for this PR.

I've allowed this to be passed via flag and envvar, but envvar always comes first, and overrides the flag. This ensures the second run will never trigger a third run of nox. If someone has other ideas for ways to ensure this, I'm open. Also, the envvar is needed if you request an older nox, since the flag won't be valid in the "inner" run. `--script-mode=fresh` allows you to enforce a fresh environment.

It supports both pip and uv; since this is a new feature, defaulted to uv if available, and fallback on pip. ~~Maybe should be configurable; currently it's locked on the "default" is `uv|virtualenv`.~~ I've made it configurable with `tool.nox.script-venv-backend`/`--script-venv-backend`/`NOX_SCRIPT_VENV_BACKEND`.

It's a bit less clever on Windows following pipx's example; pipx doesn't use process replacement there; the original PR said it "wasn't reliable" for pipx. Looks like path quoting is not handled by this method, and it doesn't do anything special on Windows. https://github.com/pypa/pipx/pull/531

Note this is available in tox as `requires = ...`, but before PEP 723 there wasn't a clean way to do this for nox.

Fix https://github.com/wntrblm/nox/issues/414.
