### PR TITLE
Add `--script` to `uv run` inline metadata for nox-uv example

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -147,7 +147,7 @@ By default, ``nox-uv`` also validates that the lockfile is up-to-date.
 
 .. code-block:: python
 
-    #!/usr/bin/env -S uv run --script -q
+    #!/usr/bin/env -S uv run --script --quiet
 
     # /// script
     # dependencies = ["nox", "nox-uv"]


### PR DESCRIPTION
@henryiii Would you agree it's best practice to explicitly add the `--script` flag to the `uv run` shebang for a `noxfile.py`? To me this seems like a good best practice. Did you happen to have an explicit reason for not using `--script`, or would you accept including it?

Example reference

- https://thisdavej.com/share-python-scripts-like-a-pro-uv-and-pep-723-for-easy-deployment/#linuxmacos-users