### PR TITLE
Recommend `--locked` over `--frozen` for `uv sync`

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -140,7 +140,7 @@ If you use a tool like ``uv`` to lock your dependencies, you can use that inside
         session.run("pytest", *session.posargs)
 
 
-Here we run ``uv sync`` on the nox virtual environment. Other useful flags might include ``--frozen`` (won't touch the lockfile) and ``--inexact`` (will allow you to install other packages as well).
+Here we run ``uv sync`` on the nox virtual environment. Other useful flags might include ``--locked`` (validate lockfile is up-to-date) and ``--inexact`` (will allow you to install other packages as well).
 
 
 Generating a matrix with GitHub Actions


### PR DESCRIPTION
This tracks upstream recommendations

- https://github.com/astral-sh/uv/pull/12818
- https://github.com/astral-sh/uv/pull/12819

To be honest, I actually think that we should put `--locked` into the default code example above this paragraph. An out-of-date lockfile is something you almost always want to catch in CI or locally with a tool like Nox.

@henryiii what do you think?

For now, this PR takes the more conservative change of simply recommending `--locked` over `--frozen`.