### PR TITLE
feat: color help on 3.14+ and suggestions, plus no abbrev

### DIFF
--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import functools
 import os
+import sys
 from argparse import ArgumentError, ArgumentParser, Namespace
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Literal
@@ -280,7 +281,12 @@ class OptionSet:
         Generally, you won't use this directly. Instead, use
         :func:`parse_args`.
         """
-        parser = argparse.ArgumentParser(*self.parser_args, **self.parser_kwargs)
+        parser_kwargs = {"allow_abbrev": False, **self.parser_kwargs}
+        if sys.version_info >= (3, 14):
+            parser_kwargs["color"] = True
+            parser_kwargs["suggest_on_error"] = True
+
+        parser = argparse.ArgumentParser(*self.parser_args, **parser_kwargs)
 
         groups = {
             name: parser.add_argument_group(*option_group.args, **option_group.kwargs)

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import os
 import re
 import sys
@@ -68,7 +69,10 @@ def write_output_to_file(output: str, filename: str) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Converts toxfiles to noxfiles.")
+    make_parser = functools.partial(argparse.ArgumentParser, allow_abbrev=False)
+    if sys.version_info >= (3, 14):
+        make_parser = functools.partial(make_parser, color=True, suggest_on_error=True)
+    parser = make_parser(description="Converts toxfiles to noxfiles.")
     parser.add_argument("--output", default="noxfile.py")
 
     args = parser.parse_args()


### PR DESCRIPTION
This makes `--help` colorized on Python 3.14+. "Did you mean" suggestions are also added.

For all Pythons, abbreviations have been disabled. This is generally error prone, so I think it's better to avoid it. It works properly on 3.8+ (it causes some issues before that).
