### PR TITLE
fix: warning about __main__ already being imported

### DIFF
--- a/nox/__init__.py
+++ b/nox/__init__.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from nox import project
-from nox.__main__ import main
+from nox._cli import main
 from nox._options import noxfile_options as options
 from nox._parametrize import Param as param
 from nox._parametrize import parametrize_decorator as parametrize

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -19,56 +19,11 @@ function). This module primarily loads configuration, and then passes
 control to :meth:``nox.workflow.execute``.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # pragma: no cover
 
-import sys
-from typing import Any
+from nox._cli import main  # pragma: no cover
 
-from nox import _options, tasks, workflow
-from nox._version import get_nox_version
-from nox.logger import setup_logging
-
-
-def execute_workflow(args: Any) -> int:
-    """
-    Execute the appropriate tasks.
-    """
-
-    return workflow.execute(
-        global_config=args,
-        workflow=(
-            tasks.load_nox_module,
-            tasks.merge_noxfile_options,
-            tasks.discover_manifest,
-            tasks.filter_manifest,
-            tasks.honor_list_request,
-            tasks.run_manifest,
-            tasks.print_summary,
-            tasks.create_report,
-            tasks.final_reduce,
-        ),
-    )
-
-
-def main() -> None:
-    args = _options.options.parse_args()
-
-    if args.help:
-        _options.options.print_help()
-        return
-
-    if args.version:
-        print(get_nox_version(), file=sys.stderr)
-        return
-
-    setup_logging(
-        color=args.color, verbose=args.verbose, add_timestamp=args.add_timestamp
-    )
-
-    exit_code = execute_workflow(args)
-
-    # Done; exit.
-    sys.exit(exit_code)
+__all__ = ["main"]  # pragma: no cover
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -1,0 +1,66 @@
+# Copyright 2016 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The Nox `main` function and helpers."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from nox import _options, tasks, workflow
+from nox._version import get_nox_version
+from nox.logger import setup_logging
+
+
+def execute_workflow(args: Any) -> int:
+    """
+    Execute the appropriate tasks.
+    """
+
+    return workflow.execute(
+        global_config=args,
+        workflow=(
+            tasks.load_nox_module,
+            tasks.merge_noxfile_options,
+            tasks.discover_manifest,
+            tasks.filter_manifest,
+            tasks.honor_list_request,
+            tasks.run_manifest,
+            tasks.print_summary,
+            tasks.create_report,
+            tasks.final_reduce,
+        ),
+    )
+
+
+def main() -> None:
+    args = _options.options.parse_args()
+
+    if args.help:
+        _options.options.print_help()
+        return
+
+    if args.version:
+        print(get_nox_version(), file=sys.stderr)
+        return
+
+    setup_logging(
+        color=args.color, verbose=args.verbose, add_timestamp=args.add_timestamp
+    )
+
+    exit_code = execute_workflow(args)
+
+    # Done; exit.
+    sys.exit(exit_code)


### PR DESCRIPTION
Follow up to https://github.com/wntrblm/nox/pull/878, fixing a warning about `__main__` already being imported when running `__main__` (I think it messes with the `if __name__ == "__main__"` statement when you use `python -m nox` and that imports `__init__` and that triggers the `__main__` import early).

Fixed by moving `__main__.py` contents to `_cli.py` then importing from there for `__init__.py` and `__main__.py`. Backward compatible.

Noticed in #881.