### PR TITLE
ci: use last intel macOS image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             python-version: "3.9"
           - os: ubuntu-22.04
             python-version: "3.11"
-          - os: macos-13
+          - os: macos-15-intel
             python-version: "3.12"
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
macos-13 is going away.
