### PR TITLE
fix: include encoding for consistent behavior (default in Python 3.15+)

### DIFF
--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -81,7 +81,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if TOX4:
-        output = check_output(["tox", "config"], text=True)  # noqa: S607
+        output = check_output(["tox", "config"], text=True, encoding="utf-8")  # noqa: S607
         original_config = ConfigParser()
         original_config.read_string(output)
         config: dict[str, dict[str, Any]] = {}

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -80,6 +80,7 @@ def uv_version() -> version.Version:
             check=False,
             text=True,
             capture_output=True,
+            encoding="utf-8",
         )
     except FileNotFoundError:
         logger.info("uv binary not found.")

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,6 +60,7 @@ def tests(session: nox.Session, tox_version: str) -> None:
     session.install("-e.[tox_to_nox]")
     if tox_version != "latest":
         session.install(f"tox{tox_version}")
+    extra_env = {} if tox_version != "latest" else {"PYTHONWARNDEFAULTENCODING": "1"}
     session.run(
         "pytest",
         "--cov",
@@ -69,6 +70,7 @@ def tests(session: nox.Session, tox_version: str) -> None:
         *session.posargs,
         env={
             "COVERAGE_FILE": coverage_file,
+            **extra_env,
         },
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,7 +60,7 @@ def tests(session: nox.Session, tox_version: str) -> None:
     session.install("-e.[tox_to_nox]")
     if tox_version != "latest":
         session.install(f"tox{tox_version}")
-    extra_env = {} if tox_version != "latest" else {"PYTHONWARNDEFAULTENCODING": "1"}
+    extra_env = {"PYTHONWARNDEFAULTENCODING": "1"} if tox_version == "latest" else {}
     session.run(
         "pytest",
         "--cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,9 @@ max_supported_python = "3.13"
 minversion = "7.0"
 addopts = [ "-ra", "--strict-markers", "--strict-config" ]
 xfail_strict = true
-filterwarnings = [ "error" ]
+filterwarnings = [
+  "error",
+]
 log_cli_level = "info"
 testpaths = [ "tests" ]
 pythonpath = [ ".github/" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,7 @@ max_supported_python = "3.13"
 minversion = "7.0"
 addopts = [ "-ra", "--strict-markers", "--strict-config" ]
 xfail_strict = true
-filterwarnings = [
-  "error",
-]
+filterwarnings = [ "error" ]
 log_cli_level = "info"
 testpaths = [ "tests" ]
 pythonpath = [ ".github/" ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def generate_noxfile_options(tmp_path: Path) -> Callable[..., str]:
                 text = re.sub(rf"(# )?nox.options.{opt}", f"nox.options.{opt}", text)
             text = Template(text).safe_substitute(**option_mapping)
         path = tmp_path / "noxfile.py"
-        path.write_text(text)
+        path.write_text(text, encoding="utf8")
         return str(path)
 
     return generate_noxfile

--- a/tests/test__version.py
+++ b/tests/test__version.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 def temp_noxfile(tmp_path: Path) -> Callable[[str], str]:
     def make_temp_noxfile(content: str) -> str:
         path = tmp_path / "noxfile.py"
-        path.write_text(content)
+        path.write_text(content, encoding="utf8")
         return str(path)
 
     return make_temp_noxfile

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -694,14 +694,14 @@ def generate_noxfile_options_pythons(tmp_path: Path) -> Callable[[str, str, str]
         default_session: str, default_python: str, alternate_python: str
     ) -> str:
         path = Path(RESOURCES) / "noxfile_options_pythons.py"
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
         text = text.format(
             default_session=default_session,
             default_python=default_python,
             alternate_python=alternate_python,
         )
         path = tmp_path / "noxfile.py"
-        path.write_text(text)
+        path.write_text(text, encoding="utf-8")
         return str(path)
 
     return generate_noxfile

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -148,7 +148,7 @@ def test_load_nox_module_needs_version_static(tmp_path: Path) -> None:
         """
     )
     noxfile = tmp_path / "noxfile.py"
-    noxfile.write_text(text)
+    noxfile.write_text(text, encoding="utf-8")
     config = _options.options.namespace(noxfile=str(noxfile))
     assert tasks.load_nox_module(config) == 2
 
@@ -162,7 +162,7 @@ def test_load_nox_module_needs_version_dynamic(tmp_path: Path) -> None:
         """
     )
     noxfile = tmp_path / "noxfile.py"
-    noxfile.write_text(text)
+    noxfile.write_text(text, encoding="utf-8")
     config = _options.options.namespace(noxfile=str(noxfile))
     tasks.load_nox_module(config)
     # Dynamic version requirements are not checked.

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -14,7 +14,8 @@ def test_load_pyproject(tmp_path: Path) -> None:
         name = "hi"
         version = "1.0"
         dependencies = ["numpy", "requests"]
-        """
+        """,
+        encoding="utf-8",
     )
 
     toml = nox.project.load_toml(filepath)
@@ -43,7 +44,8 @@ def test_load_script_block(tmp_path: Path, example: str) -> None:
             data = resp.json()
             pprint([(k, v["title"]) for k, v in data.items()][:10])
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     toml = nox.project.load_toml(filepath)
@@ -64,7 +66,8 @@ def test_load_no_script_block(tmp_path: Path) -> None:
             data = resp.json()
             pprint([(k, v["title"]) for k, v in data.items()][:10])
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     with pytest.raises(ValueError, match="No script block found"):
@@ -94,7 +97,8 @@ def test_load_multiple_script_block(tmp_path: Path) -> None:
             data = resp.json()
             pprint([(k, v["title"]) for k, v in data.items()][:10])
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     with pytest.raises(ValueError, match="Multiple script blocks found"):

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -35,12 +35,12 @@ PYTHON_VERSION_NODOT = PYTHON_VERSION.replace(".", "")
 @pytest.fixture
 def makeconfig(tmpdir: LEGACY_PATH) -> Callable[[str], str]:
     def makeconfig(toxini_content: str) -> str:
-        tmpdir.join("tox.ini").write(toxini_content)
+        tmpdir.join("tox.ini").write_text(toxini_content, encoding="utf8")
         old = tmpdir.chdir()
         try:
             sys.argv = [sys.executable]
             tox_to_nox.main()
-            return tmpdir.join("noxfile.py").read()  # type: ignore[no-any-return]
+            return tmpdir.join("noxfile.py").read_text(encoding="utf8")  # type: ignore[no-any-return]
         finally:
             old.chdir()
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -510,7 +510,7 @@ def test_create_reuse_stale_venv_environment(
     version = 3.9.6
     uv = 0.1.9
     """
-    location.join("pyvenv.cfg").write(dedent(pyvenv_cfg))
+    location.join("pyvenv.cfg").write_text(dedent(pyvenv_cfg), encoding="utf-8")
 
     reused = not venv.create()
 
@@ -670,7 +670,7 @@ def test_create_reuse_stale_virtualenv_environment(
     base-exec-prefix = /usr
     base-executable = /usr/bin/python3.9
     """
-    location.join("pyvenv.cfg").write(dedent(pyvenv_cfg))
+    location.join("pyvenv.cfg").write_text(dedent(pyvenv_cfg), encoding="utf-8")
 
     reused = not venv.create()
 
@@ -688,7 +688,9 @@ def test_create_reuse_uv_environment(
 
     # Place a spurious occurrence of "uv" in the pyvenv.cfg.
     pyvenv_cfg = location.join("pyvenv.cfg")
-    pyvenv_cfg.write(pyvenv_cfg.read() + "bogus = uv\n")
+    pyvenv_cfg.write_text(
+        pyvenv_cfg.read_text(encoding="utf-8") + "bogus = uv\n", encoding="utf-8"
+    )
 
     reused = not venv.create()
 
@@ -790,7 +792,10 @@ def test_create_reuse_venv_environment(
 
     # Place a spurious occurrence of "virtualenv" in the pyvenv.cfg.
     pyvenv_cfg = location.join("pyvenv.cfg")
-    pyvenv_cfg.write(pyvenv_cfg.read() + "bogus = virtualenv\n")
+    pyvenv_cfg.write_text(
+        pyvenv_cfg.read_text(encoding="utf-8") + "bogus = virtualenv\n",
+        encoding="utf-8",
+    )
 
     reused = not venv.create()
 
@@ -834,7 +839,7 @@ def test_inner_functions_reusing_venv(
     version = 3.10
     base-prefix = foo
     """
-    location.join("pyvenv.cfg").write(dedent(pyvenv_cfg))
+    location.join("pyvenv.cfg").write_text(dedent(pyvenv_cfg), encoding="utf-8")
 
     config = venv._read_pyvenv_cfg()
     assert config


### PR DESCRIPTION
Noticed when checking some Ruff preview stuff.
