### PR TITLE
docs: fix parametrized session tagging example

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -442,12 +442,10 @@ More sophisticated tag assignment can be performed by passing a generator to the
                     tags.append("quick")
                 if dependency == "2.0" or database == "sqlite":
                     tags.append("standard")
-                yield nox.param((dependency, database), tags)
+                yield nox.param(dependency, database, tags=tags)
 
     @nox.session
-    @nox.parametrize(
-        ["dependency", "database"], generate_params(),
-    )
+    @nox.parametrize(["dependency", "database"], generate_params())
     def tests(session, dependency, database):
         ...
 


### PR DESCRIPTION
The final example in the "Assigning tags to parametrized sessions" section was using `nox.param()` incorrectly.  Fix by passing the parameter values as positional arguments (rather than as a tuple), and passing the tags as a keyword argument.