### PR TITLE
fix: ignore default selection for tags and keywords

### DIFF
--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -197,16 +197,17 @@ def filter_manifest(manifest: Manifest, global_config: Namespace) -> Manifest | 
     # Filter by the name of any explicit sessions.
     # This can raise KeyError if a specified session does not exist;
     # log this if it happens. The sessions does not come from the Noxfile
-    # if keywords is not empty.
-    if global_config.sessions is None:
-        manifest.filter_by_default()
-    else:
-        try:
-            manifest.filter_by_name(global_config.sessions)
-        except KeyError as exc:
-            logger.error("Error while collecting sessions.")
-            logger.error(exc.args[0])
-            return 3
+    # if keywords is not empty or tags are supplied.
+    if global_config.tags is None and not global_config.keywords:
+        if global_config.sessions is None:
+            manifest.filter_by_default()
+        else:
+            try:
+                manifest.filter_by_name(global_config.sessions)
+            except KeyError as exc:
+                logger.error("Error while collecting sessions.")
+                logger.error(exc.args[0])
+                return 3
 
     if not manifest and not global_config.list_sessions:
         print("No sessions selected. Please select a session with -s <session name>.\n")

--- a/noxfile.py
+++ b/noxfile.py
@@ -193,6 +193,7 @@ def _check_python_version(session: nox.Session) -> None:
         "3.14t",
     ],
     default=False,
+    tags=["gha"],
 )
 def github_actions_default_tests(session: nox.Session) -> None:
     """Check default versions installed by the nox GHA Action"""
@@ -208,6 +209,7 @@ def github_actions_default_tests(session: nox.Session) -> None:
         "pypy3.11",
     ],
     default=False,
+    tags=["gha"],
 )
 def github_actions_all_tests(session: nox.Session) -> None:
     """Check all versions installed by the nox GHA Action"""


### PR DESCRIPTION
Currently, if tags are not selected by default, you can't get them with `-t` (similarly with keywords). This patch ignores the `default` status and provides everything to the tag/keyword selector.

An alternative would be to add `-a`, which selects all sessions, so then `-a -t <tag>` would be the correct way to select non-default sessions with tags. I'm fine with either, I think this PR is simpler, but that would be more powerful.
