### PR TITLE
CI ensure there are no duplicate log handlers

### DIFF
--- a/nox/logger.py
+++ b/nox/logger.py
@@ -132,8 +132,20 @@ def setup_logging(
         root_logger.setLevel(OUTPUT)
     else:
         root_logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
 
+    active_handlers = [
+        handler
+        for handler in root_logger.handlers
+        if handler.get_name() == "nox-stream-handler"
+    ]
+    for handler in active_handlers:
+        # Avoid duplicate handlers by removing all we've previously created
+        # this causes trouble in tests where setup_logging is called multiple
+        # times
+        root_logger.removeHandler(handler)
+
+    handler = logging.StreamHandler()
+    handler.set_name("nox-stream-handler")
     handler.setFormatter(_get_formatter(color=color, add_timestamp=add_timestamp))
     root_logger.addHandler(handler)
 


### PR DESCRIPTION
related: https://github.com/wntrblm/nox/pull/989#issuecomment-3054366659

nox tests run setup_logging() multiple times in a session and we end up with multiple duplicate handlers, some of which are already closed, fail and try to log the error, creating a cascade of logs

The change is making sure we get rid of our own handler before creating a new one
