### PR TITLE
Reapply "feat: drop Python 3.8 (#1004)" (#1060)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
-          - "3.8"
-          - "3.10"
-          - "3.13"
+          - "3.9"
+          - "3.11"
           - "3.14"
         include:
           - os: ubuntu-22.04

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -21,7 +21,7 @@ import functools
 import itertools
 import os
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import argcomplete
 
@@ -30,7 +30,7 @@ from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 from nox.virtualenv import ALL_VENVS
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
 
     from nox._option_set import NoxOptions
 

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import functools
 import itertools
-from typing import TYPE_CHECKING, Any, Iterable, Union
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import itertools
-from typing import Hashable, Iterable, Iterator, Mapping, TypeVar
+from collections.abc import Hashable, Iterable, Iterator, Mapping
+from typing import TypeVar
 
 __all__ = ["CycleError", "lazy_stable_topo_sort"]
 

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 __all__ = ["Python"]
 

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import ast
 import itertools
 import operator
-from typing import TYPE_CHECKING, Any, Mapping, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, cast
 
 from nox._decorators import Call, Func
 from nox._resolver import CycleError, lazy_stable_topo_sort

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -19,7 +19,8 @@ import importlib.util
 import json
 import os
 import sys
-from typing import TYPE_CHECKING, Sequence, TypeVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, TypeVar
 
 from colorlog.escape_codes import parse_colors
 

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -24,15 +24,14 @@ import sys
 from configparser import ConfigParser
 from pathlib import Path
 from subprocess import check_output
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import jinja2
 
-if sys.version_info < (3, 9):
-    from importlib_resources import files
-else:
-    from importlib.resources import files
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
+from importlib.resources import files
 
 __all__ = ["main"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -191,6 +191,8 @@ def _check_python_version(session: nox.Session) -> None:
     python=[
         *ALL_PYTHONS,
         "pypy-3.11",
+        "3.13t",
+        "3.14t",
     ],
     default=False,
 )
@@ -203,7 +205,6 @@ def github_actions_default_tests(session: nox.Session) -> None:
 @nox.session(
     python=[
         *ALL_PYTHONS,
-        "pypy3.8",
         "pypy3.9",
         "pypy3.10",
         "pypy3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 authors = [
   { name = "Alethea Katherine Flowers", email = "me@thea.codes" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -29,7 +29,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -53,7 +52,6 @@ optional-dependencies.pbs = [
   "pbs-installer[all]>=2025.1.6",
 ]
 optional-dependencies.tox-to-nox = [
-  "importlib-resources; python_version<'3.9'",
   "jinja2",
   "tox>=4",
 ]
@@ -72,7 +70,7 @@ dev = [
   { include-group = "test" },
 ]
 test = [
-  "coverage[toml]>=7.2",
+  "coverage[toml]>=7.10.3",
   "pytest>=7.4; python_version>='3.12'",
   "pytest>=7; python_version<'3.12'",
   "pytest-cov>=3",
@@ -134,7 +132,9 @@ markers = [
 ]
 
 [tool.coverage]
+run.core = "sysmon"
 run.branch = true
+run.patch = [ "subprocess" ]
 run.relative_files = true
 run.source_pkgs = [ "nox" ]
 run.disable_warnings = [

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -41,8 +41,6 @@ def test_get_dependencies() -> None:
             "tox",
             "virtualenv",
         }
-        if sys.version_info < (3, 9):
-            dep_list.add("importlib-resources")
         if sys.version_info < (3, 11):
             dep_list.add("tomli")
         assert {d.name for d in deps} == dep_list

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -339,8 +339,9 @@ def test_main_positional_args(
     fake_exit = mock.Mock(side_effect=ValueError("asdf!"))
 
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3"])
-    with mock.patch.object(sys, "exit", fake_exit), pytest.raises(
-        ValueError, match="asdf!"
+    with (
+        mock.patch.object(sys, "exit", fake_exit),
+        pytest.raises(ValueError, match="asdf!"),
     ):
         nox.main()
     _, stderr = capsys.readouterr()
@@ -349,8 +350,9 @@ def test_main_positional_args(
 
     fake_exit.reset_mock()
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3", "--"])
-    with mock.patch.object(sys, "exit", fake_exit), pytest.raises(
-        ValueError, match="asdf!"
+    with (
+        mock.patch.object(sys, "exit", fake_exit),
+        pytest.raises(ValueError, match="asdf!"),
     ):
         nox.main()
     _, stderr = capsys.readouterr()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -529,11 +529,12 @@ class TestSession:
 
         subp_popen_instance = mock.Mock()
         subp_popen_instance.communicate.side_effect = KeyboardInterrupt()
-        with mock.patch(
-            "nox.popen.shutdown_process", autospec=True
-        ) as shutdown_process, mock.patch(
-            "nox.popen.subprocess.Popen",
-            new=mock.Mock(return_value=subp_popen_instance),
+        with (
+            mock.patch("nox.popen.shutdown_process", autospec=True) as shutdown_process,
+            mock.patch(
+                "nox.popen.subprocess.Popen",
+                new=mock.Mock(return_value=subp_popen_instance),
+            ),
         ):
             shutdown_process.return_value = ("", "")
 
@@ -1296,11 +1297,12 @@ class TestSessionRunner:
             "OPTIONAL_VENVS",
             {"uv": False, "conda": False, "mamba": False},
         )
-        with mock.patch(
-            "nox.virtualenv.VirtualEnv.create", autospec=True
-        ), pytest.raises(
-            ValueError,
-            match=r"No backends present|Only optional backends|Expected venv_backend",
+        with (
+            mock.patch("nox.virtualenv.VirtualEnv.create", autospec=True),
+            pytest.raises(
+                ValueError,
+                match=r"No backends present|Only optional backends|Expected venv_backend",
+            ),
         ):
             runner._create_venv()
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1554,8 +1554,9 @@ def test_download_python_failed_install(
         download_python=download_python,
     )
 
-    with mock.patch.object(shutil, "which", return_value=None) as _, pytest.raises(
-        nox.virtualenv.InterpreterNotFound
+    with (
+        mock.patch.object(shutil, "which", return_value=None) as _,
+        pytest.raises(nox.virtualenv.InterpreterNotFound),
     ):
         _ = venv._resolved_interpreter
 


### PR DESCRIPTION
This reverts commit 90a8aef54122e188dbea80680552507517523ced.

(Except for coverage core, which isn't needed anymore, coverage changed the default.)
