### PR TITLE
fix: correctly separate command-line arguments in `tox-to-nox`

### DIFF
--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -116,7 +116,12 @@ def main() -> None:
                 wrapjoin(c.split()) for c in section["commands"].strip().splitlines()
             ]
 
-            config[name]["deps"] = wrapjoin(section["deps"].strip().splitlines())
+            config[name]["deps"] = wrapjoin([
+                part for dep
+                in section["deps"].strip().splitlines()
+                for part in
+                (dep.split() if dep.startswith("-r") else [dep])
+            ])
 
             for option in "skip_install", "use_develop":
                 if section.get(option):

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -357,3 +357,33 @@ def test_descriptions_into_docstrings(makeconfig: Callable[[str], str]) -> None:
             """
         ).lstrip()
     )
+
+
+def test_commands_with_requirements(makeconfig: Callable[[str], str]) -> None:
+    result = makeconfig(
+        textwrap.dedent("""
+        [tox]
+        envlist = aiohttp
+
+        [testenv]
+        use_develop = true
+        deps =
+            pytest
+            pytest-cov
+            aiohttp: -r requirements/aiohttp.txt
+    """
+        )
+    )
+
+    assert (
+        result
+        == textwrap.dedent("""
+    import nox
+
+
+    @nox.session(python='python3.13')
+    def aiohttp(session):
+        session.install('pytest', 'pytest-cov', '-r', 'requirements/aiohttp.txt')
+        session.install('-e', '.')
+    """).lstrip()
+    )


### PR DESCRIPTION
Fixes #905