### PR TITLE
fix: let uv replace the directory instead of deleting it ourselves

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -92,7 +92,7 @@ def _remove_readonly(func: Callable[[str], None], path: str, _: object) -> None:
 
 
 def _rmtree(path: str) -> None:
-    with contextlib.suppress(FileNotFoundError):
+    with contextlib.suppress(FileNotFoundError, OSError):
         if sys.version_info >= (3, 12):
             shutil.rmtree(path, onexc=_remove_readonly)
         else:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -21,7 +21,6 @@ import json
 import os
 import re
 import shutil
-import stat
 import subprocess
 import sys
 import sysconfig
@@ -81,22 +80,6 @@ _BLACKLISTED_ENV_VARS = frozenset(
         "UV_PYTHON",
     ]
 )
-
-
-def _remove_readonly(func: Callable[[str], None], path: str, _: object) -> None:
-    os.chmod(path, stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
-    try:
-        func(path)
-    except PermissionError:
-        logger.warning("PermissionError on %s", path)
-
-
-def _rmtree(path: str) -> None:
-    with contextlib.suppress(FileNotFoundError, OSError):
-        if sys.version_info >= (3, 12):
-            shutil.rmtree(path, onexc=_remove_readonly)
-        else:
-            shutil.rmtree(path, onerror=_remove_readonly)
 
 
 def find_uv() -> tuple[bool, str, version.Version]:
@@ -388,7 +371,7 @@ class CondaEnv(ProcessEnv):
             if self.reuse_existing and is_conda:
                 return False
             if not is_conda:
-                _rmtree(self.location)
+                shutil.rmtree(self.location, ignore_errors=True)
             else:
                 cmd = [
                     self.conda_cmd,
@@ -400,7 +383,7 @@ class CondaEnv(ProcessEnv):
                 ]
                 nox.command.run(cmd, silent=True, log=False)
             # Make sure that location is clean
-            _rmtree(self.location)
+            shutil.rmtree(self.location, ignore_errors=True)
 
         return True
 
@@ -532,7 +515,9 @@ class VirtualEnv(ProcessEnv):
                 and self._check_reused_environment_interpreter()
             ):
                 return False
-            _rmtree(self.location)
+            # uv clears it for us, and it balks at files left around
+            if self.venv_backend != "uv":
+                shutil.rmtree(self.location, ignore_errors=True)
         return True
 
     def _read_pyvenv_cfg(self) -> dict[str, str] | None:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -84,12 +84,12 @@ _BLACKLISTED_ENV_VARS = frozenset(
 
 
 def _remove_readonly(func: Callable[[str], None], path: str, _: object) -> None:
-    os.chmod(path, stat.S_IWRITE)
+    os.chmod(path, stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
     func(path)
 
 
 def _rmtree(path: str) -> None:
-    if Path(path).exists():
+    with contextlib.suppress(FileNotFoundError):
         if sys.version_info >= (3, 12):
             shutil.rmtree(path, onexc=_remove_readonly)
         else:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -89,11 +89,15 @@ def _remove_readonly(func: Callable[[str], None], path: str, _: object) -> None:
 
 
 def _rmtree(path: str) -> None:
-    with contextlib.suppress(FileNotFoundError):
+    try:
         if sys.version_info >= (3, 12):
             shutil.rmtree(path, onexc=_remove_readonly)
         else:
             shutil.rmtree(path, onerror=_remove_readonly)
+    except FileNotFoundError:
+        pass
+    except PermissionError:
+        logger.warn("PermissionError on %s", path)
 
 
 def find_uv() -> tuple[bool, str, version.Version]:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -88,10 +88,7 @@ def _remove_readonly(func: Callable[[str], None], path: str, _: object) -> None:
     try:
         func(path)
     except PermissionError:
-        if os.path.isfile(path) or os.path.islink(path):
-            os.remove(path)
-        else:
-            logger.warn("PermissionError on %s", path)
+        logger.warning("PermissionError on %s", path)
 
 
 def _rmtree(path: str) -> None:

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -304,6 +304,9 @@ def test_uv_creation(
     venv.create()
     assert venv._check_reused_environment_type()
 
+    venv.create()
+    assert venv._check_reused_environment_type()
+
 
 @has_uv
 def test_uv_managed_python(


### PR DESCRIPTION
We can't get rid of Conda-trash files on Windows, so let uv delete it. Might be faster too. It complains if you give it a non-empty directory without a `pyvenv.cfg` file in it.