### PR TITLE
ci: trusted publisher

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,49 @@
+name: CD
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  FORCE_COLOR: "1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  deploy:
+    needs: [dist]
+    environment:
+      name: pypi
+      url: https://pypi.org/project/nox
+    permissions:
+      id-token: write
+      attestations: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Generate artifact attestation for sdist and wheel
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         run: python -m pip install --disable-pip-version-check .
       - name: Lint
         run: nox --non-interactive --error-on-missing-interpreter --session "lint"
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -123,17 +124,3 @@ jobs:
         run:  uv pip install --system .
       - name: Docs
         run: nox --non-interactive --error-on-missing-interpreter --session "docs"
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Build sdist and wheel
-        run: pipx run build
-      - name: Publish distribution PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This needs to be setup in PyPI as well. No need to make a `pypi` environment, it will be created automatically. Publishing a release triggers the deployment; you can add environment protection rules to requiressome number of maintainer approvals and such. Docs: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/

You can download the SDist/wheel from any run, now, too.

Fields:

* Workflow name: `cd.yml`
* Environment name: `pypi`
