### PR TITLE
tests: fix broken mock on CPython 3.12.8+

### DIFF
--- a/nox/command.py
+++ b/nox/command.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 __all__ = ["CommandFailed", "ExternalType", "run", "which"]
 
+_PLATFORM = sys.platform
+
 
 def __dir__() -> list[str]:
     return __all__
@@ -72,7 +74,7 @@ def _clean_env(env: Mapping[str, str | None] | None = None) -> dict[str, str] | 
     clean_env = {k: v for k, v in env.items() if v is not None}
 
     # Ensure systemroot is passed down, otherwise Windows will explode.
-    if sys.platform == "win32":
+    if _PLATFORM.startswith("win"):
         clean_env.setdefault("SYSTEMROOT", os.environ.get("SYSTEMROOT", ""))
 
     return clean_env

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -162,7 +162,7 @@ def test_run_env_remove(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-@mock.patch("sys.platform", "win32")
+@mock.patch("nox.command._PLATFORM", "win32")
 def test_run_env_systemroot() -> None:
     systemroot = os.environ.setdefault("SYSTEMROOT", "sigil")
 


### PR DESCRIPTION
Should fix #902 and our test suite, where 3.12 and 3.13 are failing.
