### PR TITLE
refactor: pull out env creation into helper method

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -618,14 +618,7 @@ class Session:
             args = (nox.virtualenv.UV, *args[1:])
 
         # Combine the env argument with our virtualenv's env vars.
-        env = env or {}
-        env = {**self.env, **env}
-        if include_outer_env:
-            env = {**os.environ, **env}
-        if self.virtualenv.bin_paths:
-            env["PATH"] = os.pathsep.join(
-                [*self.virtualenv.bin_paths, env.get("PATH") or ""]
-            )
+        env = self.virtualenv.get_env(env=env, include_outer_env=include_outer_env)
 
         # If --error-on-external-run is specified, error on external programs.
         if self._runner.global_config.error_on_external_run and external is None:
@@ -821,7 +814,7 @@ class Session:
         if not isinstance(
             venv, (CondaEnv, VirtualEnv, PassthroughEnv)
         ):  # pragma: no cover
-            msg = "A session without a virtualenv can not install dependencies."
+            msg = f"A session without a virtualenv (got {venv!r}) can not install dependencies."
             raise TypeError(msg)
         if isinstance(venv, PassthroughEnv):
             if self._runner.global_config.no_install:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -618,7 +618,7 @@ class Session:
             args = (nox.virtualenv.UV, *args[1:])
 
         # Combine the env argument with our virtualenv's env vars.
-        env = self.virtualenv.get_env(env=env, include_outer_env=include_outer_env)
+        env = self.virtualenv._get_env(env or {}, include_outer_env=include_outer_env)
 
         # If --error-on-external-run is specified, error on external programs.
         if self._runner.global_config.error_on_external_run and external is None:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -191,6 +191,26 @@ class ProcessEnv(abc.ABC):
         Returns the string used to select this environment.
         """
 
+    def get_env(
+        self,
+        *,
+        env: Mapping[str, str | None] | None = None,
+        include_outer_env: bool = True,
+    ) -> dict[str, str | None]:
+        """
+        Get the computed environment, with bin paths added.  You can request
+        the outer environment be excluded, and/or pass in an env to add.
+        """
+
+        computed_env = {**self.env, **(env or {})}
+        if include_outer_env:
+            computed_env = {**os.environ, **computed_env}
+        if self.bin_paths:
+            computed_env["PATH"] = os.pathsep.join(
+                [*self.bin_paths, computed_env.get("PATH") or ""]
+            )
+        return computed_env
+
 
 def locate_via_py(version: str) -> str | None:
     """Find the Python executable using the Windows Launcher.

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -191,18 +191,19 @@ class ProcessEnv(abc.ABC):
         Returns the string used to select this environment.
         """
 
-    def get_env(
+    def _get_env(
         self,
+        /,
+        env: Mapping[str, str | None],
         *,
-        env: Mapping[str, str | None] | None = None,
         include_outer_env: bool = True,
     ) -> dict[str, str | None]:
         """
         Get the computed environment, with bin paths added.  You can request
-        the outer environment be excluded, and/or pass in an env to add.
+        the outer environment be excluded. The initial env can be empty.
         """
 
-        computed_env = {**self.env, **(env or {})}
+        computed_env = {**self.env, **env}
         if include_outer_env:
             computed_env = {**os.environ, **computed_env}
         if self.bin_paths:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -106,7 +106,7 @@ def test__normalize_path_give_up() -> None:
 
 
 class FakeEnv(mock.MagicMock):
-    get_env = nox.virtualenv.VirtualEnv.get_env
+    _get_env = nox.virtualenv.VirtualEnv._get_env
 
 
 def make_fake_env(venv_backend: str = "venv", **kwargs: Any) -> FakeEnv:


### PR DESCRIPTION
Helping with #881 which is tripping up over the test mocking. This pulled out this function to make it reusable and also improves the test mocking.
