### PR TITLE
feat: drop Python 3.9

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -31,9 +31,9 @@ body:
       label: Environment
       description: |
         examples:
-          - **OS**: Ubuntu 20.04
-          - **Python**: 3.9.7
-          - **Nox**: 0.14.2
+          - **OS**: Ubuntu 24.04
+          - **Python**: 3.14.3
+          - **Nox**: 2026.04.10
       value: |
         - OS:
         - Python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
-          - "3.9"
-          - "3.11"
+          - "3.10"
+          - "3.12"
           - "3.14"
         include:
           - os: ubuntu-22.04
-            python-version: "3.9"
-          - os: ubuntu-22.04
             python-version: "3.11"
+          - os: ubuntu-22.04
+            python-version: "3.13"
           - os: macos-15-intel
             python-version: "3.12"
     steps:
@@ -41,8 +41,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: |
-            3.9
             3.10
+            3.11
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       id: localpython
       with:
-        python-version: "3.9 - 3.14"
+        python-version: "3.10 - 3.14"
         update-environment: false
 
     - name: "Validate input"

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -114,8 +114,8 @@ You can tell Nox to use a different Python interpreter/version by specifying the
 .. note::
 
     The Python binaries on Windows are found via the Python `Launcher`_ for
-    Windows (``py``). For example, Python 3.9 can be found by determining which
-    executable is invoked by ``py -3.9``. If a given test needs to use the 32-bit
+    Windows (``py``). For example, Python 3.10 can be found by determining which
+    executable is invoked by ``py -3.10``. If a given test needs to use the 32-bit
     version of a given Python, then ``X.Y-32`` should be used as the version.
 
     .. _Launcher: https://docs.python.org/3/using/windows.html#python-launcher-for-windows
@@ -142,7 +142,7 @@ When collecting your sessions, Nox will create a separate session for each inter
 
 .. code-block:: python
 
-    @nox.session(python=['2.7', '3.6', '3.7', '3.8', '3.9'])
+    @nox.session(python=['3.10', '3.11', '3.12', '3.13', '3.14'])
     def tests(session):
         pass
 
@@ -150,11 +150,11 @@ Will produce these sessions:
 
 .. code-block:: console
 
-    * tests-2.7
-    * tests-3.6
-    * tests-3.7
-    * tests-3.8
-    * tests-3.9
+    * tests-3.10
+    * tests-3.11
+    * tests-3.12
+    * tests-3.13
+    * tests-3.14
 
 Note that this expansion happens *before* parameterization occurs, so you can still parametrize sessions with multiple interpreters.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -245,11 +245,11 @@ In addition to Nox supporting executing single sessions, it also supports runnin
 
    .. code-tab:: console CLI options
 
-         nox --extra-pythons 3.8 3.9 3.10
+         nox --extra-pythons 3.12 3.13 3.14
 
    .. code-tab:: console Environment variables
 
-         NOXEXTRAPYTHON=3.8,3.9,3.10 nox
+         NOXEXTRAPYTHON=3.12,3.13,3.14 nox
 
 
 This will, in addition to specified Python versions in the Noxfile, also create sessions for the specified versions.

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -18,7 +18,8 @@ import copy
 import functools
 import inspect
 import types
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -47,7 +47,7 @@ def __dir__() -> list[str]:
 
 
 av_opt_str = av.optional(av.instance_of(str))
