### PR TITLE
fix: add a pyproject.toml default for load_toml

### DIFF
--- a/nox/project.py
+++ b/nox/project.py
@@ -34,13 +34,13 @@ REGEX = re.compile(
 )
 
 
-def load_toml(filename: os.PathLike[str] | str) -> dict[str, Any]:
+def load_toml(filename: os.PathLike[str] | str = "pyproject.toml") -> dict[str, Any]:
     """
     Load a toml file or a script with a PEP 723 script block.
 
     The file must have a ``.toml`` extension to be considered a toml file or a
     ``.py`` extension / no extension to be considered a script. Other file
-    extensions are not valid in this function.
+    extensions are not valid in this function. The default is ``"pyproject.toml"``.
 
     Example:
 


### PR DESCRIPTION
Close https://github.com/wntrblm/nox/issues/843. I was worried about nox's handling of the CWD but I think this is actually safe.
