### PR TITLE
chore: drop some type ignores for colorlog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
         files: ^nox/
         args: []
         additional_dependencies:
+          - colorlog
           - dependency-groups>=1.2
           - jinja2
           - packaging

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -46,7 +46,7 @@ class NoxFormatter(logging.Formatter):
         return super().format(record)
 
 
-class NoxColoredFormatter(ColoredFormatter):  # type: ignore[misc]
+class NoxColoredFormatter(ColoredFormatter):
     def __init__(
         self,
         datefmt: Any = None,
@@ -69,7 +69,7 @@ class NoxColoredFormatter(ColoredFormatter):  # type: ignore[misc]
     def format(self, record: Any) -> str:
         if record.levelname == "OUTPUT":
             return self._simple_fmt.format(record)
-        return super().format(record)  # type: ignore[no-any-return]
+        return super().format(record)
 
 
 class LoggerWithSuccessAndOutput(logging.getLoggerClass()):  # type: ignore[misc]


### PR DESCRIPTION
Looks like these haven't been needed for a few years.