-av_opt_path = av.optional(av.or_(av.instance_of(str), av.instance_of(os.PathLike)))
+av_opt_path = av.optional(av.or_(av.instance_of(str), av.instance_of(os.PathLike)))  # type: ignore[type-abstract]
 av_opt_list_str = av.optional(
     av.deep_iterable(
         member_validator=av.instance_of(str),

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -21,7 +21,7 @@ import functools
 import itertools
 import os
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import argcomplete
 
@@ -30,7 +30,7 @@ from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 from nox.virtualenv import ALL_VENVS
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 
     from nox._option_set import NoxOptions
 

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import functools
 import itertools
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -64,7 +64,7 @@ class Param:
 
     @property
     def call_spec(self) -> dict[str, Any]:
-        return dict(zip(self.arg_names, self.args))
+        return dict(zip(self.arg_names, self.args, strict=True))
 
     def __str__(self) -> str:
         if self.id:
@@ -96,7 +96,7 @@ class Param:
                 and self.tags == other.tags
             )
         if isinstance(other, dict):
-            return dict(zip(self.arg_names, self.args)) == other
+            return dict(zip(self.arg_names, self.args, strict=True)) == other
 
         return NotImplemented
 
@@ -108,7 +108,7 @@ def _apply_param_specs(param_specs: Iterable[Param], f: Any) -> Any:
     return f
 
 
-ArgValue = Union[Param, Iterable[Any]]
+ArgValue = Param | Iterable[Any]
 
 
 def parametrize_decorator(

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Union
 
 __all__ = ["Python"]
 
@@ -24,4 +23,4 @@ def __dir__() -> list[str]:
     return __all__
 
 
-Python = Union[str, Sequence[str], bool, None]
+Python = str | Sequence[str] | bool | None

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -41,27 +41,23 @@ def get_nox_version() -> str:
     return metadata.version("nox")
 
 
-def _parse_string_constant(node: ast.AST) -> str | None:  # pragma: no cover
-    """Return the value of a string constant."""
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value
-    return None
-
-
 def _parse_needs_version(source: str, filename: str = "<unknown>") -> str | None:
     """Parse ``nox.needs_version`` from the user's Noxfile."""
     value: str | None = None
     module: ast.Module = ast.parse(source, filename=filename)
     for statement in module.body:
-        if isinstance(statement, ast.Assign):
-            for target in statement.targets:
-                if (
-                    isinstance(target, ast.Attribute)
-                    and isinstance(target.value, ast.Name)
-                    and target.value.id == "nox"
-                    and target.attr == "needs_version"
-                ):
-                    value = _parse_string_constant(statement.value)
+        match statement:
+            case ast.Assign(
+                targets=[
+                    ast.Attribute(
+                        value=ast.Name(id="nox"),
+                        attr="needs_version",
+                    ),
+                    *_,
+                ],
+                value=ast.Constant(value=str() as constant_value),
+            ):
+                value = constant_value
     return value
 
 

--- a/nox/project.py
+++ b/nox/project.py
@@ -57,12 +57,14 @@ def load_toml(
             session.install(*myscript_options["dependencies"])
     """
     filepath = Path(filename)
-    if filepath.suffix == ".toml":
-        return _load_toml_file(filepath)
-    if filepath.suffix in {".py", ""}:
-        return _load_script_block(filepath, missing_ok=missing_ok)
-    msg = f"Extension must be .py or .toml, got {filepath.suffix}"
-    raise ValueError(msg)
+    match filepath.suffix:
+        case ".toml":
+            return _load_toml_file(filepath)
+        case ".py" | "":
+            return _load_script_block(filepath, missing_ok=missing_ok)
+        case suffix:
+            msg = f"Extension must be .py or .toml, got {suffix}"
+            raise ValueError(msg)
 
 
 def _load_toml_file(filepath: Path) -> dict[str, Any]:

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import copy
 import functools
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Literal, overload
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from ._decorators import Func
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -1278,14 +1278,15 @@ class Result:
         Returns:
             str: A word or phrase representing the status.
         """
-        if self.status == Status.SUCCESS:
-            return "was successful" + _duration_str(self.duration, " in {time}")
-
-        status = self.status.name.lower()
-        if self.reason:
-            duration_err = _duration_str(self.duration, " (took {time})")
-            return f"{status}: {self.reason}{duration_err}"
-        return status
+        match self.status:
+            case Status.SUCCESS:
+                return "was successful" + _duration_str(self.duration, " in {time}")
+            case _:
+                status = self.status.name.lower()
+                if self.reason:
+                    duration_err = _duration_str(self.duration, " (took {time})")
+                    return f"{status}: {self.reason}{duration_err}"
+                return status
 
     def log(self, message: str) -> None:
         """Log a message using the appropriate log function.
@@ -1293,13 +1294,13 @@ class Result:
         Args:
             message (str): The message to be logged.
         """
-        log_function = logger.info
-        if self.status == Status.SUCCESS:
-            log_function = logger.success
-        if self.status == Status.SKIPPED:
-            log_function = logger.warning
-        if self.status.value <= 0:
-            log_function = logger.error
+        match self.status:
+            case Status.SUCCESS:
+                log_function = logger.success
+            case Status.SKIPPED:
+                log_function = logger.warning
+            case status:
+                log_function = logger.error if status.value <= 0 else logger.info
         log_function(message)
 
     def serialize(self) -> dict[str, Any]:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -777,49 +777,47 @@ class VirtualEnv(ProcessEnv):
             t = match.group("t")
             cleaned_interpreter = f"python{xy_version}{t}"
 
-        # never -> check for interpreters
-        if self.download_python == "never":
-            if resolved := _find_python(cleaned_interpreter, xy_version):
-                self._resolved = resolved
-                return self._resolved
-
-        # always -> skip check, always install
-        elif self.download_python == "always" and self.venv_backend == "uv":
-            if HAS_UV and version.Version("0.4.16") <= UV_VERSION:
-                uv_python_success = uv_install_python(cleaned_interpreter)
-                if uv_python_success:
-                    self._resolved = cleaned_interpreter
+        match self.download_python, self.venv_backend:
+            # never -> check for interpreters
+            case "never", _:
+                if resolved := _find_python(cleaned_interpreter, xy_version):
+                    self._resolved = resolved
                     return self._resolved
 
-        elif self.download_python == "always" and self.venv_backend in (
-            "venv",
-            "virtualenv",
-        ):
-            pbs_python_path = pbs_install_python(cleaned_interpreter)
-            if pbs_python_path:
-                self._resolved = pbs_python_path
-                return self._resolved
+            # always -> skip check, always install
+            case "always", "uv":
+                if HAS_UV and version.Version("0.4.16") <= UV_VERSION:
+                    uv_python_success = uv_install_python(cleaned_interpreter)
+                    if uv_python_success:
+                        self._resolved = cleaned_interpreter
+                        return self._resolved
 
-        # auto -> check interpreters -> fallback to installing
-        else:
-            if resolved := _find_python(cleaned_interpreter, xy_version):
-                self._resolved = resolved
-                return self._resolved
-
-            if (
-                self.venv_backend == "uv"
-                and HAS_UV
-                and version.Version("0.4.16") <= UV_VERSION
-            ):
-                uv_python_success = uv_install_python(cleaned_interpreter)
-                if uv_python_success:
-                    self._resolved = cleaned_interpreter
-                    return self._resolved
-            elif self.venv_backend in ("venv", "virtualenv"):
+            case "always", "venv" | "virtualenv":
                 pbs_python_path = pbs_install_python(cleaned_interpreter)
                 if pbs_python_path:
                     self._resolved = pbs_python_path
                     return self._resolved
+
+            case "auto", venv_backend:
+                # auto -> check interpreters -> fallback to installing
+                if resolved := _find_python(cleaned_interpreter, xy_version):
+                    self._resolved = resolved
+                    return self._resolved
+
+                if (
+                    venv_backend == "uv"
+                    and HAS_UV
+                    and version.Version("0.4.16") <= UV_VERSION
+                ):
+                    uv_python_success = uv_install_python(cleaned_interpreter)
+                    if uv_python_success:
+                        self._resolved = cleaned_interpreter
+                        return self._resolved
+                elif venv_backend in {"venv", "virtualenv"}:
+                    pbs_python_path = pbs_install_python(cleaned_interpreter)
+                    if pbs_python_path:
+                        self._resolved = pbs_python_path
+                        return self._resolved
 
         self._resolved = InterpreterNotFound(self.interpreter)
         raise self._resolved
@@ -846,28 +844,29 @@ class VirtualEnv(ProcessEnv):
 
             return False
 
-        if self.venv_backend == "virtualenv":
-            cmd = [
-                sys.executable,
-                "-m",
-                "virtualenv",
-                self.location,
-                "--no-periodic-update",
-            ]
-            if self.interpreter:
-                cmd.extend(["-p", self._resolved_interpreter])
-        elif self.venv_backend == "uv":
-            cmd = [
-                UV,
-                "venv",
-                "-p",
-                self._resolved_interpreter if self.interpreter else sys.executable,
-                self.location,
-            ]
-            if version.Version("0.8") <= UV_VERSION:
-                cmd += ["--clear"]
-        else:
-            cmd = [self._resolved_interpreter, "-m", "venv", self.location]
+        match self.venv_backend:
+            case "virtualenv":
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "virtualenv",
+                    self.location,
+                    "--no-periodic-update",
+                ]
+                if self.interpreter:
+                    cmd.extend(["-p", self._resolved_interpreter])
+            case "uv":
+                cmd = [
+                    UV,
+                    "venv",
+                    "-p",
+                    self._resolved_interpreter if self.interpreter else sys.executable,
+                    self.location,
+                ]
+                if version.Version("0.8") <= UV_VERSION:
+                    cmd += ["--clear"]
+            case _:
+                cmd = [self._resolved_interpreter, "-m", "venv", self.location]
         cmd.extend(self.venv_params)
 
         resolved_interpreter_name = os.path.basename(self._resolved_interpreter)

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -798,8 +798,9 @@ class VirtualEnv(ProcessEnv):
                     self._resolved = pbs_python_path
                     return self._resolved
 
-            case "auto", venv_backend:
+            case _:
                 # auto -> check interpreters -> fallback to installing
+                venv_backend = self.venv_backend
                 if resolved := _find_python(cleaned_interpreter, xy_version):
                     self._resolved = resolved
                     return self._resolved

--- a/noxfile.py
+++ b/noxfile.py
@@ -204,7 +204,6 @@ def github_actions_default_tests(session: nox.Session) -> None:
 @nox.session(
     python=[
         *ALL_PYTHONS,
-        "pypy3.9",
         "pypy3.10",
         "pypy3.11",
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 authors = [
   { name = "Alethea Katherine Flowers", email = "me@thea.codes" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -29,7 +29,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -45,8 +44,7 @@ dependencies = [
   "humanize>=4",
   "packaging>=22",
   "tomli>=1.1; python_version<'3.11'",
-  "virtualenv>=20.14.1; python_version<'3.10'",
-  "virtualenv>=20.15; python_version>='3.10'",
+  "virtualenv>=20.15",
 ]
 optional-dependencies.pbs = [
   "pbs-installer[all]>=2025.1.6",
@@ -149,7 +147,7 @@ report.exclude_also = [
 report.omit = [ "nox/_typing.py" ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 warn_unreachable = true
 enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,12 @@ import shutil
 import subprocess
 from pathlib import Path
 from string import Template
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 HAS_CONDA = shutil.which("conda") is not None
 

--- a/tests/resources/noxfile_requires.py
+++ b/tests/resources/noxfile_requires.py
@@ -67,7 +67,7 @@ def j(session):
     print(session.name)
 
 
-@nox.session(python=["3.9", "3.10"])
+@nox.session(python=["3.10", "3.11"])
 def k(session):
     print(session.name)
 
@@ -77,7 +77,7 @@ def m(session):
     print(session.name)
 
 
-@nox.session(python="3.10", requires=["k-{python}"])
+@nox.session(python="3.11", requires=["k-{python}"])
 def n(session):
     print(session.name)
 
@@ -87,7 +87,7 @@ def o(session):
     print(session.name)
 
 
-@nox.session(python=["3.9", "3.10"])
+@nox.session(python=["3.10", "3.11"])
 def p(session):
     print(session.name)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -258,12 +258,12 @@ def test_main_explicit_sessions_with_spaces_in_names(
     [
         ("NOXSESSION", "sessions", "foo", ["foo"]),
         ("NOXSESSION", "sessions", "foo,bar", ["foo", "bar"]),
-        ("NOXPYTHON", "pythons", "3.9", ["3.9"]),
-        ("NOXPYTHON", "pythons", "3.9,3.10", ["3.9", "3.10"]),
-        ("NOXEXTRAPYTHON", "extra_pythons", "3.9", ["3.9"]),
-        ("NOXEXTRAPYTHON", "extra_pythons", "3.9,3.10", ["3.9", "3.10"]),
-        ("NOXFORCEPYTHON", "force_pythons", "3.9", ["3.9"]),
-        ("NOXFORCEPYTHON", "force_pythons", "3.9,3.10", ["3.9", "3.10"]),
+        ("NOXPYTHON", "pythons", "3.10", ["3.10"]),
+        ("NOXPYTHON", "pythons", "3.10,3.11", ["3.10", "3.11"]),
+        ("NOXEXTRAPYTHON", "extra_pythons", "3.10", ["3.10"]),
+        ("NOXEXTRAPYTHON", "extra_pythons", "3.10,3.11", ["3.10", "3.11"]),
+        ("NOXFORCEPYTHON", "force_pythons", "3.10", ["3.10"]),
+        ("NOXFORCEPYTHON", "force_pythons", "3.10,3.11", ["3.10", "3.11"]),
     ],
     ids=[
         "single_session",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -560,9 +560,9 @@ def test_main_with_bad_session_names(
     assert session in stderr
 
 
-py39py310 = pytest.mark.skipif(
-    shutil.which("python3.10") is None or shutil.which("python3.9") is None,
-    reason="Python 3.9 and 3.10 required",
+py310py311 = pytest.mark.skipif(
+    shutil.which("python3.10") is None or shutil.which("python3.11") is None,
+    reason="Python 3.10 and 3.11 required",
 )
 
 
@@ -570,8 +570,8 @@ py39py310 = pytest.mark.skipif(
     ("sessions", "expected_order"),
     [
         (("g", "a", "d"), ("b", "c", "h", "g", "a", "e", "d")),
-        pytest.param(("m",), ("k-3.9", "k-3.10", "m"), marks=py39py310),
-        pytest.param(("n",), ("k-3.10", "n"), marks=py39py310),
+        pytest.param(("m",), ("k-3.10", "k-3.11", "m"), marks=py310py311),
+        pytest.param(("n",), ("k-3.11", "n"), marks=py310py311),
         (("v",), ("u(django='1.9')", "u(django='2.0')", "v")),
         (("w",), ("u(django='1.9')", "u(django='2.0')", "w")),
     ],

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -9,8 +9,8 @@ def test_classifiers() -> None:
     pyproject = {
         "project": {
             "classifiers": [
-                "Programming Language :: Python :: 3.7",
-                "Programming Language :: Python :: 3.9",
+                "Programming Language :: Python :: 3.10",
+                "Programming Language :: Python :: 3.11",
                 "Programming Language :: Python :: 3.12",
                 "Programming Language :: Python",
                 "Programming Language :: Python :: 3 :: Only",
@@ -20,11 +20,11 @@ def test_classifiers() -> None:
         }
     }
 
-    assert python_versions(pyproject) == ["3.7", "3.9", "3.12"]
+    assert python_versions(pyproject) == ["3.10", "3.11", "3.12"]
 
 
 def test_no_classifiers() -> None:
-    pyproject = {"project": {"requires-python": ">=3.9"}}
+    pyproject = {"project": {"requires-python": ">=3.10"}}
     with pytest.raises(ValueError, match="No Python version classifiers"):
         python_versions(pyproject)
 
@@ -41,8 +41,8 @@ def test_python_range() -> None:
     pyproject = {
         "project": {
             "classifiers": [
-                "Programming Language :: Python :: 3.7",
-                "Programming Language :: Python :: 3.9",
+                "Programming Language :: Python :: 3.10",
+                "Programming Language :: Python :: 3.11",
                 "Programming Language :: Python :: 3.12",
                 "Programming Language :: Python",
                 "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Run on 3.10+, 3.9 is EoL.

Pip has merged the 3.9 drop, next release in a few weeks is 3.10+ only.

:robot: last two commits had some assistance from `OpenCode:Kimi-K2.5`