### PR TITLE
tests: run in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Install Nox-under-test (uv)
         run:  uv pip install --system .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --session "tests-${{ matrix.python-version }}" -- --full-trace
+        run: nox --session "tests-${{ matrix.python-version }}" -- --durations=10
       - name: Run min-version tests on ${{ matrix.os }}
-        run: nox --session minimums --force-python="${{ matrix.python-version }}" -- --full-trace
+        run: nox --session minimums --force-python="${{ matrix.python-version }}" -- --durations=10
       - name: Run Conda tests
         if: matrix.python-version == '3.14'
-        run: nox --session "conda_tests" -- --full-trace
+        run: nox --session "conda_tests" -- --durations=5
       - name: Save coverage report
         uses: actions/upload-artifact@v7
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ def tests(session: nox.Session) -> None:
         "PYTHONWARNDEFAULTENCODING": "1",
         "COVERAGE_FILE": coverage_file,
     }
+    parallel = [] if sys.platform.startswith("win32") else ["--numprocesses=auto"]
 
     session.create_tmp()  # Fixes permission errors on Windows
     session.install(*PYPROJECT["dependency-groups"]["test"], "uv")
@@ -57,7 +58,7 @@ def tests(session: nox.Session) -> None:
         "run",
         "-m",
         "pytest",
-        "--numprocesses=auto",
+        *parallel,
         "-m",
         "not conda",
         *session.posargs,

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,7 +43,7 @@ ALL_PYTHONS = nox.project.python_versions(PYPROJECT)
 def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
 
-    coverage_file = f".coverage.{sys.platform}.{session.python}"
+    coverage_file = f".coverage.pypi.{sys.platform}.{session.python}"
 
     session.create_tmp()  # Fixes permission errors on Windows
     session.install(*PYPROJECT["dependency-groups"]["test"], "uv")
@@ -55,10 +55,13 @@ def tests(session: nox.Session) -> None:
         "--cov-config",
         "pyproject.toml",
         "--cov-report=",
+        "--numprocesses=auto",
+        "-m",
+        "not conda",
         *session.posargs,
         env={
+            "PYTHONWARNDEFAULTENCODING": "1",
             "COVERAGE_FILE": coverage_file,
-            **extra_env,
         },
     )
 
@@ -78,9 +81,11 @@ def minimums(session: nox.Session) -> None:
     session.run("pytest", *session.posargs)
 
 
-@nox.session(venv_backend="conda", default=bool(shutil.which("conda")))
-def conda_tests(session: nox.Session) -> None:
-    """Run test suite set up with conda."""
+def xonda_tests(session: nox.Session, xonda: str) -> None:
+    """Run test suite set up with conda/mamba/etc."""
+
+    coverage_file = f".coverage.{xonda}.{sys.platform}.{session.python}"
+
     session.conda_install(
         "--file", "requirements-conda-test.txt", channel="conda-forge"
     )
@@ -88,32 +93,35 @@ def conda_tests(session: nox.Session) -> None:
     # Currently, this doesn't work on Windows either with or without quoting
     if not sys.platform.startswith("win32"):
         session.conda_install("requests<99")
-    session.run("pytest", *session.posargs)
+    session.run(
+        "pytest",
+        "--cov",
+        "--cov-config",
+        "pyproject.toml",
+        "--cov-report=",
+        "-m",
+        "conda",
+        *session.posargs,
+        env={"COVERAGE_FILE": coverage_file},
+    )
+
+
+@nox.session(venv_backend="conda", default=bool(shutil.which("conda")))
+def conda_tests(session: nox.Session) -> None:
+    """Run test suite set up with conda."""
+    xonda_tests(session, "conda")
 
 
 @nox.session(venv_backend="mamba", default=shutil.which("mamba"))
 def mamba_tests(session: nox.Session) -> None:
     """Run test suite set up with mamba."""
-    session.conda_install(
-        "--file", "requirements-conda-test.txt", channel="conda-forge"
-    )
-    session.install("-e.", "--no-deps")
-    if not sys.platform.startswith("win32"):
-        session.conda_install("requests<99")
-    session.run("pytest", *session.posargs)
+    xonda_tests(session, "mamba")
 
 
 @nox.session(venv_backend="micromamba", default=shutil.which("micromamba"))
 def micromamba_tests(session: nox.Session) -> None:
     """Run test suite set up with micromamba."""
