### PR TITLE
chore: more typing and test improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,14 @@ repos:
         files: ^nox/
         args: []
         additional_dependencies:
+          - argcomplete
           - attrs
           - colorlog
           - dependency-groups>=1.2
           - jinja2
           - orjson # Faster mypy
           - packaging
+          - pytest
           - importlib_metadata
           - importlib_resources
           - tomli

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -371,7 +371,7 @@ options.add_options(
         noxfile=True,
         merge_func=functools.partial(_sessions_merge_func, "keywords"),
         help="Only run sessions that match the given expression.",
-        completer=argcomplete.completers.ChoicesCompleter(()),
+        completer=argcomplete.completers.ChoicesCompleter(()),  # type: ignore[no-untyped-call]
     ),
     _option_set.Option(
         "tags",
@@ -499,7 +499,7 @@ options.add_options(
         merge_func=_envdir_merge_func,
         group=options.groups["environment"],
         help="Directory where Nox will store virtualenvs, this is ``.nox`` by default.",
-        completer=argcomplete.completers.DirectoriesCompleter(),
+        completer=argcomplete.completers.DirectoriesCompleter(),  # type: ignore[no-untyped-call]
     ),
     _option_set.Option(
         "extra_pythons",
@@ -577,7 +577,7 @@ options.add_options(
         group=options.groups["reporting"],
         noxfile=True,
         help="Output a report of all sessions to the given filename.",
-        completer=argcomplete.completers.FilesCompleter(("json",)),
+        completer=argcomplete.completers.FilesCompleter(("json",)),  # type: ignore[no-untyped-call]
     ),
     _option_set.Option(
         "non_interactive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ xfail_strict = true
 filterwarnings = [ "error" ]
 log_cli_level = "info"
 testpaths = [ "tests" ]
+pythonpath = [ ".github/" ]
 
 [tool.coverage]
 run.branch = true
@@ -132,7 +133,8 @@ python_version = "3.8"
 strict = true
 warn_unreachable = true
 enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
+mypy_path = [ ".github" ]
 
 [[tool.mypy.overrides]]
-module = [ "argcomplete", "colorlog.*", "py", "tox.*" ]
+module = [ "tox.*" ]
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def reset_color_envvars(monkeypatch):
+def reset_color_envvars(monkeypatch: pytest.MonkeyPatch) -> None:
     """Remove color-related envvars to fix test output"""
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.delenv("NO_COLOR", raising=False)

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
 import json
-import sys
-from pathlib import Path
 
 import pytest
-
-GITHUB_FOLDER = Path(__file__).resolve().parent.parent / ".github"
-sys.path.insert(0, str(GITHUB_FOLDER))
-from action_helper import filter_version, setup_action  # noqa: E402
+from action_helper import filter_version, setup_action
 
 VALID_VERSIONS = {
     "2.7.18": "2.7",


### PR DESCRIPTION
Some packages now have types.

PyTest 7+ required now for `pythonpath`.