### PR TITLE
fix: use Python 3.12 for action, allow 3.13, drop 3.8 from auto versions

### DIFF
--- a/.github/action_helper.py
+++ b/.github/action_helper.py
@@ -33,7 +33,7 @@ def filter_version(version: str) -> str:
     return ".".join(version_parts[:2])
 
 
-def setup_action(input_: str) -> None:
+def setup_action(input_: str, *, self_version: str = "3.12") -> None:
     versions = [version.strip() for version in input_.split(",") if version.strip()]
 
     pypy_versions = [version for version in versions if version.startswith("pypy")]
@@ -60,15 +60,15 @@ def setup_action(input_: str) -> None:
     # other interpreters also define pythonX.Y symlinks.
     versions = pypy_versions + cpython_versions
 
-    # we want to install python 3.11 last to ease nox set-up
-    if "3.11" in cpython_versions_filtered:
-        index = cpython_versions_filtered.index("3.11")
+    # we want to install our own self version last to ease nox set-up
+    if self_version in cpython_versions_filtered:
+        index = cpython_versions_filtered.index(self_version)
         index = versions.index(cpython_versions[index])
         cpython_nox = versions.pop(index)
         versions.append(cpython_nox)
     else:
         # add this to install nox
-        versions.append("3.11")
+        versions.append(self_version)
 
     print(f"interpreters={json.dumps(versions)}")
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-versions:
     description: "comma-separated list of python versions to install"
     required: false
-    default: "3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+    default: "3.9, 3.10, 3.11, 3.12, 3.13"
 branding:
   icon: package
   color: blue
@@ -15,7 +15,7 @@ runs:
     - uses: actions/setup-python@v5
       id: localpython
       with:
-        python-version: "3.8 - 3.12"
+        python-version: "3.9 - 3.13"
         update-environment: false
 
     - name: "Validate input"

--- a/noxfile.py
+++ b/noxfile.py
@@ -177,7 +177,7 @@ def _check_python_version(session: nox.Session) -> None:
 )
 def github_actions_default_tests(session: nox.Session) -> None:
     """Check default versions installed by the nox GHA Action"""
-    assert sys.version_info[:2] == (3, 11)
+    assert sys.version_info[:2] == (3, 12)
     _check_python_version(session)
 
 

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -48,17 +48,18 @@ VALID_VERSION_LISTS = {
         "3.9",
         "3.10",
         "3.11",
+        "3.12",
     ],
-    "": ["3.11"],
-    "~3.12.0-0": ["~3.12.0-0", "3.11"],
-    "3.11.4": ["3.11.4"],
-    "3.9-dev,pypy3.9-nightly": ["pypy3.9-nightly", "3.9-dev", "3.11"],
-    "3.11, 3.10, 3.9, 3.8": ["3.10", "3.9", "3.8", "3.11"],
+    "": ["3.12"],
+    "~3.12.0-0": ["~3.12.0-0"],
+    "3.11.4": ["3.11.4", "3.12"],
+    "3.9-dev,pypy3.9-nightly": ["pypy3.9-nightly", "3.9-dev", "3.12"],
+    "3.12, 3.11, 3.10, 3.9": ["3.11", "3.10", "3.9", "3.12"],
     ",".join(f"3.{minor}" for minor in range(20)): [
         f"3.{minor}"
-        for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 11)
+        for i, minor in enumerate(minor_ for minor_ in range(20) if minor_ != 12)
     ]
-    + ["3.11"],
+    + ["3.12"],
 }
 
 


### PR DESCRIPTION
See #943.

This bumps the built-in version to 3.12, drops 3.8 from the default list, and adds 3.13 to the potential versions running our script.
