### PR TITLE
Revert "feat: drop Python 3.8 (#1004)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
-          - "3.9"
-          - "3.11"
+          - "3.8"
+          - "3.10"
+          - "3.13"
           - "3.14"
         include:
           - os: ubuntu-22.04

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -21,7 +21,7 @@ import functools
 import itertools
 import os
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
 import argcomplete
 
@@ -30,7 +30,7 @@ from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 from nox.virtualenv import ALL_VENVS
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable
 
     from nox._option_set import NoxOptions
 

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import functools
 import itertools
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Iterable, Union
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -15,8 +15,7 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Hashable, Iterable, Iterator, Mapping
-from typing import TypeVar
+from typing import Hashable, Iterable, Iterator, Mapping, TypeVar
 
 __all__ = ["CycleError", "lazy_stable_topo_sort"]
 

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -14,8 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Union
+from typing import Sequence, Union
 
 __all__ = ["Python"]
 

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 import ast
 import itertools
 import operator
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from nox._decorators import Call, Func
 from nox._resolver import CycleError, lazy_stable_topo_sort

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -19,8 +19,7 @@ import importlib.util
 import json
 import os
 import sys
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Sequence, TypeVar
 
 from colorlog.escape_codes import parse_colors
 

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -24,14 +24,15 @@ import sys
 from configparser import ConfigParser
 from pathlib import Path
 from subprocess import check_output
-from typing import TYPE_CHECKING, Any
+from typing import Any, Iterable
 
 import jinja2
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+if sys.version_info < (3, 9):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 
-from importlib.resources import files
 
 __all__ = ["main"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -191,8 +191,6 @@ def _check_python_version(session: nox.Session) -> None:
     python=[
         *ALL_PYTHONS,
         "pypy-3.11",
-        "3.13t",
-        "3.14t",
     ],
     default=False,
 )
@@ -205,6 +203,7 @@ def github_actions_default_tests(session: nox.Session) -> None:
 @nox.session(
     python=[
         *ALL_PYTHONS,
+        "pypy3.8",
         "pypy3.9",
         "pypy3.10",
         "pypy3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 authors = [
   { name = "Alethea Katherine Flowers", email = "me@thea.codes" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -29,6 +29,7 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -52,6 +53,7 @@ optional-dependencies.pbs = [
   "pbs-installer[all]>=2025.1.6",
 ]
 optional-dependencies.tox-to-nox = [
+  "importlib-resources; python_version<'3.9'",
   "jinja2",
   "tox>=4",
 ]
@@ -70,7 +72,7 @@ dev = [
   { include-group = "test" },
 ]
 test = [
-  "coverage[toml]>=7.10.3",
+  "coverage[toml]>=7.2",
   "pytest>=7.4; python_version>='3.12'",
   "pytest>=7; python_version<'3.12'",
   "pytest-cov>=3",
@@ -132,9 +134,7 @@ markers = [
 ]
 
 [tool.coverage]
-run.core = "sysmon"
 run.branch = true
-run.patch = [ "subprocess" ]
 run.relative_files = true
 run.source_pkgs = [ "nox" ]
 run.disable_warnings = [

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -41,6 +41,8 @@ def test_get_dependencies() -> None:
             "tox",
             "virtualenv",
         }
+        if sys.version_info < (3, 9):
+            dep_list.add("importlib-resources")
         if sys.version_info < (3, 11):
             dep_list.add("tomli")
         assert {d.name for d in deps} == dep_list

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -339,9 +339,8 @@ def test_main_positional_args(
     fake_exit = mock.Mock(side_effect=ValueError("asdf!"))
 
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3"])
-    with (
-        mock.patch.object(sys, "exit", fake_exit),
-        pytest.raises(ValueError, match="asdf!"),
+    with mock.patch.object(sys, "exit", fake_exit), pytest.raises(
+        ValueError, match="asdf!"
     ):
         nox.main()
     _, stderr = capsys.readouterr()
@@ -350,9 +349,8 @@ def test_main_positional_args(
 
     fake_exit.reset_mock()
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3", "--"])
-    with (
-        mock.patch.object(sys, "exit", fake_exit),
-        pytest.raises(ValueError, match="asdf!"),
+    with mock.patch.object(sys, "exit", fake_exit), pytest.raises(
+        ValueError, match="asdf!"
     ):
         nox.main()
     _, stderr = capsys.readouterr()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -529,12 +529,11 @@ class TestSession:
 
         subp_popen_instance = mock.Mock()
         subp_popen_instance.communicate.side_effect = KeyboardInterrupt()
-        with (
-            mock.patch("nox.popen.shutdown_process", autospec=True) as shutdown_process,
-            mock.patch(
-                "nox.popen.subprocess.Popen",
-                new=mock.Mock(return_value=subp_popen_instance),
-            ),
+        with mock.patch(
+            "nox.popen.shutdown_process", autospec=True
+        ) as shutdown_process, mock.patch(
+            "nox.popen.subprocess.Popen",
+            new=mock.Mock(return_value=subp_popen_instance),
         ):
             shutdown_process.return_value = ("", "")
 
@@ -1297,12 +1296,11 @@ class TestSessionRunner:
             "OPTIONAL_VENVS",
             {"uv": False, "conda": False, "mamba": False},
         )
-        with (
-            mock.patch("nox.virtualenv.VirtualEnv.create", autospec=True),
-            pytest.raises(
-                ValueError,
-                match=r"No backends present|Only optional backends|Expected venv_backend",
-            ),
+        with mock.patch(
+            "nox.virtualenv.VirtualEnv.create", autospec=True
+        ), pytest.raises(
+            ValueError,
+            match=r"No backends present|Only optional backends|Expected venv_backend",
         ):
             runner._create_venv()
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1554,9 +1554,8 @@ def test_download_python_failed_install(
         download_python=download_python,
     )
 
-    with (
-        mock.patch.object(shutil, "which", return_value=None) as _,
-        pytest.raises(nox.virtualenv.InterpreterNotFound),
+    with mock.patch.object(shutil, "which", return_value=None) as _, pytest.raises(
+        nox.virtualenv.InterpreterNotFound
     ):
         _ = venv._resolved_interpreter
 


### PR DESCRIPTION
Since uv 0.10 supports Python 3.8, we are now broken on 3.8, so let's revert this, make a release, then unrevert.