-    session.conda_install(
-        "--file", "requirements-conda-test.txt", channel="conda-forge"
-    )
-    # Currently, this doesn't work on Windows either with or without quoting
-    session.install("-e.", "--no-deps")
-    if not sys.platform.startswith("win32"):
-        session.conda_install("requests<99")
-    session.run("pytest", *session.posargs)
+    xonda_tests(session, "micromamba")
 
 
 @nox.session(default=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,11 +21,9 @@
 
 from __future__ import annotations
 
-import contextlib
 import functools
 import os
 import shutil
-import sqlite3
 import sys
 
 import nox
@@ -44,31 +42,34 @@ def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
 
     coverage_file = f".coverage.pypi.{sys.platform}.{session.python}"
+    env = {
+        "PYTHONWARNDEFAULTENCODING": "1",
+        "COVERAGE_FILE": coverage_file,
+    }
 
     session.create_tmp()  # Fixes permission errors on Windows
     session.install(*PYPROJECT["dependency-groups"]["test"], "uv")
     session.install("-e.[tox-to-nox,pbs]")
     extra_env = {"PYTHONWARNDEFAULTENCODING": "1"}
+    session.run("coverage", "erase", env=env)
     session.run(
+        "coverage",
+        "run",
+        "-m",
         "pytest",
-        "--cov",
-        "--cov-config",
-        "pyproject.toml",
-        "--cov-report=",
         "--numprocesses=auto",
         "-m",
         "not conda",
         *session.posargs,
-        env={
-            "PYTHONWARNDEFAULTENCODING": "1",
-            "COVERAGE_FILE": coverage_file,
-        },
+        env=env,
     )
+    session.run("coverage", "combine", env=env)
+    session.run("coverage", "report", env=env)
 
-    if sys.platform.startswith("win"):
-        with contextlib.closing(sqlite3.connect(coverage_file)) as con, con:
-            con.execute("UPDATE file SET path = REPLACE(path, '\\', '/')")
-            con.execute("DELETE FROM file WHERE SUBSTR(path, 2, 1) == ':'")
+    # if sys.platform.startswith("win"):
+    #    with contextlib.closing(sqlite3.connect(coverage_file)) as con, con:
+    #        con.execute("UPDATE file SET path = REPLACE(path, '\\', '/')")
+    #        con.execute("DELETE FROM file WHERE SUBSTR(path, 2, 1) == ':'")
 
 
 @nox.session(venv_backend="uv", default=False)
@@ -85,6 +86,7 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     """Run test suite set up with conda/mamba/etc."""
 
     coverage_file = f".coverage.{xonda}.{sys.platform}.{session.python}"
+    env = {"COVERAGE_FILE": coverage_file}
 
     session.conda_install(
         "--file", "requirements-conda-test.txt", channel="conda-forge"
@@ -93,17 +95,20 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     # Currently, this doesn't work on Windows either with or without quoting
     if not sys.platform.startswith("win32"):
         session.conda_install("requests<99")
+
+    session.run("coverage", "erase", env=env)
     session.run(
+        "coverage",
+        "run",
+        "-m",
         "pytest",
-        "--cov",
-        "--cov-config",
-        "pyproject.toml",
-        "--cov-report=",
         "-m",
         "conda",
         *session.posargs,
-        env={"COVERAGE_FILE": coverage_file},
+        env=env,
     )
+    session.run("coverage", "combine", env=env)
+    session.run("coverage", "report", env=env)
 
 
 @nox.session(venv_backend="conda", default=bool(shutil.which("conda")))

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,6 @@ def tests(session: nox.Session) -> None:
     session.create_tmp()  # Fixes permission errors on Windows
     session.install(*PYPROJECT["dependency-groups"]["test"], "uv")
     session.install("-e.[tox-to-nox,pbs]")
-    extra_env = {"PYTHONWARNDEFAULTENCODING": "1"}
     session.run("coverage", "erase", env=env)
     session.run(
         "coverage",
@@ -67,11 +66,6 @@ def tests(session: nox.Session) -> None:
     session.run("coverage", "combine", env=env)
     session.run("coverage", "report", env=env)
 
-    # if sys.platform.startswith("win"):
-    #    with contextlib.closing(sqlite3.connect(coverage_file)) as con, con:
-    #        con.execute("UPDATE file SET path = REPLACE(path, '\\', '/')")
-    #        con.execute("DELETE FROM file WHERE SUBSTR(path, 2, 1) == ':'")
-
 
 @nox.session(venv_backend="uv", default=False)
 def minimums(session: nox.Session) -> None:
@@ -80,7 +74,7 @@ def minimums(session: nox.Session) -> None:
 
     session.install("-e.", "--group=test", "--resolution=lowest-direct")
     session.run("uv", "pip", "list")
-    session.run("pytest", *session.posargs)
+    session.run("pytest", "-m", "not conda", *session.posargs)
 
 
 def xonda_tests(session: nox.Session, xonda: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ test = [
   "coverage[toml]>=7.10.3",
   "pytest>=7.4; python_version>='3.12'",
   "pytest>=7; python_version<'3.12'",
-  "pytest-cov>=3",
   "pytest-xdist>=3",
 ]
 docs = [
@@ -135,7 +134,7 @@ run.core = "sysmon"
 run.branch = true
 run.patch = [ "subprocess" ]
 run.relative_files = true
-run.source_pkgs = [ "nox" ]
+run.source_dirs = [ "nox" ]
 run.disable_warnings = [
   "no-sysmon",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = [
   "pytest>=7.4; python_version>='3.12'",
   "pytest>=7; python_version<'3.12'",
   "pytest-cov>=3",
+  "pytest-xdist>=3",
 ]
 docs = [
   "docutils<0.22",    # Waiting for sphinx-tabs release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ run.core = "sysmon"
 run.branch = true
 run.patch = [ "subprocess" ]
 run.relative_files = true
-run.source_dirs = [ "nox" ]
+run.source_pkgs = [ "nox" ]
 run.disable_warnings = [
   "no-sysmon",
 ]

--- a/requirements-conda-test.txt
+++ b/requirements-conda-test.txt
@@ -8,6 +8,7 @@ humanize
 jinja2
 pbs-installer>=2025.1.6
 pytest
+pytest-xdist
 tox>=4.0.0
 virtualenv >=20.14.1
 zstandard


### PR DESCRIPTION
You can run in serial with `-- -n0`.

Nice little timesave in CI, but have to make sure tests are isolated (such as ones that fight for making a `.nox` dir in the same place).

For some reason, this seems to sometimes corrupt coverage. Needs to be reliable before we can merge.