### PR TITLE
Never ignore URL dependencies in PEP 723 noxfiles

### DIFF
--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -106,6 +106,8 @@ def check_dependencies(dependencies: list[str]) -> bool:
             version = importlib.metadata.version(dep.name)
             if not dep.specifier.contains(version):
                 return False
+        if dep.url:
+            return False
 
     return True
 

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import subprocess
 import sys
+import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -107,9 +108,32 @@ def check_dependencies(dependencies: list[str]) -> bool:
             if not dep.specifier.contains(version):
                 return False
         if dep.url:
-            return False
+            dist = importlib.metadata.distribution(dep.name)
+            if not check_url_dependency(dep.url, dist):
+                return False
 
     return True
+
+
+def check_url_dependency(dep_url: str, dist: importlib.metadata.Distribution) -> bool:
+    """
+    Check to see if a url matches an installed distribution object. Returns false if
+    this is not a clear match.
+    """
+
+    # The .origin property added in Python 3.13
+    origin = getattr(dist, "origin", None)
+    if origin is None:
+        return False
+
+    dep_purl = urllib.parse.urlparse(dep_url)
+
+    if hasattr(origin, "requested_revision"):
+        origin_purl = urllib.parse.urlparse(f"{origin.url}@{origin.requested_revision}")
+    else:
+        origin_purl = urllib.parse.urlparse(origin.url)
+
+    return dep_purl.netloc == origin_purl.netloc and dep_purl.path == origin_purl.path
 
 
 def run_script_mode(

--- a/tests/resources/noxfile_script_mode_url_req.py
+++ b/tests/resources/noxfile_script_mode_url_req.py
@@ -1,0 +1,14 @@
+# /// script
+# dependencies = ["nox @ git+https://github.com/wntrblm/nox.git@2024.10.09"]
+# ///
+
+# The Nox version pinned above should be the second-most-recent version or older.
+
+import importlib.metadata
+
+import nox
+
+
+@nox.session(python=False)
+def example(session: nox.Session) -> None:
+    print(importlib.metadata.version("nox"))

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
+import dataclasses
 import importlib.metadata
 import importlib.util
 import sys
-from pathlib import Path
+import typing
+from types import SimpleNamespace
 
 import packaging.requirements
 import packaging.version
 import pytest
 
 import nox._cli
+
+if typing.TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_get_dependencies() -> None:
@@ -99,3 +106,27 @@ def test_invalid_backend_inline(
 
     with pytest.raises(ValueError, match="Expected venv_backend one of"):
         nox._cli.main()
+
+
+@dataclasses.dataclass
+class FakeDistribution:
+    origin: SimpleNamespace | None
+
+
+def test_url_dependency() -> None:
+    assert nox._cli.check_url_dependency(
+        "https://github.com/a/package",
+        FakeDistribution(origin=SimpleNamespace(url="https://github.com/a/package")),  # type: ignore[arg-type]
+    )
+    assert not nox._cli.check_url_dependency(
+        "https://github.com/a/package",
+        FakeDistribution(origin=None),  # type: ignore[arg-type]
+    )
+    assert nox._cli.check_url_dependency(
+        "https://github.com/a/package@v1.2.3",
+        FakeDistribution(  # type: ignore[arg-type]
+            origin=SimpleNamespace(
+                url="https://github.com/a/package", requested_revision="v1.2.3"
+            )
+        ),
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1065,3 +1065,25 @@ def test_noxfile_no_script_mode() -> None:
     )
     assert job.returncode == 1
     assert "No module named 'cowsay'" in job.stderr
+
+
+def test_noxfile_script_mode_url_req() -> None:
+    job = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nox",
+            "-f",
+            Path(RESOURCES) / "noxfile_script_mode_url_req.py",
+            "-s",
+            "example",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    print(job.stdout)
+    print(job.stderr)
+    assert job.returncode == 0
+    assert job.stdout.rstrip() == "2024.10.9"


### PR DESCRIPTION
Fixes #934.

W.r.t. performance: On uv (the default, if available), uv caches based on the URL. On virtualenv however, the URL will get pulled and built/installed every time.

Ideally, for the virtualenv case, nox would do its own caching on the URL, similar to what the uv backend, `uv run -s noxfile.py` and `pipx run noxfile.py` all do. I have not included that here since I wanted to keep the scope of this PR to the correctness issue. Caching can be added later if needed. URL dependencies in PEP 723 noxfiles are perhaps not a very common case anyway, so perhaps it is TBD whether it's worth it for Nox to build a serialization format for doing said caching?