### PR TITLE
fix: avoid warnings when running in script mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ target/
 
 # Standard venv location
 .venv
+
+# Lockfiles
+uv.lock
+*pylock.toml

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -29,6 +29,7 @@ import packaging.requirements
 import packaging.utils
 
 import nox.command
+import nox.registry
 import nox.virtualenv
 from nox import _options, tasks, workflow
 from nox._options import DefaultStr
@@ -270,6 +271,7 @@ def _main(*, main_ep: bool) -> None:
                     download_python=download_python,
                 )
 
+    nox.registry.reset()
     exit_code = execute_workflow(args)
 
     # Done; exit.

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from ._typing import Python
 
-__all__ = ["get", "session_decorator"]
+__all__ = ["get", "reset", "session_decorator"]
 
 
 def __dir__() -> list[str]:
@@ -36,6 +36,10 @@ def __dir__() -> list[str]:
 RawFunc = Callable[..., Any]
 
 _REGISTRY: dict[str, Func] = {}
+
+
+def reset() -> None:
+    _REGISTRY.clear()
 
 
 @overload

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env -S uv run --script
+
 # Copyright 2016 Alethea Katherine Flowers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# /// script
+# dependencies = ["nox>=2025.02.09"]
+# ///
 
 
 from __future__ import annotations
@@ -26,16 +32,11 @@ import nox
 
 ON_WINDOWS_CI = "CI" in os.environ and sys.platform.startswith("win32")
 
-nox.needs_version = ">=2024.4.15"
+nox.needs_version = ">=2025.02.09"
 nox.options.default_venv_backend = "uv|virtualenv"
 
 PYPROJECT = nox.project.load_toml("pyproject.toml")
-
-ALL_PYTHONS = [
-    c.split()[-1]
-    for c in PYPROJECT["project"]["classifiers"]
-    if c.startswith("Programming Language :: Python :: 3.")
-]
+ALL_PYTHONS = nox.project.python_versions(PYPROJECT)
 
 
 @nox.session(python=ALL_PYTHONS)
@@ -189,7 +190,7 @@ def _check_python_version(session: nox.Session) -> None:
 @nox.session(
     python=[
         *ALL_PYTHONS,
-        "pypy-3.10",
+        "pypy-3.11",
     ],
     default=False,
 )
@@ -205,9 +206,14 @@ def github_actions_default_tests(session: nox.Session) -> None:
         "pypy3.8",
         "pypy3.9",
         "pypy3.10",
+        "pypy3.11",
     ],
     default=False,
 )
 def github_actions_all_tests(session: nox.Session) -> None:
     """Check all versions installed by the nox GHA Action"""
     _check_python_version(session)
+
+
+if __name__ == "__main__":
+    nox.main()


### PR DESCRIPTION
Fix #1024.

Like before, files run twice, once with `__main__`.