### PR TITLE
fix: uv version is now uv self version, support UV

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -103,7 +103,11 @@ def find_uv() -> tuple[bool, str, version.Version]:
 
     # Fall back to PATH.
     uv_vers = uv_version(uv_name or "uv")
-    return uv_on_path is not None and uv_vers > version.Version("0"), "uv", uv_vers
+    return (
+        uv_on_path is not None and uv_vers > version.Version("0"),
+        uv_name or "uv",
+        uv_vers,
+    )
 
 
 def uv_version(uv_bin: str) -> version.Version:

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -751,7 +751,7 @@ def test_find_uv(
 
     def mock_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
-            args=["uv", "version", "--output-format", "json"],
+            args=["uv", "self", "version", "--output-format", "json"],
             stdout=f'{{"version": "{vers}", "commit_info": null}}',
             returncode=vers_rc,
         )
@@ -787,7 +787,7 @@ def test_uv_version(
 ) -> None:
     def mock_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
-            args=["uv", "version", "--output-format", "json"],
+            args=["uv", "self", "version", "--output-format", "json"],
             stdout=stdout,
             returncode=return_code,
         )


### PR DESCRIPTION
We don't support uv 0.7. This fixes it and also supports the UV environment variable, which wasn't something UV had before. (This fixes nested uv calls, uv sets UV when it calls anything)
