### PR TITLE
fix: hide new coverage warning on 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,9 @@ pythonpath = [ ".github/" ]
 run.branch = true
 run.relative_files = true
 run.source_pkgs = [ "nox" ]
+run.disable_warnings = [
+  "no-ctracer",
+]
 report.exclude_also = [
   "@overload",
   "def __dir__()",


### PR DESCRIPTION
Fix for https://github.com/nedbat/coveragepy/issues/1983.
