### PR TITLE
chore: limit the visible items for tab completion

### DIFF
--- a/nox/__init__.py
+++ b/nox/__init__.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from types import ModuleType
+
 from nox import project
 from nox._cli import main
 from nox._options import noxfile_options as options
@@ -34,3 +36,11 @@ __all__ = [
     "project",
     "session",
 ]
+
+
+def __dir__() -> list[str]:
+    # Only nox modules are imported here, so we can safely use globals() to
+    # find nox modules only. Other modules, like types and __future__, are imported
+    # from, so don't populate the module globals with surprising entries.
+    modules = {k for k, v in globals().items() if isinstance(v, ModuleType)}
+    return sorted(set(__all__) | modules)

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -26,5 +26,9 @@ from nox._cli import main  # pragma: no cover
 __all__ = ["main"]  # pragma: no cover
 
 
+def __dir__() -> list[str]:
+    return __all__
+
+
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -23,6 +23,12 @@ from nox import _options, tasks, workflow
 from nox._version import get_nox_version
 from nox.logger import setup_logging
 
+__all__ = ["execute_workflow", "main"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 def execute_workflow(args: Any) -> int:
     """

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -28,6 +28,12 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", bound=Callable[..., Any])
 
+__all__ = ["Call", "Func", "FunctionDecorator", "_copy_func"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 class FunctionDecorator:
     """This is a function decorator."""

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 import argparse
 import collections
 import functools
-from argparse import ArgumentError as ArgumentError  # noqa: PLC0414
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentError, ArgumentParser, Namespace
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 import argcomplete
@@ -31,6 +31,20 @@ import attrs.validators as av
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
+
+__all__ = [
+    "ArgumentError",
+    "NoxOptions",
+    "Option",
+    "OptionGroup",
+    "OptionSet",
+    "make_flag_pair",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 av_opt_str = av.optional(av.instance_of(str))
 av_opt_list_str = av.optional(

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""All of Nox's configuration options."""
+
 from __future__ import annotations
 
 import argparse
@@ -32,9 +34,15 @@ if TYPE_CHECKING:
 
     from nox._option_set import NoxOptions
 
-ReuseVenvType = Literal["no", "yes", "never", "always"]
 
-"""All of Nox's configuration options."""
+__all__ = ["ReuseVenvType", "noxfile_options", "options"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+ReuseVenvType = Literal["no", "yes", "never", "always"]
 
 options = _option_set.OptionSet(
     description="Nox is a Python automation toolkit.", add_help=False

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -21,6 +21,12 @@ from typing import TYPE_CHECKING, Any, Iterable, Union
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+__all__ = ["Param", "parametrize_decorator", "update_param_specs"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 class Param:
     """A class that encapsulates a single set of parameters to a parametrized

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -18,6 +18,13 @@ import itertools
 from collections import OrderedDict
 from typing import Hashable, Iterable, Iterator, Mapping, TypeVar
 
+__all__ = ["CycleError", "lazy_stable_topo_sort"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 Node = TypeVar("Node", bound=Hashable)
 
 

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -14,8 +14,13 @@
 
 from __future__ import annotations
 
+from typing import Sequence, Union
+
 __all__ = ["Python"]
 
-from typing import Sequence, Union
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 Python = Union[str, Sequence[str], bool, None]

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -21,6 +21,12 @@ from importlib import metadata
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
+__all__ = ["InvalidVersionSpecifier", "VersionCheckFailed", "check_nox_version"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 class VersionCheckFailed(Exception):
     """The Nox version does not satisfy what ``nox.needs_version`` specifies."""

--- a/nox/command.py
+++ b/nox/command.py
@@ -29,6 +29,13 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
     from typing import IO
 
+__all__ = ["CommandFailed", "ExternalType", "run", "which"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 ExternalType = Literal["error", True, False]
 
 

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -19,6 +19,13 @@ from typing import Any, cast
 
 from colorlog import ColoredFormatter
 
+__all__ = ["OUTPUT", "SUCCESS", "logger", "setup_logging"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 SUCCESS = 25
 OUTPUT = logging.DEBUG - 1
 

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -28,6 +28,13 @@ if TYPE_CHECKING:
     import argparse
     from collections.abc import Iterable, Iterator, Sequence
 
+__all__ = ["WARN_PYTHONS_IGNORED", "Manifest", "keyword_match"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 WARN_PYTHONS_IGNORED = "python_ignored"
 
 

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -23,6 +23,18 @@ from typing import IO, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
+__all__ = [
+    "DEFAULT_INTERRUPT_TIMEOUT",
+    "DEFAULT_TERMINATE_TIMEOUT",
+    "decode_output",
+    "popen",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 DEFAULT_INTERRUPT_TIMEOUT = 0.3
 DEFAULT_TERMINATE_TIMEOUT = 0.2
 

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
 
     from ._typing import Python
 
+__all__ = ["get", "session_decorator"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 RawFunc = Callable[..., Any]
 
 _REGISTRY: collections.OrderedDict[str, Func] = collections.OrderedDict()

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -59,6 +59,12 @@ if TYPE_CHECKING:
     from nox.command import ExternalType
     from nox.manifest import Manifest
 
+__all__ = ["Result", "Session", "SessionRunner", "Status", "nox"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 @contextlib.contextmanager
 def _chdir(path: str) -> Generator[None, None, None]:

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -35,6 +35,22 @@ if TYPE_CHECKING:
     import types
     from argparse import Namespace
 
+__all__ = [
+    "create_report",
+    "discover_manifest",
+    "filter_manifest",
+    "final_reduce",
+    "honor_list_request",
+    "load_nox_module",
+    "merge_noxfile_options",
+    "print_summary",
+    "run_manifest",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
     """

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -34,6 +34,14 @@ if sys.version_info < (3, 9):
 else:
     from importlib.resources import files
 
+
+__all__ = ["main"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 TOX_VERSION = metadata.version("tox")
 
 TOX4 = int(TOX_VERSION.split(".")[0]) >= 4

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -39,6 +39,31 @@ if TYPE_CHECKING:
 
     from nox._typing import Python
 
+__all__ = [
+    "ALL_VENVS",
+    "HAS_UV",
+    "OPTIONAL_VENVS",
+    "UV",
+    "UV_PYTHON_SUPPORT",
+    "CondaEnv",
+    "InterpreterNotFound",
+    "PassthroughEnv",
+    "ProcessEnv",
+    "VirtualEnv",
+    "find_uv",
+    "get_virtualenv",
+    "get_virtualenv",
+    "uv_install_python",
+    "uv_install_python",
+    "uv_version",
+    "uv_version",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 # Problematic environment variables that are stripped from all commands inside
 # of a virtualenv. See https://github.com/theacodes/nox/issues/44
 _BLACKLISTED_ENV_VARS = frozenset(

--- a/nox/workflow.py
+++ b/nox/workflow.py
@@ -20,6 +20,12 @@ if TYPE_CHECKING:
     import argparse
     from collections.abc import Callable, Iterable
 
+__all__ = ["execute"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 def execute(
     workflow: Iterable[Callable[..., Any]], global_config: argparse.Namespace


### PR DESCRIPTION
Adding `__all__` and `def __dir__` everwhere so tab completion is clean. Using a trick I've not tried elsewhere to also include tab completion cleanup in `__init__`.
