### PR TITLE
fix(typing): install env was typed differently

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -775,7 +775,7 @@ class Session:
     def install(
         self,
         *args: str,
-        env: Mapping[str, str] | None = None,
+        env: Mapping[str, str | None] | None = None,
         include_outer_env: bool = True,
         silent: bool | None = None,
         success_codes: Iterable[int] | None = None,


### PR DESCRIPTION
I think this was just an oversight, since it seems to pass mypy with the change. Fix #1027.
