### PR TITLE
docs: avoid newest docutils until sphinx-tabs updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ test = [
   "pytest-cov>=3",
 ]
 docs = [
-  "docutils<0.22",  # Waiting for sphinx-tabs release
+  "docutils<0.22",    # Waiting for sphinx-tabs release
   "myst-parser",
   "sphinx>=3",
   "sphinx-autobuild",


### PR DESCRIPTION
Fixed in the main branch, it seems, but for now we have to pin: https://github.com/executablebooks/sphinx-tabs/issues/212
