### PR TITLE
uv version is now uv self version

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -108,7 +108,7 @@ def uv_version(uv_bin: str) -> version.Version:
     """Returns uv's version defaulting to 0.0 if uv is not available"""
     try:
         ret = subprocess.run(
-            [uv_bin, "version", "--output-format", "json"],
+            [uv_bin, "self", "version", "--output-format", "json"],
             check=False,
             text=True,
             capture_output=True,

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -751,7 +751,7 @@ def test_find_uv(
 
     def mock_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
-            args=["uv", "version", "--output-format", "json"],
+            args=["uv", "self", "version", "--output-format", "json"],
             stdout=f'{{"version": "{vers}", "commit_info": null}}',
             returncode=vers_rc,
         )
@@ -787,7 +787,7 @@ def test_uv_version(
 ) -> None:
     def mock_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
-            args=["uv", "version", "--output-format", "json"],
+            args=["uv", "self", "version", "--output-format", "json"],
             stdout=stdout,
             returncode=return_code,
         )


### PR DESCRIPTION
Fixes #953

See https://github.com/astral-sh/uv/pull/12349

Note that I have not actually tested it on my previously failing environment from the issue.  Also, the test cases mock the call to uv version, so perhaps it would be worthwhile to add another test case without the mock to make sure uv is found?

Also, this will work with uv >= 0.7.0 but fail for versions before that, so this becomes a breaking change in nox.  Perhaps a maintainer would rather add in the logic to make nox work for uv versions both before and after 0.7.0.  If not, then `"uv>=0.1.6"` in the pyproject.toml file should be updated to `"uv>=0.7.0"`.