### PR TITLE
chore: remove docs from default dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ scripts.tox-to-nox = "nox.tox_to_nox:main"
 
 [dependency-groups]
 dev = [
-  { include-group = "docs" },
   { include-group = "test" },
 ]
 test = [


### PR DESCRIPTION
This slows down `uv run`, especially on 3.14, where it has to build two packages, and one of them requires a custom environment variable to get PyO3 to build on 3.14. Better to just make docs opt in, since most people are `uv run`'ing pytest, not needing docs, or using nox to build the docs (the uv command is much more involved for docs, and you can add `--group=docs` in that case).
