### PR TITLE
fix(gha): drop PyPy from the default list for the GitHub Action

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -21,6 +21,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - windows-2019
           - windows-2022
           - macos-13

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-versions:
     description: "comma-separated list of python versions to install"
     required: false
-    default: "3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy-3.10"
+    default: "3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
 branding:
   icon: package
   color: blue


### PR DESCRIPTION
Close #915. Add an ARM runner, drop PyPy from the default list, which should also speed up non-ARM runs.
