### PR TITLE
chore: add our own requirements to conda too

### DIFF
--- a/requirements-conda-test.txt
+++ b/requirements-conda-test.txt
@@ -1,5 +1,7 @@
 argcomplete >=1.9.4,<3.0
+attrs >=23.1
 colorlog >=2.6.1,<7.0.0
+dependency-groups >=1.1
 jinja2
 pytest
 tox>=4.0.0


### PR DESCRIPTION
Notice these were missing, which causes our own noxfile to fail.
