### PR TITLE
refactor: use dict instead of OrderedDict

### DIFF
--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -19,7 +19,6 @@ and surfaced in documentation."""
 from __future__ import annotations
 
 import argparse
-import collections
 import functools
 import os
 from argparse import ArgumentError, ArgumentParser, Namespace
@@ -254,10 +253,8 @@ class OptionSet:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.parser_args = args
         self.parser_kwargs = kwargs
-        self.options: collections.OrderedDict[str, Option] = collections.OrderedDict()
-        self.groups: collections.OrderedDict[str, OptionGroup] = (
-            collections.OrderedDict()
-        )
+        self.options: dict[str, Option] = {}
+        self.groups: dict[str, OptionGroup] = {}
 
     def add_options(self, *args: Option) -> None:
         """Adds a sequence of Options to the OptionSet.

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import itertools
-from collections import OrderedDict
 from typing import Hashable, Iterable, Iterator, Mapping, TypeVar
 
 __all__ = ["CycleError", "lazy_stable_topo_sort"]
@@ -130,7 +129,7 @@ def lazy_stable_topo_sort(
 
     def prepended_by_dependencies(
         node: Node,
-        walk: OrderedDict[Node, None] | None = None,
+        walk: dict[Node, None] | None = None,
     ) -> Iterator[Node]:
         """Yields a node's dependencies depth-first, followed by the node itself.
 
@@ -142,10 +141,10 @@ def lazy_stable_topo_sort(
         Args:
             node (~nox._resolver.Node):
                 A node in the dependency graph.
-            walk (OrderedDict[~nox._resolver.Node, None] | None):
-                An ``OrderedDict`` whose keys are the nodes traversed when walking a
+            walk (dict[~nox._resolver.Node, None] | None):
+                An ordered ``dict`` whose keys are the nodes traversed when walking a
                 path leading up to ``node`` on the reversed-edge dependency graph.
-                Defaults to ``OrderedDict()``.
+                Defaults to ``{}``.
 
         Yields:
             ~nox._resolver.Node: ``node``'s direct dependencies, each
@@ -159,9 +158,9 @@ def lazy_stable_topo_sort(
         # We would like for ``walk`` to be an ordered set so that we get (a) O(1) ``node
         # in walk`` and (b) so that we can use the order to report to the user what the
         # dependency cycle is, if one is encountered. The standard library does not have
-        # an ordered set type, so we instead use the keys of an ``OrderedDict[Node,
-        # None]`` as an ordered set.
-        walk = walk or OrderedDict()
+        # an ordered set type, so we instead use the keys of an ``dict[Node, None]`` as
+        # an ordered set.
+        walk = walk or {}
         walk = extend_walk(walk, node)
         if not visited[node]:
             visited[node] = True
@@ -175,19 +174,17 @@ def lazy_stable_topo_sort(
         else:
             return
 
-    def extend_walk(
-        walk: OrderedDict[Node, None], node: Node
-    ) -> OrderedDict[Node, None]:
+    def extend_walk(walk: dict[Node, None], node: Node) -> dict[Node, None]:
         """Extend a walk by a node, checking for dependency cycles.
 
         Args:
-            walk (OrderedDict[~nox._resolver.Node, None]):
+            walk (dict[~nox._resolver.Node, None]):
                 See ``prepended_by_dependencies``.
             nodes (~nox._resolver.Node):
                 A node to extend the walk with.
 
         Returns:
-            OrderedDict[~nox._resolver.Node, None]: ``walk``, extended by
+            dict[~nox._resolver.Node, None]: ``walk``, extended by
             ``node``.
 
         Raises:

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import ast
 import itertools
 import operator
-from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from nox._decorators import Call, Func
@@ -40,7 +39,7 @@ WARN_PYTHONS_IGNORED = "python_ignored"
 
 def _unique_list(*args: str) -> list[str]:
     """Return a list without duplicates, while preserving order."""
-    return list(OrderedDict.fromkeys(args))
+    return list(dict.fromkeys(args))
 
 
 class Manifest:

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import collections
 import copy
 import functools
 from typing import TYPE_CHECKING, Any, Callable, overload
@@ -35,7 +34,7 @@ def __dir__() -> list[str]:
 
 RawFunc = Callable[..., Any]
 
-_REGISTRY: collections.OrderedDict[str, Func] = collections.OrderedDict()
+_REGISTRY: dict[str, Func] = {}
 
 
 @overload
@@ -122,7 +121,7 @@ def session_decorator(
     return fn
 
 
-def get() -> collections.OrderedDict[str, Func]:
+def get() -> dict[str, Func]:
     """Return a shallow copy of the registry.
 
     This ensures that the registry is not accidentally modified by

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import collections
 import typing
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
@@ -37,8 +36,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-def create_mock_sessions() -> collections.OrderedDict[str, mock.Mock]:
-    sessions = collections.OrderedDict()
+def create_mock_sessions() -> dict[str, mock.Mock]:
+    sessions = {}
     sessions["foo"] = mock.Mock(spec=(), python=None, venv_backend=None, tags=["baz"])
     sessions["bar"] = mock.Mock(
         spec=(),


### PR DESCRIPTION
Part of the language officially since 3.7 (unofficially 3.6).
