### PR TITLE
fix: support scripts with custom names

### DIFF
--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -21,7 +21,7 @@ control to :meth:``nox.workflow.execute``.
 
 from __future__ import annotations  # pragma: no cover
 
-from nox._cli import main  # pragma: no cover
+from nox._cli import nox_main as main  # pragma: no cover
 
 __all__ = ["main"]  # pragma: no cover
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -42,6 +42,11 @@ def __dir__() -> list[str]:
     return __all__
 
 
+# User-specified arguments will be a regular string
+class DefaultStr(str):
+    __slots__ = ()
+
+
 ReuseVenvType = Literal["no", "yes", "never", "always"]
 
 options = _option_set.OptionSet(
@@ -515,7 +520,7 @@ options.add_options(
         "-f",
         "--noxfile",
         group=options.groups["general"],
-        default="noxfile.py",
+        default=DefaultStr("noxfile.py"),
         help="Location of the Python file containing Nox sessions.",
     ),
     _option_set.Option(

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -68,7 +68,7 @@ def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
         types.ModuleType: The initialised Nox module.
     """
     spec = importlib.util.spec_from_file_location(
-        "user_nox_module", global_config.noxfile
+        "user_nox_module", str(global_config.noxfile)
     )
     assert spec is not None  # If None, fatal importlib error, would crash anyway
 
@@ -107,8 +107,9 @@ def load_nox_module(global_config: Namespace) -> types.ModuleType | int:
     # Save the absolute path to the Noxfile.
     # This will inoculate it if Nox changes paths because of an implicit
     # or explicit chdir (like the one below).
-    global_config.noxfile = os.path.join(
-        noxfile_parent_dir, os.path.basename(global_config_noxfile)
+    # Keeps the class of the original string
+    global_config.noxfile = global_config.noxfile.__class__(
+        os.path.join(noxfile_parent_dir, os.path.basename(global_config_noxfile))
     )
 
     try:

--- a/tests/resources/noxfile_script_mode_exec.py
+++ b/tests/resources/noxfile_script_mode_exec.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# /// script
+# dependencies = ["nox", "cowsay"]
+# ///
+
+
+import nox
+
+
+@nox.session
+def exec_example(session: nox.Session) -> None:
+    # Importing inside the function so that if the test fails,
+    # it shows a better failure than immediately failing to import
+    import cowsay  # noqa: PLC0415
+
+    print(cowsay.cow("another_world"))
+
+
+if __name__ == "__main__":
+    nox.main()

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -87,6 +87,8 @@ def test_invalid_backend_envvar(
 ) -> None:
     monkeypatch.setenv("NOX_SCRIPT_VENV_BACKEND", "invalid")
     monkeypatch.setattr(sys, "argv", ["nox"])
+    # This will return pytest's filename instead, so patching it to None
+    monkeypatch.setattr(nox._cli, "get_main_filename", lambda: None)
     monkeypatch.chdir(tmp_path)
     tmp_path.joinpath("noxfile.py").write_text(
         "# /// script\n# dependencies=['nox', 'invalid']\n# ///",
@@ -101,6 +103,8 @@ def test_invalid_backend_inline(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["nox"])
+    # This will return pytest's filename instead, so patching it to None
+    monkeypatch.setattr(nox._cli, "get_main_filename", lambda: None)
     monkeypatch.chdir(tmp_path)
     tmp_path.joinpath("noxfile.py").write_text(
         "# /// script\n# dependencies=['nox', 'invalid']\n# tool.nox.script-venv-backend = 'invalid'\n# ///",


### PR DESCRIPTION
Close #1005. Was rather tricky since we need to detect if the noxfile option is passed.

Changes:

* Detect if the `noxfile` option was overridden (by making the default an instance of a custom class).
* Look for the `__main__` module's name if a noxfile isn't passed.
* Split `main` and `nox_main` - this is so nox's own entry point doesn't do the main-script search, while the user-called one does. I thought this was better than exposing the option to control this.