### PR TITLE
tests: statically type tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,8 @@ repos:
     rev: v1.13.0
     hooks:
       - id: mypy
-        files: ^nox/
+        files: ^(nox/|tests/)
+        exclude: ^tests/resources/
         args: []
         additional_dependencies:
           - argcomplete

--- a/nox/command.py
+++ b/nox/command.py
@@ -20,7 +20,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Literal
+from typing import Literal, overload
 
 from nox.logger import logger
 from nox.popen import DEFAULT_INTERRUPT_TIMEOUT, DEFAULT_TERMINATE_TIMEOUT, popen
@@ -71,6 +71,57 @@ def _clean_env(env: Mapping[str, str | None] | None = None) -> dict[str, str] | 
 
 def _shlex_join(args: Sequence[str | os.PathLike[str]]) -> str:
     return " ".join(shlex.quote(os.fspath(arg)) for arg in args)
+
+
+@overload
+def run(
+    args: Sequence[str | os.PathLike[str]],
+    *,
+    env: Mapping[str, str | None] | None = ...,
+    silent: Literal[True],
+    paths: Sequence[str] | None = ...,
+    success_codes: Iterable[int] | None = ...,
+    log: bool = ...,
+    external: ExternalType = ...,
+    stdout: int | IO[str] | None = ...,
+    stderr: int | IO[str] | None = ...,
+    interrupt_timeout: float | None = ...,
+    terminate_timeout: float | None = ...,
+) -> str: ...
+
+
+@overload
+def run(
+    args: Sequence[str | os.PathLike[str]],
+    *,
+    env: Mapping[str, str | None] | None = ...,
+    silent: Literal[False] = ...,
+    paths: Sequence[str] | None = ...,
+    success_codes: Iterable[int] | None = ...,
+    log: bool = ...,
+    external: ExternalType = ...,
+    stdout: int | IO[str] | None = ...,
+    stderr: int | IO[str] | None = ...,
+    interrupt_timeout: float | None = ...,
+    terminate_timeout: float | None = ...,
+) -> bool: ...
+
+
+@overload
+def run(
+    args: Sequence[str | os.PathLike[str]],
+    *,
+    env: Mapping[str, str | None] | None = ...,
+    silent: bool,
+    paths: Sequence[str] | None = ...,
+    success_codes: Iterable[int] | None = ...,
+    log: bool = ...,
+    external: ExternalType = ...,
+    stdout: int | IO[str] | None = ...,
+    stderr: int | IO[str] | None = ...,
+    interrupt_timeout: float | None = ...,
+    terminate_timeout: float | None = ...,
+) -> str | bool: ...
 
 
 def run(

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -419,8 +419,8 @@ class KeywordLocals(Mapping[str, bool]):
     returns False.
     """
 
-    def __init__(self, keywords: set[str]) -> None:
-        self._keywords = keywords
+    def __init__(self, keywords: Iterable[str]) -> None:
+        self._keywords = frozenset(keywords)
 
     def __getitem__(self, variable_name: str) -> bool:
         return any(variable_name in keyword for keyword in self._keywords)

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -18,18 +18,18 @@ import collections
 import copy
 import functools
 from collections.abc import Sequence
-from typing import Any, Callable, TypeVar, overload
+from typing import Any, Callable, overload
 
 from ._decorators import Func
 from ._typing import Python
 
-F = TypeVar("F", bound=Callable[..., Any])
+RawFunc = Callable[..., Any]
 
 _REGISTRY: collections.OrderedDict[str, Func] = collections.OrderedDict()
 
 
 @overload
-def session_decorator(__func: F) -> F: ...
+def session_decorator(__func: RawFunc | Func) -> Func: ...
 
 
 @overload
@@ -45,11 +45,11 @@ def session_decorator(
     *,
     default: bool = ...,
     requires: Sequence[str] | None = ...,
-) -> Callable[[F], F]: ...
+) -> Callable[[RawFunc | Func], Func]: ...
 
 
 def session_decorator(
-    func: F | None = None,
+    func: Callable[..., Any] | Func | None = None,
     python: Python | None = None,
     py: Python | None = None,
     reuse_venv: bool | None = None,
@@ -60,7 +60,7 @@ def session_decorator(
     *,
     default: bool = True,
     requires: Sequence[str] | None = None,
-) -> F | Callable[[F], F]:
+) -> Func | Callable[[RawFunc | Func], Func]:
     """Designate the decorated function as a session."""
     # If `func` is provided, then this is the decorator call with the function
     # being sent as part of the Python syntax (`@nox.session`).

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -121,9 +121,11 @@ class ProcessEnv(abc.ABC):
     allowed_globals: ClassVar[tuple[Any, ...]] = ()
 
     def __init__(
-        self, bin_paths: None = None, env: Mapping[str, str | None] | None = None
+        self,
+        bin_paths: Sequence[str] | None = None,
+        env: Mapping[str, str | None] | None = None,
     ) -> None:
-        self._bin_paths = bin_paths
+        self._bin_paths = None if bin_paths is None else list(bin_paths)
         self._reused = False
 
         # Filter envs now so `.env` is dict[str, str] (easier to use)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ lint.typing-modules = [ "nox._typing" ]
 max_supported_python = "3.13"
 
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 addopts = [ "-ra", "--strict-markers", "--strict-config" ]
 xfail_strict = true
 filterwarnings = [ "error" ]
@@ -128,7 +128,6 @@ run.source_pkgs = [ "nox" ]
 report.exclude_also = [ "def __dir__()", "if TYPE_CHECKING:", "@overload" ]
 
 [tool.mypy]
-files = [ "nox/**/*.py", "noxfile.py" ]
 python_version = "3.8"
 strict = true
 warn_unreachable = true

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -28,7 +28,7 @@ RESOURCES = Path(__file__).parent.joinpath("resources")
 
 
 class TestOptionSet:
-    def test_namespace(self):
+    def test_namespace(self) -> None:
         optionset = _option_set.OptionSet()
         optionset.add_groups(_option_set.OptionGroup("group_a"))
         optionset.add_options(
@@ -43,7 +43,7 @@ class TestOptionSet:
         assert not hasattr(namespace, "non_existent_option")
         assert namespace.option_a == "meep"
 
-    def test_namespace_values(self):
+    def test_namespace_values(self) -> None:
         optionset = _option_set.OptionSet()
         optionset.add_groups(_option_set.OptionGroup("group_a"))
         optionset.add_options(
@@ -56,13 +56,13 @@ class TestOptionSet:
 
         assert namespace.option_a == "moop"
 
-    def test_namespace_non_existent_options_with_values(self):
+    def test_namespace_non_existent_options_with_values(self) -> None:
         optionset = _option_set.OptionSet()
 
         with pytest.raises(KeyError):
             optionset.namespace(non_existent_option="meep")
 
-    def test_parser_hidden_option(self):
+    def test_parser_hidden_option(self) -> None:
         optionset = _option_set.OptionSet()
         optionset.add_options(
             _option_set.Option(
@@ -76,7 +76,7 @@ class TestOptionSet:
 
         assert namespace.oh_boy_i_am_hidden == "meep"
 
-    def test_parser_groupless_option(self):
+    def test_parser_groupless_option(self) -> None:
         optionset = _option_set.OptionSet()
         optionset.add_options(
             _option_set.Option("oh_no_i_have_no_group", group=None, default="meep")
@@ -85,46 +85,46 @@ class TestOptionSet:
         with pytest.raises(ValueError):
             optionset.parser()
 
-    def test_session_completer(self):
+    def test_session_completer(self) -> None:
         parsed_args = _options.options.namespace(
             posargs=[],
             noxfile=str(RESOURCES.joinpath("noxfile_multiple_sessions.py")),
         )
         actual_sessions_from_file = _options._session_completer(
-            prefix=None, parsed_args=parsed_args
+            prefix="", parsed_args=parsed_args
         )
 
         expected_sessions = ["testytest", "lintylint", "typeytype"]
         assert expected_sessions == list(actual_sessions_from_file)
 
-    def test_session_completer_invalid_sessions(self):
+    def test_session_completer_invalid_sessions(self) -> None:
         parsed_args = _options.options.namespace(
             sessions=("baz",), keywords=(), posargs=[]
         )
         all_nox_sessions = _options._session_completer(
-            prefix=None, parsed_args=parsed_args
+            prefix="", parsed_args=parsed_args
         )
-        assert len(all_nox_sessions) == 0
+        assert len(list(all_nox_sessions)) == 0
 
-    def test_python_completer(self):
+    def test_python_completer(self) -> None:
         parsed_args = _options.options.namespace(
             posargs=[],
             noxfile=str(RESOURCES.joinpath("noxfile_pythons.py")),
         )
         actual_pythons_from_file = _options._python_completer(
-            prefix=None, parsed_args=parsed_args
+            prefix="", parsed_args=parsed_args
         )
 
         expected_pythons = {"3.6", "3.12"}
         assert expected_pythons == set(actual_pythons_from_file)
 
-    def test_tag_completer(self):
+    def test_tag_completer(self) -> None:
         parsed_args = _options.options.namespace(
             posargs=[],
             noxfile=str(RESOURCES.joinpath("noxfile_tags.py")),
         )
         actual_tags_from_file = _options._tag_completer(
-            prefix=None, parsed_args=parsed_args
+            prefix="", parsed_args=parsed_args
         )
 
         expected_tags = {f"tag{n}" for n in range(1, 8)}

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 import pytest
 
+import nox
 from nox import _decorators, _parametrize, parametrize, session
 
 
@@ -30,94 +31,99 @@ from nox import _decorators, _parametrize, parametrize, session
         (_parametrize.Param(1, 2, arg_names=("a", "b")), {"a": 1, "b": 2}, True),
     ],
 )
-def test_param_eq(param, other, expected):
+def test_param_eq(
+    param: _parametrize.Param,
+    other: _parametrize.Param | dict[str, int],
+    expected: bool,
+) -> None:
     assert (param == other) is expected
 
 
-def test_param_eq_fail():
+def test_param_eq_fail() -> None:
     assert _parametrize.Param() != "a"
 
 
-def test_parametrize_decorator_one():
-    def f():
+def test_parametrize_decorator_one() -> None:
+    def f() -> None:
         pass
 
-    _parametrize.parametrize_decorator("abc", 1)(f)
+    # A raw int is supported, but not part of the typed API.
+    _parametrize.parametrize_decorator("abc", 1)(f)  # type: ignore[arg-type]
 
-    assert f.parametrize == [_parametrize.Param(1, arg_names=("abc",))]
+    assert f.parametrize == [_parametrize.Param(1, arg_names=("abc",))]  # type: ignore[attr-defined]
 
 
-def test_parametrize_decorator_one_param():
-    def f():
+def test_parametrize_decorator_one_param() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator("abc", _parametrize.Param(1))(f)
 
-    assert f.parametrize == [_parametrize.Param(1, arg_names=("abc",))]
+    assert f.parametrize == [_parametrize.Param(1, arg_names=("abc",))]  # type: ignore[attr-defined]
 
 
-def test_parametrize_decorator_one_with_args():
-    def f():
+def test_parametrize_decorator_one_with_args() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator("abc", [1, 2, 3])(f)
 
-    assert f.parametrize == [{"abc": 1}, {"abc": 2}, {"abc": 3}]
+    assert f.parametrize == [{"abc": 1}, {"abc": 2}, {"abc": 3}]  # type: ignore[attr-defined]
 
 
-def test_parametrize_decorator_param():
-    def f():
+def test_parametrize_decorator_param() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator(["abc", "def"], _parametrize.Param(1))(f)
 
-    assert f.parametrize == [_parametrize.Param(1, arg_names=("abc", "def"))]
+    assert f.parametrize == [_parametrize.Param(1, arg_names=("abc", "def"))]  # type: ignore[attr-defined]
 
 
-def test_parametrize_decorator_id_list():
-    def f():
+def test_parametrize_decorator_id_list() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator("abc", [1, 2, 3], ids=["a", "b", "c"])(f)
 
     arg_names = ("abc",)
-    assert f.parametrize == [
+    assert f.parametrize == [  # type: ignore[attr-defined]
         _parametrize.Param(1, arg_names=arg_names, id="a"),
         _parametrize.Param(2, arg_names=arg_names, id="b"),
         _parametrize.Param(3, arg_names=arg_names, id="c"),
     ]
 
 
-def test_parametrize_decorator_multiple_args_as_list():
-    def f():
+def test_parametrize_decorator_multiple_args_as_list() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator(["abc", "def"], [("a", 1), ("b", 2), ("c", 3)])(
         f
     )
 
-    assert f.parametrize == [
+    assert f.parametrize == [  # type: ignore[attr-defined]
         {"abc": "a", "def": 1},
         {"abc": "b", "def": 2},
         {"abc": "c", "def": 3},
     ]
 
 
-def test_parametrize_decorator_multiple_args_as_string():
-    def f():
+def test_parametrize_decorator_multiple_args_as_string() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator("abc, def", [("a", 1), ("b", 2), ("c", 3)])(f)
 
-    assert f.parametrize == [
+    assert f.parametrize == [  # type: ignore[attr-defined]
         {"abc": "a", "def": 1},
         {"abc": "b", "def": 2},
         {"abc": "c", "def": 3},
     ]
 
 
-def test_parametrize_decorator_mixed_params():
-    def f():
+def test_parametrize_decorator_mixed_params() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator(
@@ -125,21 +131,21 @@ def test_parametrize_decorator_mixed_params():
     )(f)
 
     arg_names = ("abc", "def")
-    assert f.parametrize == [
+    assert f.parametrize == [  # type: ignore[attr-defined]
         _parametrize.Param(1, 2, arg_names=arg_names),
         _parametrize.Param(3, 4, arg_names=arg_names, id="b"),
         _parametrize.Param(5, 6, arg_names=arg_names),
     ]
 
 
-def test_parametrize_decorator_stack():
-    def f():
+def test_parametrize_decorator_stack() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator("abc", [1, 2, 3])(f)
     _parametrize.parametrize_decorator("def", ["a", "b"])(f)
 
-    assert f.parametrize == [
+    assert f.parametrize == [  # type: ignore[attr-defined]
         {"abc": 1, "def": "a"},
         {"abc": 2, "def": "a"},
         {"abc": 3, "def": "a"},
@@ -149,14 +155,14 @@ def test_parametrize_decorator_stack():
     ]
 
 
-def test_parametrize_decorator_multiple_and_stack():
-    def f():
+def test_parametrize_decorator_multiple_and_stack() -> None:
+    def f() -> None:
         pass
 
     _parametrize.parametrize_decorator("abc, def", [(1, "a"), (2, "b")])(f)
     _parametrize.parametrize_decorator("foo", ["bar", "baz"])(f)
 
-    assert f.parametrize == [
+    assert f.parametrize == [  # type: ignore[attr-defined]
         {"abc": 1, "def": "a", "foo": "bar"},
         {"abc": 2, "def": "b", "foo": "bar"},
         {"abc": 1, "def": "a", "foo": "baz"},
@@ -164,7 +170,7 @@ def test_parametrize_decorator_multiple_and_stack():
     ]
 
 
-def test_generate_calls_simple():
+def test_generate_calls_simple() -> None:
     f = mock.Mock(should_warn={}, tags=[])
     f.__name__ = "f"
     f.requires = None
@@ -193,11 +199,11 @@ def test_generate_calls_simple():
 
     # Make sure wrapping was done correctly.
     for call in calls:
-        assert call.some_prop == 42
-        assert call.__name__ == "f"
+        assert call.some_prop == 42  # type: ignore[attr-defined]
+        assert call.__name__ == "f"  # type: ignore[attr-defined]
 
 
-def test_generate_calls_multiple_args():
+def test_generate_calls_multiple_args() -> None:
     f = mock.Mock(should_warn=None, tags=[])
     f.__name__ = "f"
     f.requires = None
@@ -224,7 +230,7 @@ def test_generate_calls_multiple_args():
     f.assert_called_with(abc=3, foo="c")
 
 
-def test_generate_calls_ids():
+def test_generate_calls_ids() -> None:
     f = mock.Mock(should_warn={}, tags=[])
     f.__name__ = "f"
     f.requires = None
@@ -247,7 +253,7 @@ def test_generate_calls_ids():
     f.assert_called_with(foo=2)
 
 
-def test_generate_calls_tags():
+def test_generate_calls_tags() -> None:
     f = mock.Mock(should_warn={}, tags=[], requires=[])
     f.__name__ = "f"
 
@@ -266,7 +272,7 @@ def test_generate_calls_tags():
     assert calls[2].tags == ["tag4", "tag5"]
 
 
-def test_generate_calls_merge_tags():
+def test_generate_calls_merge_tags() -> None:
     f = mock.Mock(should_warn={}, tags=["tag1", "tag2"], requires=[])
     f.__name__ = "f"
 
@@ -285,12 +291,12 @@ def test_generate_calls_merge_tags():
     assert calls[2].tags == ["tag1", "tag2", "tag4", "tag5"]
 
 
-def test_generate_calls_session_python():
+def test_generate_calls_session_python() -> None:
     called_with = []
 
     @session
     @parametrize("python,dependency", [("3.8", "0.9"), ("3.9", "0.9"), ("3.9", "1.0")])
-    def f(session, dependency):
+    def f(session: nox.Session, dependency: str) -> None:
         called_with.append((session, dependency))
 
     calls = _decorators.Call.generate_calls(f, f.parametrize)
@@ -313,17 +319,17 @@ def test_generate_calls_session_python():
 
     assert len(called_with) == 3
 
-    assert called_with[0] == (session_, "0.9")
-    assert called_with[1] == (session_, "0.9")
-    assert called_with[2] == (session_, "1.0")
+    assert called_with[0] == (session_, "0.9")  # type: ignore[comparison-overlap]
+    assert called_with[1] == (session_, "0.9")  # type: ignore[comparison-overlap]
+    assert called_with[2] == (session_, "1.0")  # type: ignore[comparison-overlap]
 
 
-def test_generate_calls_python_compatibility():
+def test_generate_calls_python_compatibility() -> None:
     called_with = []
 
     @session
     @parametrize("python,dependency", [("3.8", "0.9"), ("3.9", "0.9"), ("3.9", "1.0")])
-    def f(session, python, dependency):
+    def f(session: nox.Session, python: str, dependency: str) -> None:
         called_with.append((session, python, dependency))
 
     calls = _decorators.Call.generate_calls(f, f.parametrize)
@@ -346,6 +352,6 @@ def test_generate_calls_python_compatibility():
 
     assert len(called_with) == 3
 
-    assert called_with[0] == (session_, "3.8", "0.9")
-    assert called_with[1] == (session_, "3.9", "0.9")
-    assert called_with[2] == (session_, "3.9", "1.0")
+    assert called_with[0] == (session_, "3.8", "0.9")  # type: ignore[comparison-overlap]
+    assert called_with[1] == (session_, "3.9", "0.9")  # type: ignore[comparison-overlap]
+    assert called_with[2] == (session_, "3.9", "1.0")  # type: ignore[comparison-overlap]

--- a/tests/test__resolver.py
+++ b/tests/test__resolver.py
@@ -125,7 +125,9 @@ from nox._resolver import CycleError, lazy_stable_topo_sort
         ),
     ],
 )
-def test_lazy_stable_topo_sort(dependencies, expected):
+def test_lazy_stable_topo_sort(
+    dependencies: dict[str, tuple[str, ...]], expected: tuple[str, ...]
+) -> None:
     actual = tuple(lazy_stable_topo_sort(dependencies, "0"))
     actual_with_root = tuple(lazy_stable_topo_sort(dependencies, "0", drop_root=False))
     assert actual == actual_with_root[:-1] == expected
@@ -156,7 +158,9 @@ def test_lazy_stable_topo_sort(dependencies, expected):
         ),
     ],
 )
-def test_lazy_stable_topo_sort_CycleError(dependencies, expected_cycle):
+def test_lazy_stable_topo_sort_CycleError(
+    dependencies: dict[str, tuple[str, ...]], expected_cycle: tuple[str, ...]
+) -> None:
     with pytest.raises(CycleError) as exc_info:
         tuple(lazy_stable_topo_sort(dependencies, "0"))
     # While the exact cycle reported is not unique and is an implementation detail, this

--- a/tests/test__version.py
+++ b/tests/test__version.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from textwrap import dedent
 
@@ -30,7 +31,7 @@ from nox._version import (
 
 
 @pytest.fixture
-def temp_noxfile(tmp_path: Path):
+def temp_noxfile(tmp_path: Path) -> Callable[[str], str]:
     def make_temp_noxfile(content: str) -> str:
         path = tmp_path / "noxfile.py"
         path.write_text(content)
@@ -100,7 +101,9 @@ def test_parse_needs_version(text: str, expected: str | None) -> None:
 
 
 @pytest.mark.parametrize("specifiers", ["", ">=2020.12.31", ">=2020.12.31,<9999.99.99"])
-def test_check_nox_version_succeeds(temp_noxfile, specifiers: str) -> None:
+def test_check_nox_version_succeeds(
+    temp_noxfile: Callable[[str], str], specifiers: str
+) -> None:
     """It does not raise if the version specifiers are satisfied."""
     text = dedent(
         f"""
@@ -112,7 +115,9 @@ def test_check_nox_version_succeeds(temp_noxfile, specifiers: str) -> None:
 
 
 @pytest.mark.parametrize("specifiers", [">=9999.99.99"])
-def test_check_nox_version_fails(temp_noxfile, specifiers: str) -> None:
+def test_check_nox_version_fails(
+    temp_noxfile: Callable[[str], str], specifiers: str
+) -> None:
     """It raises an exception if the version specifiers are not satisfied."""
     text = dedent(
         f"""
@@ -125,7 +130,9 @@ def test_check_nox_version_fails(temp_noxfile, specifiers: str) -> None:
 
 
 @pytest.mark.parametrize("specifiers", ["invalid", "2020.12.31"])
-def test_check_nox_version_invalid(temp_noxfile, specifiers: str) -> None:
+def test_check_nox_version_invalid(
+    temp_noxfile: Callable[[str], str], specifiers: str
+) -> None:
     """It raises an exception if the version specifiers cannot be parsed."""
     text = dedent(
         f"""

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -19,21 +19,21 @@ VALID_VERSIONS = {
 
 
 @pytest.mark.parametrize("version", VALID_VERSIONS.keys())
-def test_filter_version(version):
+def test_filter_version(version: str) -> None:
     assert filter_version(version) == VALID_VERSIONS[version]
 
 
-def test_filter_version_invalid():
+def test_filter_version_invalid() -> None:
     with pytest.raises(ValueError, match=r"invalid version: 3"):
         filter_version("3")
 
 
-def test_filter_version_invalid_major():
+def test_filter_version_invalid_major() -> None:
     with pytest.raises(ValueError, match=r"invalid major python version: x.0"):
         filter_version("x.0")
 
 
-def test_filter_version_invalid_minor():
+def test_filter_version_invalid_minor() -> None:
     with pytest.raises(ValueError, match=r"invalid minor python version: 3.x"):
         filter_version("3.x")
 
@@ -63,7 +63,7 @@ VALID_VERSION_LISTS = {
 
 
 @pytest.mark.parametrize("version_list", VALID_VERSION_LISTS.keys())
-def test_setup_action(capsys, version_list):
+def test_setup_action(capsys: pytest.CaptureFixture[str], version_list: str) -> None:
     setup_action(version_list)
     captured = capsys.readouterr()
     lines = captured.out.splitlines()
@@ -71,7 +71,7 @@ def test_setup_action(capsys, version_list):
     assert lines == [f"interpreters={json.dumps(ordered_versions)}"]
 
 
-def test_setup_action_multiple_pypy():
+def test_setup_action_multiple_pypy() -> None:
     with pytest.raises(
         ValueError,
         match=(
@@ -81,7 +81,7 @@ def test_setup_action_multiple_pypy():
         setup_action("pypy3.9, pypy-3.9-v7.3.9")
 
 
-def test_setup_action_multiple_cpython():
+def test_setup_action_multiple_cpython() -> None:
     with pytest.raises(
         ValueError,
         match=(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -22,19 +22,19 @@ import pytest
 from nox import logger
 
 
-def test_success():
+def test_success() -> None:
     with mock.patch.object(logger.LoggerWithSuccessAndOutput, "_log") as _log:
         logger.LoggerWithSuccessAndOutput("foo").success("bar")
         _log.assert_called_once_with(logger.SUCCESS, "bar", ())
 
 
-def test_output():
+def test_output() -> None:
     with mock.patch.object(logger.LoggerWithSuccessAndOutput, "_log") as _log:
         logger.LoggerWithSuccessAndOutput("foo").output("bar")
         _log.assert_called_once_with(logger.OUTPUT, "bar", ())
 
 
-def test_formatter(caplog):
+def test_formatter(caplog: pytest.LogCaptureFixture) -> None:
     caplog.clear()
     logger.setup_logging(True, verbose=True)
     with caplog.at_level(logging.DEBUG):
@@ -68,7 +68,7 @@ def test_formatter(caplog):
         pytest.param(False, id="no-color"),
     ],
 )
-def test_no_color_timestamp(caplog, color):
+def test_no_color_timestamp(caplog: pytest.LogCaptureFixture, color: bool) -> None:
     logger.setup_logging(color=color, add_timestamp=True)
     caplog.clear()
     with caplog.at_level(logging.DEBUG):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,8 +18,10 @@ import contextlib
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 from importlib import metadata
 from pathlib import Path
+from typing import Any, Literal
 from unittest import mock
 
 import pytest
@@ -39,7 +41,7 @@ VERSION = metadata.version("nox")
 os.environ.pop("NOXSESSION", None)
 
 
-def test_main_no_args(monkeypatch):
+def test_main_no_args(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", [sys.executable])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -61,7 +63,7 @@ def test_main_no_args(monkeypatch):
         assert config.posargs == []
 
 
-def test_main_long_form_args():
+def test_main_long_form_args() -> None:
     sys.argv = [
         sys.executable,
         "--noxfile",
@@ -102,7 +104,9 @@ def test_main_long_form_args():
         assert config.posargs == []
 
 
-def test_main_no_venv(monkeypatch, capsys):
+def test_main_no_venv(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     # Check that --no-venv overrides force_venv_backend
     monkeypatch.setattr(
         sys,
@@ -129,7 +133,7 @@ def test_main_no_venv(monkeypatch, capsys):
         sys_exit.assert_called_once_with(0)
 
 
-def test_main_no_venv_error():
+def test_main_no_venv_error() -> None:
     # Check that --no-venv can not be set together with a non-none --force-venv-backend
     sys.argv = [
         sys.executable,
@@ -143,7 +147,7 @@ def test_main_no_venv_error():
         nox.main()
 
 
-def test_main_short_form_args(monkeypatch):
+def test_main_short_form_args(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         sys,
         "argv",
@@ -180,7 +184,7 @@ def test_main_short_form_args(monkeypatch):
         assert config.reuse_venv == "yes"
 
 
-def test_main_explicit_sessions(monkeypatch):
+def test_main_explicit_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", [sys.executable, "-e", "1", "2"])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -196,7 +200,9 @@ def test_main_explicit_sessions(monkeypatch):
         assert config.sessions == ["1", "2"]
 
 
-def test_main_explicit_sessions_with_spaces_in_names(monkeypatch):
+def test_main_explicit_sessions_with_spaces_in_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         sys, "argv", [sys.executable, "-e", "unit tests", "the unit tests"]
     )
@@ -237,7 +243,13 @@ def test_main_explicit_sessions_with_spaces_in_names(monkeypatch):
         "multiple_force_pythons",
     ],
 )
-def test_main_list_option_from_nox_env_var(monkeypatch, var, option, env, values):
+def test_main_list_option_from_nox_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+    var: str,
+    option: str,
+    env: str,
+    values: list[str],
+) -> None:
     monkeypatch.setenv(var, env)
     monkeypatch.setattr(sys, "argv", [sys.executable])
 
@@ -266,7 +278,12 @@ def test_main_list_option_from_nox_env_var(monkeypatch, var, option, env, values
     ],
     ids=["option", "env", "option_over_env"],
 )
-def test_default_venv_backend_option(monkeypatch, options, env, expected):
+def test_default_venv_backend_option(
+    monkeypatch: pytest.MonkeyPatch,
+    options: list[str],
+    env: str,
+    expected: str,
+) -> None:
     monkeypatch.setenv("NOX_DEFAULT_VENV_BACKEND", env)
     monkeypatch.setattr(sys, "argv", [sys.executable, *options])
     with mock.patch("nox.workflow.execute") as execute:
@@ -283,7 +300,9 @@ def test_default_venv_backend_option(monkeypatch, options, env, expected):
         assert config.default_venv_backend == expected
 
 
-def test_main_positional_args(capsys, monkeypatch):
+def test_main_positional_args(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     fake_exit = mock.Mock(side_effect=ValueError("asdf!"))
 
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3"])
@@ -306,7 +325,7 @@ def test_main_positional_args(capsys, monkeypatch):
     fake_exit.assert_called_once_with(2)
 
 
-def test_main_positional_with_double_hyphen(monkeypatch):
+def test_main_positional_with_double_hyphen(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", [sys.executable, "--", "1", "2", "3"])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -322,7 +341,9 @@ def test_main_positional_with_double_hyphen(monkeypatch):
         assert config.posargs == ["1", "2", "3"]
 
 
-def test_main_positional_flag_like_with_double_hyphen(monkeypatch):
+def test_main_positional_flag_like_with_double_hyphen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         sys, "argv", [sys.executable, "--", "1", "2", "3", "-f", "--baz"]
     )
@@ -340,7 +361,9 @@ def test_main_positional_flag_like_with_double_hyphen(monkeypatch):
         assert config.posargs == ["1", "2", "3", "-f", "--baz"]
 
 
-def test_main_version(capsys, monkeypatch):
+def test_main_version(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(sys, "argv", [sys.executable, "--version"])
 
     with contextlib.ExitStack() as stack:
@@ -353,7 +376,9 @@ def test_main_version(capsys, monkeypatch):
         execute.assert_not_called()
 
 
-def test_main_help(capsys, monkeypatch):
+def test_main_help(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(sys, "argv", [sys.executable, "--help"])
 
     with contextlib.ExitStack() as stack:
@@ -366,7 +391,7 @@ def test_main_help(capsys, monkeypatch):
         execute.assert_not_called()
 
 
-def test_main_failure(monkeypatch):
+def test_main_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", [sys.executable])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 1
@@ -375,7 +400,9 @@ def test_main_failure(monkeypatch):
             exit.assert_called_once_with(1)
 
 
-def test_main_nested_config(capsys, monkeypatch):
+def test_main_nested_config(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(
         sys,
         "argv",
@@ -396,7 +423,9 @@ def test_main_nested_config(capsys, monkeypatch):
         sys_exit.assert_called_once_with(0)
 
 
-def test_main_session_with_names(capsys, monkeypatch):
+def test_main_session_with_names(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(
         sys,
         "argv",
@@ -418,8 +447,10 @@ def test_main_session_with_names(capsys, monkeypatch):
 
 
 @pytest.fixture
-def run_nox(capsys, monkeypatch):
-    def _run_nox(*args):
+def run_nox(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> Callable[..., tuple[int, str, str]]:
+    def _run_nox(*args: str) -> tuple[int, str, str]:
         monkeypatch.setattr(sys, "argv", ["nox", *args])
 
         with mock.patch("sys.exit") as sys_exit:
@@ -461,7 +492,9 @@ def run_nox(capsys, monkeypatch):
         ),
     ],
 )
-def test_main_with_normalized_session_names(run_nox, normalized_name, session):
+def test_main_with_normalized_session_names(
+    run_nox: Callable[..., tuple[int, str, str]], normalized_name: str, session: str
+) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_normalization.py")
     returncode, _, stderr = run_nox(f"--noxfile={noxfile}", f"--session={session}")
     assert returncode == 0
@@ -482,7 +515,10 @@ def test_main_with_normalized_session_names(run_nox, normalized_name, session):
         "test(arg=datetime.datetime(1980, 1, 1))",
     ],
 )
-def test_main_with_bad_session_names(run_nox, session):
+def test_main_with_bad_session_names(
+    run_nox: Callable[..., tuple[Any, Any, Any]],
+    session: str,
+) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_normalization.py")
     returncode, _, stderr = run_nox(f"--noxfile={noxfile}", f"--session={session}")
     assert returncode != 0
@@ -499,14 +535,18 @@ def test_main_with_bad_session_names(run_nox, session):
         (("w",), ("u(django='1.9')", "u(django='2.0')", "w")),
     ],
 )
-def test_main_requires(run_nox, sessions, expected_order):
+def test_main_requires(
+    run_nox: Callable[..., tuple[Any, Any, Any]],
+    sessions: tuple[str, ...],
+    expected_order: tuple[str, ...],
+) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_requires.py")
     returncode, stdout, _ = run_nox(f"--noxfile={noxfile}", "--sessions", *sessions)
     assert returncode == 0
     assert tuple(stdout.rstrip("\n").split("\n")) == expected_order
 
 
-def test_main_requires_cycle(run_nox):
+def test_main_requires_cycle(run_nox: Callable[..., tuple[Any, Any, Any]]) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_requires.py")
     returncode, _, stderr = run_nox(f"--noxfile={noxfile}", "--session=i")
     assert returncode != 0
@@ -516,14 +556,18 @@ def test_main_requires_cycle(run_nox):
     assert "Sessions are in a dependency cycle: i -> j -> i" in stderr
 
 
-def test_main_requires_missing_session(run_nox):
+def test_main_requires_missing_session(
+    run_nox: Callable[..., tuple[Any, Any, Any]],
+) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_requires.py")
     returncode, _, stderr = run_nox(f"--noxfile={noxfile}", "--session=o")
     assert returncode != 0
     assert "Session not found: does_not_exist" in stderr
 
 
-def test_main_requires_bad_python_parametrization(run_nox):
+def test_main_requires_bad_python_parametrization(
+    run_nox: Callable[..., tuple[Any, Any, Any]],
+) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_requires.py")
     with pytest.raises(
         ValueError,
@@ -534,7 +578,9 @@ def test_main_requires_bad_python_parametrization(run_nox):
 
 
 @pytest.mark.parametrize("session", ("s", "t"))
-def test_main_requires_chain_fail(run_nox, session):
+def test_main_requires_chain_fail(
+    run_nox: Callable[..., tuple[Any, Any, Any]], session: str
+) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_requires.py")
     returncode, _, stderr = run_nox(f"--noxfile={noxfile}", f"--session={session}")
     assert returncode != 0
@@ -542,13 +588,18 @@ def test_main_requires_chain_fail(run_nox, session):
 
 
 @pytest.mark.parametrize("session", ("w", "u"))
-def test_main_requries_modern_param(run_nox, session):
+def test_main_requries_modern_param(
+    run_nox: Callable[..., tuple[Any, Any, Any]],
+    session: str,
+) -> None:
     noxfile = os.path.join(RESOURCES, "noxfile_requires.py")
     returncode, _, stderr = run_nox(f"--noxfile={noxfile}", f"--session={session}")
     assert returncode == 0
 
 
-def test_main_noxfile_options(monkeypatch, generate_noxfile_options):
+def test_main_noxfile_options(
+    monkeypatch: pytest.MonkeyPatch, generate_noxfile_options: Callable[..., str]
+) -> None:
     noxfile_path = generate_noxfile_options(reuse_existing_virtualenvs=True)
     monkeypatch.setattr(
         sys,
@@ -577,7 +628,9 @@ def test_main_noxfile_options(monkeypatch, generate_noxfile_options):
         assert config.reuse_venv == "yes"
 
 
-def test_main_noxfile_options_disabled_by_flag(monkeypatch, generate_noxfile_options):
+def test_main_noxfile_options_disabled_by_flag(
+    monkeypatch: pytest.MonkeyPatch, generate_noxfile_options: Callable[..., str]
+) -> None:
     noxfile_path = generate_noxfile_options(reuse_existing_virtualenvs=True)
     monkeypatch.setattr(
         sys,
@@ -607,7 +660,9 @@ def test_main_noxfile_options_disabled_by_flag(monkeypatch, generate_noxfile_opt
         assert config.reuse_venv == "no"
 
 
-def test_main_noxfile_options_sessions(monkeypatch, generate_noxfile_options):
+def test_main_noxfile_options_sessions(
+    monkeypatch: pytest.MonkeyPatch, generate_noxfile_options: Callable[..., str]
+) -> None:
     noxfile_path = generate_noxfile_options(reuse_existing_virtualenvs=True)
     monkeypatch.setattr(
         sys,
@@ -629,7 +684,7 @@ def test_main_noxfile_options_sessions(monkeypatch, generate_noxfile_options):
 
 
 @pytest.fixture
-def generate_noxfile_options_pythons(tmp_path):
+def generate_noxfile_options_pythons(tmp_path: Path) -> Callable[[str, str, str], str]:
     """Generate noxfile.py with test and launch_rocket sessions.
 
     The sessions are defined for both the default and alternate Python versions.
@@ -637,7 +692,9 @@ def generate_noxfile_options_pythons(tmp_path):
     goes into ``nox.options.sessions`` and ``nox.options.pythons``, respectively.
     """
 
-    def generate_noxfile(default_session, default_python, alternate_python):
+    def generate_noxfile(
+        default_session: str, default_python: str, alternate_python: str
+    ) -> str:
         path = Path(RESOURCES) / "noxfile_options_pythons.py"
         text = path.read_text()
         text = text.format(
@@ -657,8 +714,10 @@ python_next_version = f"{sys.version_info.major}.{sys.version_info.minor + 1}"
 
 
 def test_main_noxfile_options_with_pythons_override(
-    capsys, monkeypatch, generate_noxfile_options_pythons
-):
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    generate_noxfile_options_pythons: Callable[..., str],
+) -> None:
     noxfile = generate_noxfile_options_pythons(
         default_session="test",
         default_python=python_next_version,
@@ -684,8 +743,10 @@ def test_main_noxfile_options_with_pythons_override(
 
 
 def test_main_noxfile_options_with_sessions_override(
-    capsys, monkeypatch, generate_noxfile_options_pythons
-):
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    generate_noxfile_options_pythons: Callable[..., str],
+) -> None:
     noxfile = generate_noxfile_options_pythons(
         default_session="test",
         default_python=python_current_version,
@@ -711,7 +772,9 @@ def test_main_noxfile_options_with_sessions_override(
 
 
 @pytest.mark.parametrize(("isatty_value", "expected"), [(True, True), (False, False)])
-def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
+def test_main_color_from_isatty(
+    monkeypatch: pytest.MonkeyPatch, isatty_value: bool, expected: bool
+) -> None:
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.setattr(sys, "argv", [sys.executable])
     with mock.patch("nox.workflow.execute") as execute:
@@ -736,7 +799,9 @@ def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
         ("--no-color", False),
     ],
 )
-def test_main_color_options(monkeypatch, color_opt, expected):
+def test_main_color_options(
+    monkeypatch: pytest.MonkeyPatch, color_opt: str, expected: bool
+) -> None:
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.setattr(sys, "argv", [sys.executable, color_opt])
     with mock.patch("nox.workflow.execute") as execute:
@@ -750,7 +815,9 @@ def test_main_color_options(monkeypatch, color_opt, expected):
         assert config.color == expected
 
 
-def test_main_color_conflict(capsys, monkeypatch):
+def test_main_color_conflict(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(sys, "argv", [sys.executable, "--forcecolor", "--nocolor"])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 1
@@ -765,7 +832,7 @@ def test_main_color_conflict(capsys, monkeypatch):
     assert "color" in err
 
 
-def test_main_force_python(monkeypatch):
+def test_main_force_python(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["nox", "--force-python=3.11"])
     with mock.patch("nox.workflow.execute", return_value=0) as execute:
         with mock.patch.object(sys, "exit"):
@@ -774,7 +841,9 @@ def test_main_force_python(monkeypatch):
     assert config.pythons == config.extra_pythons == ["3.11"]
 
 
-def test_main_reuse_existing_virtualenvs_no_install(monkeypatch):
+def test_main_reuse_existing_virtualenvs_no_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(sys, "argv", ["nox", "-R"])
     with mock.patch("nox.workflow.execute", return_value=0) as execute:
         with mock.patch.object(sys, "exit"):
@@ -799,12 +868,12 @@ def test_main_reuse_existing_virtualenvs_no_install(monkeypatch):
     ],
 )
 def test_main_noxfile_options_with_ci_override(
-    monkeypatch,
-    generate_noxfile_options,
-    should_set_ci_env_var,
-    noxfile_option_value,
-    expected_final_value,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    generate_noxfile_options: Callable[..., str],
+    should_set_ci_env_var: bool,
+    noxfile_option_value: bool | None,
+    expected_final_value: bool,
+) -> None:
     monkeypatch.delenv("CI", raising=False)  # make sure we have a clean environment
     if should_set_ci_env_var:
         monkeypatch.setenv("CI", "True")
@@ -845,7 +914,11 @@ def test_main_noxfile_options_with_ci_override(
         "never",
     ],
 )
-def test_main_reuse_venv_cli_flags(monkeypatch, generate_noxfile_options, reuse_venv):
+def test_main_reuse_venv_cli_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    generate_noxfile_options: Callable[..., str],
+    reuse_venv: Literal["yes"] | Literal["no"] | Literal["always"] | Literal["never"],
+) -> None:
     monkeypatch.setattr(sys, "argv", ["nox", "--reuse-venv", reuse_venv])
     with mock.patch("nox.workflow.execute", return_value=0) as execute:
         with mock.patch.object(sys, "exit"):
@@ -883,12 +956,12 @@ def test_main_reuse_venv_cli_flags(monkeypatch, generate_noxfile_options, reuse_
     ],
 )
 def test_main_noxfile_options_reuse_venv_compat_check(
-    monkeypatch,
-    generate_noxfile_options,
-    reuse_venv,
-    reuse_existing_virtualenvs,
-    expected,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    generate_noxfile_options: Callable[..., str],
+    reuse_venv: str,
+    reuse_existing_virtualenvs: str | bool | None,
+    expected: str,
+) -> None:
     cmd_args = ["nox", "-l"]
     # CLI Compat Check
     if isinstance(reuse_existing_virtualenvs, str):
@@ -921,33 +994,33 @@ def test_main_noxfile_options_reuse_venv_compat_check(
     assert config.reuse_venv == expected
 
 
-def test_noxfile_options_cant_be_set():
+def test_noxfile_options_cant_be_set() -> None:
     with pytest.raises(AttributeError, match="reuse_venvs"):
-        nox.options.reuse_venvs = True
+        nox.options.reuse_venvs = True  # type: ignore[attr-defined]
 
 
-def test_noxfile_options_cant_be_set_long():
+def test_noxfile_options_cant_be_set_long() -> None:
     with pytest.raises(AttributeError, match="i_am_clearly_not_an_option"):
-        nox.options.i_am_clearly_not_an_option = True
+        nox.options.i_am_clearly_not_an_option = True  # type: ignore[attr-defined]
 
 
-def test_symlink_orig(monkeypatch):
+def test_symlink_orig(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(Path(RESOURCES) / "orig_dir")
     subprocess.run([sys.executable, "-m", "nox", "-s", "orig"], check=True)
 
 
-def test_symlink_orig_not(monkeypatch):
+def test_symlink_orig_not(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(Path(RESOURCES) / "orig_dir")
     res = subprocess.run([sys.executable, "-m", "nox", "-s", "sym"], check=False)
     assert res.returncode == 1
 
 
-def test_symlink_sym(monkeypatch):
+def test_symlink_sym(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(Path(RESOURCES) / "sym_dir")
     subprocess.run([sys.executable, "-m", "nox", "-s", "sym"], check=True)
 
 
-def test_symlink_sym_not(monkeypatch):
+def test_symlink_sym_not(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(Path(RESOURCES) / "sym_dir")
     res = subprocess.run([sys.executable, "-m", "nox", "-s", "orig"], check=False)
     assert res.returncode == 1

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -15,7 +15,9 @@
 from __future__ import annotations
 
 import collections
+import typing
 from collections.abc import Sequence
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -32,7 +34,7 @@ from nox.manifest import (
 )
 
 
-def create_mock_sessions():
+def create_mock_sessions() -> collections.OrderedDict[str, mock.Mock]:
     sessions = collections.OrderedDict()
     sessions["foo"] = mock.Mock(spec=(), python=None, venv_backend=None, tags=["baz"])
     sessions["bar"] = mock.Mock(
@@ -44,7 +46,7 @@ def create_mock_sessions():
     return sessions
 
 
-def create_mock_config():
+def create_mock_config() -> Any:
     cfg = mock.sentinel.MOCKED_CONFIG
     cfg.force_venv_backend = None
     cfg.default_venv_backend = None
@@ -54,7 +56,7 @@ def create_mock_config():
     return cfg
 
 
-def test__normalize_arg():
+def test__normalize_arg() -> None:
     assert _normalize_arg('test(foo="bar")') == _normalize_arg('test(foo="bar")')
 
     # In the case of SyntaxError it should fallback to string
@@ -64,13 +66,13 @@ def test__normalize_arg():
     )
 
 
-def test__normalized_session_match():
+def test__normalized_session_match() -> None:
     session_mock = mock.MagicMock()
     session_mock.signatures = ['test(foo="bar")']
     assert _normalized_session_match("test(foo='bar')", session_mock)
 
 
-def test_init():
+def test_init() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
 
@@ -80,7 +82,7 @@ def test_init():
     assert manifest["bar"].func is sessions["bar"]
 
 
-def test_contains():
+def test_contains() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
 
@@ -100,7 +102,7 @@ def test_contains():
     assert manifest["foo"] in manifest
 
 
-def test_getitem():
+def test_getitem() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
 
@@ -119,7 +121,7 @@ def test_getitem():
     assert manifest["bar"].func is sessions["bar"]
 
 
-def test_iteration():
+def test_iteration() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
 
@@ -149,7 +151,7 @@ def test_iteration():
         manifest.__next__()
 
 
-def test_len():
+def test_len() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     assert len(manifest) == 2
@@ -157,7 +159,7 @@ def test_len():
         assert len(manifest) == 2
 
 
-def test_filter_by_name():
+def test_filter_by_name() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     manifest.filter_by_name(("foo",))
@@ -165,21 +167,21 @@ def test_filter_by_name():
     assert "bar" not in manifest
 
 
-def test_filter_by_name_maintains_order():
+def test_filter_by_name_maintains_order() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     manifest.filter_by_name(("bar", "foo"))
     assert [session.name for session in manifest] == ["bar", "foo"]
 
 
-def test_filter_by_name_not_found():
+def test_filter_by_name_not_found() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     with pytest.raises(KeyError):
         manifest.filter_by_name(("baz",))
 
 
-def test_filter_by_python_interpreter():
+def test_filter_by_python_interpreter() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     manifest["foo"].func.python = "3.8"
@@ -189,7 +191,7 @@ def test_filter_by_python_interpreter():
     assert "bar" not in manifest
 
 
-def test_filter_by_keyword():
+def test_filter_by_keyword() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     assert len(manifest) == 2
@@ -212,7 +214,7 @@ def test_filter_by_keyword():
         (["baz", "missing"], 2),
     ],
 )
-def test_filter_by_tags(tags: Sequence[str], session_count: int):
+def test_filter_by_tags(tags: Sequence[str], session_count: int) -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     assert len(manifest) == 2
@@ -220,7 +222,7 @@ def test_filter_by_tags(tags: Sequence[str], session_count: int):
     assert len(manifest) == session_count
 
 
-def test_list_all_sessions_with_filter():
+def test_list_all_sessions_with_filter() -> None:
     sessions = create_mock_sessions()
     manifest = Manifest(sessions, create_mock_config())
     assert len(manifest) == 2
@@ -233,7 +235,7 @@ def test_list_all_sessions_with_filter():
     assert all_sessions[1][1] is False
 
 
-def test_add_session_plain():
+def test_add_session_plain() -> None:
     manifest = Manifest({}, create_mock_config())
     session_func = mock.Mock(spec=(), python=None, venv_backend=None)
     for session in manifest.make_session("my_session", session_func):
@@ -241,10 +243,10 @@ def test_add_session_plain():
     assert len(manifest) == 1
 
 
-def test_add_session_multiple_pythons():
+def test_add_session_multiple_pythons() -> None:
     manifest = Manifest({}, create_mock_config())
 
-    def session_func():
+    def session_func() -> None:
         pass
 
     func = Func(session_func, python=["3.5", "3.6"])
@@ -272,13 +274,17 @@ def test_add_session_multiple_pythons():
         (["3.5", "3.9"], ["3.5", "3.9"], ["3.5", "3.9"]),
     ],
 )
-def test_extra_pythons(python, extra_pythons, expected):
+def test_extra_pythons(
+    python: list[str] | str | bool | None,
+    extra_pythons: list[str],
+    expected: list[None] | list[bool] | list[str],
+) -> None:
     cfg = create_mock_config()
     cfg.extra_pythons = extra_pythons
 
     manifest = Manifest({}, cfg)
 
-    def session_func():
+    def session_func() -> None:
         pass
 
     func = Func(session_func, python=python)
@@ -306,14 +312,18 @@ def test_extra_pythons(python, extra_pythons, expected):
         (["3.5", "3.9"], ["3.5", "3.9"], ["3.5", "3.9"]),
     ],
 )
-def test_force_pythons(python, force_pythons, expected):
+def test_force_pythons(
+    python: list[str] | str | bool | None,
+    force_pythons: list[str],
+    expected: list[None] | list[bool] | list[str],
+) -> None:
     cfg = create_mock_config()
     cfg.force_pythons = force_pythons
     cfg.extra_pythons = force_pythons
 
     manifest = Manifest({}, cfg)
 
-    def session_func():
+    def session_func() -> None:
         pass
 
     func = Func(session_func, python=python)
@@ -323,12 +333,12 @@ def test_force_pythons(python, force_pythons, expected):
     assert expected == [session.func.python for session in manifest._all_sessions]
 
 
-def test_add_session_parametrized():
+def test_add_session_parametrized() -> None:
     manifest = Manifest({}, create_mock_config())
 
     # Define a session with parameters.
     @nox.parametrize("param", ("a", "b", "c"))
-    def my_session(session, param):
+    def my_session(session: nox.Session, param: str) -> None:
         pass
 
     func = Func(my_session, python=None)
@@ -339,12 +349,12 @@ def test_add_session_parametrized():
     assert len(manifest) == 3
 
 
-def test_add_session_parametrized_multiple_pythons():
+def test_add_session_parametrized_multiple_pythons() -> None:
     manifest = Manifest({}, create_mock_config())
 
     # Define a session with parameters.
     @nox.parametrize("param", ("a", "b"))
-    def my_session(session, param):
+    def my_session(session: nox.Session, param: str) -> None:
         pass
 
     func = Func(my_session, python=["2.7", "3.6"])
@@ -355,12 +365,12 @@ def test_add_session_parametrized_multiple_pythons():
     assert len(manifest) == 4
 
 
-def test_add_session_parametrized_noop():
+def test_add_session_parametrized_noop() -> None:
     manifest = Manifest({}, create_mock_config())
 
     # Define a session without any parameters.
     @nox.parametrize("param", ())
-    def my_session(session, param):
+    def my_session(session: nox.Session, param: object) -> None:
         pass
 
     my_session.python = None
@@ -376,18 +386,22 @@ def test_add_session_parametrized_noop():
     assert session.func == _null_session_func
 
 
-def test_notify():
+def test_notify() -> None:
     manifest = Manifest({}, create_mock_config())
 
     # Define a session.
-    def my_session(session):
+    def my_session_raw(session: nox.Session) -> None:
         pass
+
+    my_session = typing.cast(Func, my_session_raw)
 
     my_session.python = None
     my_session.venv_backend = None
 
-    def notified(session):
+    def notified_raw(session: nox.Session) -> None:
         pass
+
+    notified = typing.cast(Func, notified_raw)
 
     notified.python = None
     notified.venv_backend = None
@@ -408,12 +422,14 @@ def test_notify():
     assert len(manifest) == 2
 
 
-def test_notify_noop():
+def test_notify_noop() -> None:
     manifest = Manifest({}, create_mock_config())
 
     # Define a session and add it to the manifest.
-    def my_session(session):
+    def my_session_raw(session: nox.Session) -> None:
         pass
+
+    my_session = typing.cast(Func, my_session_raw)
 
     my_session.python = None
     my_session.venv_backend = None
@@ -428,7 +444,7 @@ def test_notify_noop():
     assert len(manifest) == 1
 
 
-def test_notify_with_posargs():
+def test_notify_with_posargs() -> None:
     cfg = create_mock_config()
     manifest = Manifest({}, cfg)
 
@@ -443,13 +459,13 @@ def test_notify_with_posargs():
     assert session.posargs == ["--an-arg"]
 
 
-def test_notify_error():
+def test_notify_error() -> None:
     manifest = Manifest({}, create_mock_config())
     with pytest.raises(ValueError):
         manifest.notify("does_not_exist")
 
 
-def test_add_session_idempotent():
+def test_add_session_idempotent() -> None:
     manifest = Manifest({}, create_mock_config())
     session_func = mock.Mock(spec=(), python=None, venv_backend=None)
     for session in manifest.make_session("my_session", session_func):
@@ -458,29 +474,31 @@ def test_add_session_idempotent():
     assert len(manifest) == 1
 
 
-def test_null_session_function():
+def test_null_session_function() -> None:
     session = mock.Mock(spec=("skip",))
     _null_session_func(session)
     assert session.skip.called
 
 
-def test_keyword_locals_length():
+def test_keyword_locals_length() -> None:
     kw = KeywordLocals({"foo", "bar"})
     assert len(kw) == 2
 
 
-def test_keyword_locals_iter():
-    values = ["foo", "bar"]
+def test_keyword_locals_iter() -> None:
+    values = ["bar", "foo"]
     kw = KeywordLocals(values)
-    assert list(kw) == values
+    assert sorted(kw) == values
 
 
-def test_no_venv_backend_but_some_pythons():
+def test_no_venv_backend_but_some_pythons() -> None:
     manifest = Manifest({}, create_mock_config())
 
     # Define a session and add it to the manifest.
-    def my_session(session):
+    def my_session_raw(session: nox.Session) -> None:
         pass
+
+    my_session = typing.cast(Func, my_session_raw)
 
     # the session sets "no venv backend" but declares some pythons
     my_session.python = ["3.7", "3.8"]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,7 @@ import pytest
 from nox.project import dependency_groups, python_versions
 
 
-def test_classifiers():
+def test_classifiers() -> None:
     pyproject = {
         "project": {
             "classifiers": [
@@ -21,19 +21,19 @@ def test_classifiers():
     assert python_versions(pyproject) == ["3.7", "3.9", "3.12"]
 
 
-def test_no_classifiers():
+def test_no_classifiers() -> None:
     pyproject = {"project": {"requires-python": ">=3.9"}}
     with pytest.raises(ValueError, match="No Python version classifiers"):
         python_versions(pyproject)
 
 
-def test_no_requires_python():
+def test_no_requires_python() -> None:
     pyproject = {"project": {"classifiers": ["Programming Language :: Python :: 3.12"]}}
     with pytest.raises(ValueError, match='No "project.requires-python" value set'):
         python_versions(pyproject, max_version="3.13")
 
 
-def test_python_range():
+def test_python_range() -> None:
     pyproject = {
         "project": {
             "classifiers": [
@@ -52,20 +52,20 @@ def test_python_range():
     assert python_versions(pyproject, max_version="3.11") == ["3.10", "3.11"]
 
 
-def test_python_range_gt():
+def test_python_range_gt() -> None:
     pyproject = {"project": {"requires-python": ">3.2.1,<3.3"}}
 
     assert python_versions(pyproject, max_version="3.4") == ["3.2", "3.3", "3.4"]
 
 
-def test_python_range_no_min():
+def test_python_range_no_min() -> None:
     pyproject = {"project": {"requires-python": "==3.3.1"}}
 
     with pytest.raises(ValueError, match="No minimum version found"):
         python_versions(pyproject, max_version="3.5")
 
 
-def test_dependency_groups():
+def test_dependency_groups() -> None:
     example = {
         "dependency-groups": {
             "test": ["pytest", "coverage"],

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,13 +14,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from typing import Literal
+
 import pytest
 
+import nox
 from nox import registry
 
 
 @pytest.fixture
-def cleanup_registry():
+def cleanup_registry() -> Generator[None, None, None]:
     """Ensure that the session registry is completely empty before and
     after each test.
     """
@@ -31,11 +35,11 @@ def cleanup_registry():
         registry._REGISTRY.clear()
 
 
-def test_session_decorator(cleanup_registry):
+def test_session_decorator(cleanup_registry: None) -> None:
     # Establish that the use of the session decorator will cause the
     # function to be found in the registry.
     @registry.session_decorator
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     answer = registry.get()
@@ -44,58 +48,61 @@ def test_session_decorator(cleanup_registry):
     assert unit_tests.python is None
 
 
-def test_session_decorator_single_python(cleanup_registry):
+def test_session_decorator_single_python(cleanup_registry: None) -> None:
     @registry.session_decorator(python="3.6")
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     assert unit_tests.python == "3.6"
 
 
-def test_session_decorator_list_of_pythons(cleanup_registry):
+def test_session_decorator_list_of_pythons(cleanup_registry: None) -> None:
     @registry.session_decorator(python=["3.5", "3.6"])
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     assert unit_tests.python == ["3.5", "3.6"]
 
 
-def test_session_decorator_tags(cleanup_registry):
+def test_session_decorator_tags(cleanup_registry: None) -> None:
     @registry.session_decorator(tags=["tag-1", "tag-2"])
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     assert unit_tests.tags == ["tag-1", "tag-2"]
 
 
-def test_session_decorator_py_alias(cleanup_registry):
+def test_session_decorator_py_alias(cleanup_registry: None) -> None:
     @registry.session_decorator(py=["3.5", "3.6"])
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     assert unit_tests.python == ["3.5", "3.6"]
 
 
-def test_session_decorator_py_alias_error(cleanup_registry):
+def test_session_decorator_py_alias_error(cleanup_registry: None) -> None:
     with pytest.raises(ValueError, match="argument"):
 
         @registry.session_decorator(python=["3.5", "3.6"], py="2.7")
-        def unit_tests(session):
+        def unit_tests(session: nox.Session) -> None:
             pass
 
 
-def test_session_decorator_reuse(cleanup_registry):
+def test_session_decorator_reuse(cleanup_registry: None) -> None:
     @registry.session_decorator(reuse_venv=True)
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     assert unit_tests.reuse_venv is True
 
 
 @pytest.mark.parametrize("name", ["unit-tests", "unit tests", "the unit tests"])
-def test_session_decorator_name(cleanup_registry, name):
+def test_session_decorator_name(
+    cleanup_registry: None,
+    name: Literal["unit-tests"] | Literal["unit tests"] | Literal["the unit tests"],
+) -> None:
     @registry.session_decorator(name=name)
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     answer = registry.get()
@@ -105,7 +112,7 @@ def test_session_decorator_name(cleanup_registry, name):
     assert unit_tests.python is None
 
 
-def test_get(cleanup_registry):
+def test_get(cleanup_registry: None) -> None:
     # Establish that the get method returns a copy of the registry.
     empty = registry.get()
     assert empty == registry._REGISTRY
@@ -113,11 +120,11 @@ def test_get(cleanup_registry):
     assert len(empty) == 0
 
     @registry.session_decorator
-    def unit_tests(session):
+    def unit_tests(session: nox.Session) -> None:
         pass
 
     @registry.session_decorator
-    def system_tests(session):
+    def system_tests(session: nox.Session) -> None:
         pass
 
     full = registry.get()

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -101,7 +101,7 @@ def test_load_multiple_script_block(tmp_path: Path) -> None:
         nox.project.load_toml(filepath)
 
 
-def test_load_non_recognised_extension():
+def test_load_non_recognised_extension() -> None:
     msg = "Extension must be .py or .toml, got .txt"
     with pytest.raises(ValueError, match=msg):
         nox.project.load_toml("some.txt")

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -16,8 +16,11 @@ from __future__ import annotations
 
 import sys
 import textwrap
+from collections.abc import Callable
+from typing import Any
 
 import pytest
+from _pytest.compat import LEGACY_PATH
 
 tox_to_nox = pytest.importorskip("nox.tox_to_nox")
 
@@ -27,21 +30,21 @@ PYTHON_VERSION_NODOT = PYTHON_VERSION.replace(".", "")
 
 
 @pytest.fixture
-def makeconfig(tmpdir):
-    def makeconfig(toxini_content):
+def makeconfig(tmpdir: LEGACY_PATH) -> Callable[[str], str]:
+    def makeconfig(toxini_content: str) -> str:
         tmpdir.join("tox.ini").write(toxini_content)
         old = tmpdir.chdir()
         try:
             sys.argv = [sys.executable]
             tox_to_nox.main()
-            return tmpdir.join("noxfile.py").read()
+            return tmpdir.join("noxfile.py").read()  # type: ignore[no-any-return]
         finally:
             old.chdir()
 
     return makeconfig
 
 
-def test_trivial(makeconfig):
+def test_trivial(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -66,7 +69,7 @@ def test_trivial(makeconfig):
     )
 
 
-def test_skipinstall(makeconfig):
+def test_skipinstall(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -93,7 +96,7 @@ def test_skipinstall(makeconfig):
     )
 
 
-def test_usedevelop(makeconfig):
+def test_usedevelop(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -121,7 +124,7 @@ def test_usedevelop(makeconfig):
     )
 
 
-def test_commands(makeconfig):
+def test_commands(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -157,7 +160,7 @@ def test_commands(makeconfig):
     )
 
 
-def test_deps(makeconfig):
+def test_deps(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -189,7 +192,7 @@ def test_deps(makeconfig):
     )
 
 
-def test_env(makeconfig):
+def test_env(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -223,7 +226,7 @@ def test_env(makeconfig):
     )
 
 
-def test_chdir(makeconfig):
+def test_chdir(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -253,7 +256,7 @@ def test_chdir(makeconfig):
     )
 
 
-def test_dash_in_envname(makeconfig):
+def test_dash_in_envname(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -282,7 +285,9 @@ def test_dash_in_envname(makeconfig):
 
 
 @pytest.mark.skipif(TOX4, reason="Not supported in tox 4.")
-def test_non_identifier_in_envname(makeconfig, capfd):
+def test_non_identifier_in_envname(
+    makeconfig: Callable[..., Any], capfd: pytest.CaptureFixture[str]
+) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""
@@ -317,7 +322,7 @@ def test_non_identifier_in_envname(makeconfig, capfd):
     )
 
 
-def test_descriptions_into_docstrings(makeconfig):
+def test_descriptions_into_docstrings(makeconfig: Callable[..., Any]) -> None:
     result = makeconfig(
         textwrap.dedent(
             f"""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -19,7 +19,7 @@ from unittest import mock
 from nox import workflow
 
 
-def test_simple_workflow():
+def test_simple_workflow() -> None:
     # Set up functions for the workflow.
     function_a = mock.Mock(spec=())
     function_b = mock.Mock(spec=())
@@ -45,7 +45,7 @@ def test_simple_workflow():
     )
 
 
-def test_workflow_int_cutoff():
+def test_workflow_int_cutoff() -> None:
     # Set up functions for the workflow.
     function_a = mock.Mock(spec=())
     function_b = mock.Mock(spec=())
@@ -73,7 +73,7 @@ def test_workflow_int_cutoff():
     assert not function_c.called
 
 
-def test_workflow_interrupted():
+def test_workflow_interrupted() -> None:
     # Set up functions for the workflow.
     function_a = mock.Mock(spec=())
     function_b = mock.Mock(spec=())


### PR DESCRIPTION
This fully statically types the test suite. This makes it easier to refactor, as mypy will help report changes. It also gives our current static typing a much better usage test, so some fixes for types are included.
