### PR TITLE
feat: use python-discovery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
           - packaging
           - pbs_installer
           - pytest<9  # pytest 9 requires 3.10+
+          - python-discovery
           - importlib_metadata
           - importlib_resources
           - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,8 @@ repos:
           - jinja2
           - packaging
           - pbs_installer
+          - platformdirs
+          - python-discovery
           - pytest
           - tomli
           - uv

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -113,12 +113,15 @@ You can tell Nox to use a different Python interpreter/version by specifying the
 
 .. note::
 
-    The Python binaries on Windows are found via the Python `Launcher`_ for
-    Windows (``py``). For example, Python 3.10 can be found by determining which
-    executable is invoked by ``py -3.10``. If a given test needs to use the 32-bit
-    version of a given Python, then ``X.Y-32`` should be used as the version.
+    Interpreters are located with the `python-discovery`_ library, which searches
+    ``PATH``, version managers (pyenv, mise, asdf, uv), and, on Windows, the
+    registry (`PEP 514`_) and the Python `Launcher`_. If a given test needs to use
+    the 32-bit version of a given Python on Windows, then ``X.Y-32`` should be used
+    as the version.
 
     .. _Launcher: https://docs.python.org/3/using/windows.html#python-launcher-for-windows
+    .. _python-discovery: https://pypi.org/project/python-discovery/
+    .. _PEP 514: https://peps.python.org/pep-0514/
 
 You can also tell Nox to run your session against multiple Python interpreters. Nox will create a separate virtualenv and run the session for each interpreter you specify. For example, this session will run twice - once for Python 2.7 and once for Python 3.6:
 
@@ -136,7 +139,27 @@ When you provide a version number, Nox automatically prepends python to determin
     def tests(session):
         pass
 
-If the specified python interpreter is not found, Nox can automatically download it when ``--download-python`` is set to ``auto`` (the default) or ``always``. ``never`` avoids the download. This requires the ``[pbs]`` extra when not using uv as a backend.
+A free-threaded build can be requested with the ``t`` suffix, e.g. ``python='3.13t'``.
+
+You can also give a `PEP 440`_ version specifier instead of an exact version, and
+Nox will use the first installed interpreter that satisfies it:
+
+.. code-block:: python
+
+    @nox.session(python='>=3.14')
+    def tests(session):
+        pass
+
+    @nox.session(python='>=3.11,<3.13')
+    def lint(session):
+        pass
+
+.. note::
+
+    Range specifiers are only supported on the ``venv``, ``virtualenv``, and ``uv``
+    backends, not on conda backends.
+
+If the specified python interpreter is not found, Nox can automatically download it when ``--download-python`` is set to ``auto`` (the default) or ``always``. ``never`` avoids the download. This requires the ``[pbs]`` extra when not using uv as a backend. When a range is given, the floor of its lowest bound is downloaded (``>=3.14`` downloads ``3.14``); a range with no lower bound (such as ``<3.14``) cannot be downloaded.
 
 When collecting your sessions, Nox will create a separate session for each interpreter. You can see these sessions when running ``nox --list``. For example this Noxfile:
 

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -157,3 +157,5 @@ def setup_logging(
     logging.getLogger("sh").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("filelock").setLevel(logging.WARNING)
+    logging.getLogger("python_discovery").setLevel(logging.WARNING)

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -34,6 +34,36 @@ import nox
 import nox.command
 from nox.logger import logger
 
+
+def _python_discovery_get_interpreter() -> Any:
+    """Lazy import of get_interpreter from python-discovery."""
+    import python_discovery  # noqa: PLC0415
+
+    return python_discovery.get_interpreter
+
+
+def _python_discovery_DiskCache() -> Any:
+    """Lazy import of DiskCache from python-discovery."""
+    import python_discovery  # noqa: PLC0415
+
+    return python_discovery.DiskCache
+
+
+def _get_python_discovery_cache() -> Any:
+    """Get or create the DiskCache for python-discovery.
+
+    Returns:
+        DiskCache instance or None if caching should not be used
+    """
+    cache_dir = Path.home() / ".cache" / "nox" / "python-discovery"
+    try:
+        disk_cache_cls = _python_discovery_DiskCache()
+        return disk_cache_cls(root=cache_dir)
+    except OSError:
+        # If cache directory can't be created, return None (no caching)
+        return None
+
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
@@ -111,10 +141,45 @@ def find_uv() -> tuple[bool, str, version.Version]:
     )
 
 
+def _is_version_range_spec(spec: str) -> bool:
+    """Check if the spec is a version range spec (e.g., '>=3.11,<3.13')."""
+    # Check for PEP 440 version comparison operators
+    return any(op in spec for op in [">=", ">", "<=", "<", "~=", "==", "!=", ","])
+
+
 def _find_python(interpreter: str, xy_ver: str) -> str | None:
-    """Find a python executable matching the requested interpreter"""
+    """Find a python executable matching the requested interpreter.
+
+    Uses traditional methods first for backwards compatibility, with python-discovery
+    as a fallback for advanced version specs or when traditional methods fail.
+    """
+    # For version range specs (e.g., ">=3.11,<3.13"), use python-discovery directly
+    if _is_version_range_spec(interpreter):
+        try:
+            cache = _get_python_discovery_cache()
+            get_interpreter = _python_discovery_get_interpreter()
+            result = get_interpreter(interpreter, cache=cache)
+            if result is not None:
+                return str(result.executable)
+        except (OSError, ValueError, RuntimeError):
+            # Fall back to traditional discovery on error
+            pass
+        return None
+
+    # Try traditional discovery first for backwards compatibility
     if shutil.which(interpreter):
         return interpreter
+
+    # Fall back to python-discovery for other interpreters that weren't found
+    try:
+        cache = _get_python_discovery_cache()
+        get_interpreter = _python_discovery_get_interpreter()
+        result = get_interpreter(interpreter, cache=cache)
+        if result is not None:
+            return str(result.executable)
+    except (OSError, ValueError, RuntimeError):
+        # Fall back to platform-specific discovery on error
+        pass
 
     # Windows only search for the executable
     if _PLATFORM.startswith("win"):
@@ -776,6 +841,14 @@ class VirtualEnv(ProcessEnv):
             xy_version = match.group("xy_ver")
             t = match.group("t")
             cleaned_interpreter = f"python{xy_version}{t}"
+
+        # For version range specs (e.g., ">=3.11,<3.13"), check directly
+        # This enables new functionality for specifying version ranges
+        if _is_version_range_spec(self.interpreter) and (
+            resolved := _find_python(self.interpreter, xy_version)
+        ):
+            self._resolved = resolved
+            return self._resolved
 
         match self.download_python, self.venv_backend:
             # never -> check for interpreters

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -166,7 +166,17 @@ def _discover_interpreter(spec: str) -> PythonInfo | None:
     """
     from python_discovery import get_interpreter  # noqa: PLC0415
 
-    return get_interpreter(spec, cache=_get_python_discovery_cache())
+    cache = _get_python_discovery_cache()
+    if cache is None:
+        return get_interpreter(spec)
+    try:
+        return get_interpreter(spec, cache=cache)
+    except OSError:
+        # The cache dir exists but isn't writable (e.g. a read-only home):
+        # DiskCache touches the filesystem only lazily, so the failure surfaces
+        # here. Degrade to uncached discovery instead of aborting resolution.
+        logger.debug("python-discovery cache is not writable; discovering without it.")
+        return get_interpreter(spec)
 
 
 @functools.cache
@@ -185,9 +195,11 @@ def _concrete_install_target(interpreter: str) -> str | None:
 
     Non-range specs (names, concrete versions, paths) are returned unchanged.
     For a PEP 440 range (``>=3.14``) the floor of the first lower-bound clause
-    is returned (``3.14``) so a concrete interpreter can be downloaded.
-    Upper-bound-only (``<3.14``) or ``!=`` ranges have no installable floor and
-    return ``None``.
+    is returned (``3.14``) so a concrete interpreter can be downloaded. A
+    non-CPython implementation prefix is preserved (``pypy>=3.10`` -> ``pypy3.10``)
+    so the right flavor is installed; the floor already carries any free-threaded
+    ``t`` suffix. Upper-bound-only (``<3.14``) or ``!=`` ranges have no
+    installable floor and return ``None``.
     """
     from python_discovery import PythonSpec  # noqa: PLC0415
 
@@ -196,7 +208,9 @@ def _concrete_install_target(interpreter: str) -> str | None:
         return interpreter
     for specifier in spec.version_specifier.specifiers:
         if specifier.operator in {">=", "==", "~=", ">"}:
-            return specifier.version_str
+            impl = spec.implementation
+            prefix = impl if impl and impl != "cpython" else ""
+            return f"{prefix}{specifier.version_str}"
     return None
 
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -49,6 +49,8 @@ from nox.logger import logger
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
+    from python_discovery import DiskCache, PythonInfo
+
     from nox._typing import Python
 
     # These are implemented via the module-level __getattr__ below, so that
@@ -132,33 +134,69 @@ def find_uv() -> tuple[bool, str, version.Version]:
 
 
 @functools.cache
-def _find_python(interpreter: str, xy_ver: str) -> str | None:
-    """Find a python executable matching the requested interpreter.
+def _get_python_discovery_cache() -> DiskCache | None:
+    """Return a python-discovery disk cache, or ``None`` if it can't be created.
 
-    Cached: discovery is pure PATH/launcher lookup, and on Windows a miss
-    spawns ``py -X.Y`` subprocesses, which would otherwise repeat for every
-    session using the same interpreter.
+    Stored under the user cache directory (``~/Library/Caches/nox`` on macOS,
+    ``%LOCALAPPDATA%\\nox`` on Windows, ``$XDG_CACHE_HOME``/``~/.cache/nox`` on
+    Linux). python-discovery validates interpreter mtime + hash before reusing
+    an entry, so stale data is not a concern. Degrades to no cache on a
+    read-only home.
     """
-    if shutil.which(interpreter):
+    import platformdirs  # noqa: PLC0415
+    from python_discovery import DiskCache  # noqa: PLC0415
+
+    try:
+        root = Path(platformdirs.user_cache_dir("nox")) / "python-discovery"
+        return DiskCache(root=root)
+    except OSError:
+        return None
+
+
+def _discover_interpreter(spec: str) -> PythonInfo | None:
+    """Locate an interpreter matching *spec* using python-discovery.
+
+    Accepts any python-discovery spec: a concrete version (``3.12``), a name
+    (``python3.12``, ``pypy3.11``), a free-threaded build (``3.13t``), a PEP 440
+    version range (``>=3.14``), or an absolute path. python-discovery searches
+    ``PATH``, version managers (pyenv/mise/asdf/uv), and the Windows registry
+    (PEP 514). Returns ``None`` when nothing matches.
+
+    This is the single seam tests mock to avoid probing the real system.
+    """
+    from python_discovery import get_interpreter  # noqa: PLC0415
+
+    return get_interpreter(spec, cache=_get_python_discovery_cache())
+
+
+@functools.cache
+def _find_python(interpreter: str) -> str | None:
+    """Return the path to an interpreter matching *interpreter*, or ``None``.
+
+    Cached because discovery is pure (read-only) and would otherwise repeat for
+    every session using the same spec.
+    """
+    info = _discover_interpreter(interpreter)
+    return info.executable if info is not None else None
+
+
+def _concrete_install_target(interpreter: str) -> str | None:
+    """Return a concrete version to hand to an installer, or ``None``.
+
+    Non-range specs (names, concrete versions, paths) are returned unchanged.
+    For a PEP 440 range (``>=3.14``) the floor of the first lower-bound clause
+    is returned (``3.14``) so a concrete interpreter can be downloaded.
+    Upper-bound-only (``<3.14``) or ``!=`` ranges have no installable floor and
+    return ``None``.
+    """
+    from python_discovery import PythonSpec  # noqa: PLC0415
+
+    spec = PythonSpec.from_string_spec(interpreter)
+    if spec.version_specifier is None:
         return interpreter
-
-    # Windows only search for the executable
-    if _PLATFORM.startswith("win"):
-        # Allow versions of the form ``X.Y-32`` for Windows.
-        match = re.match(r"^\d\.\d+-32$", interpreter)
-        if match:
-            # preserve the "-32" suffix, as the Python launcher expects it.
-            xy_ver = interpreter
-
-        path_from_launcher = locate_via_py(xy_ver)
-        if path_from_launcher:
-            return path_from_launcher
-
-        path_from_version_param = locate_using_path_and_version(xy_ver)
-        if path_from_version_param:
-            return path_from_version_param
-
-    # not found case
+    for specifier in spec.version_specifier.specifiers:
+        if specifier.operator in {">=", "==", "~=", ">"}:
+            return specifier.version_str
     return None
 
 
@@ -415,77 +453,6 @@ class ProcessEnv(abc.ABC):
                 path_parts.append(prior_path)
             computed_env["PATH"] = os.pathsep.join(path_parts)
         return computed_env
-
-
-def locate_via_py(version: str) -> str | None:
-    """Find the Python executable using the Windows Launcher.
-
-    This is based on :pep:397 which details that executing
-    ``py.exe -{version}`` should execute Python with the requested
-    version. We then make the Python process print out its full
-    executable path which we use as the location for the version-
-    specific Python interpreter.
-
-    Args:
-        version (str): The desired Python version to pass to ``py.exe``. Of the form
-            ``X.Y`` or ``X.Y-32``. For example, a usage of the Windows Launcher might
-            be ``py -3.6-32``.
-
-    Returns:
-        Optional[str]: The full executable path for the Python ``version``,
-        if it is found.
-    """
-    script = "import sys; print(sys.executable)"
-    py_exe = shutil.which("py")
-    if py_exe is not None:
-        ret = subprocess.run(
-            [py_exe, f"-{version}", "-c", script],
-            check=False,
-            text=True,
-            capture_output=True,
-            encoding="utf-8",
-        )
-        if ret.returncode == 0 and ret.stdout:
-            return ret.stdout.strip()
-    return None
-
-
-def locate_using_path_and_version(version: str) -> str | None:
-    """Check the PATH's python interpreter and return it if the version
-    matches.
-
-    On systems without version-named interpreters and with missing
-    launcher (which is on all Windows Anaconda installations),
-    we search the PATH for a plain "python" interpreter and accept it
-    if its --version matches the specified interpreter version.
-
-    Args:
-        version (str): The desired Python version. Of the form ``X.Y``.
-
-    Returns:
-        Optional[str]: The full executable path for the Python ``version``,
-        if it is found.
-    """
-    if not version:
-        return None
-
-    script = "import platform; print(platform.python_version())"
-    path_python = shutil.which("python")
-    if path_python:
-        ret = subprocess.run(
-            [path_python, "-c", script],
-            check=False,
-            text=True,
-            capture_output=True,
-        )
-        if (
-            ret.returncode == 0
-            and ret.stdout
-            and ret.stdout.strip().startswith(version)
-        ):
-            return path_python
-
-    return None
 
 
 class PassthroughEnv(ProcessEnv):
@@ -841,49 +808,51 @@ class VirtualEnv(ProcessEnv):
             self._resolved = sys.executable
             return self._resolved
 
-        # Otherwise we need to divine the path to the interpreter. This is
-        # designed to accept strings in the form of "2", "2.7", "2.7.13",
-        # "2.7.13-32", "python2", "python2.4", etc.
-        xy_version = ""
-        cleaned_interpreter = self.interpreter
-
-        # If this is just a X, X.Y, or X.Y.Z string, extract just the X / X.Y
-        # part and add Python to the front of it.
-        match = re.match(r"^(?P<xy_ver>\d(\.\d+)?)(\.\d+)?(?P<t>t?)$", self.interpreter)
-        if match:
-            xy_version = match.group("xy_ver")
-            t = match.group("t")
-            cleaned_interpreter = f"python{xy_version}{t}"
-
+        # python-discovery accepts every spec form directly: "3", "3.12",
+        # "3.12.1", "3.13t", "python3.12", "pypy3.11", "3.6-32", PEP 440 ranges
+        # like ">=3.14", and absolute paths.
         match self.download_python:
             # never -> check for interpreters
             case "never":
-                if resolved := _find_python(cleaned_interpreter, xy_version):
+                if resolved := _find_python(self.interpreter):
                     self._resolved = resolved
                     return self._resolved
 
             # always -> skip check, always install
             case "always":
-                if resolved := self._install_python(cleaned_interpreter):
+                if resolved := self._install_python(self.interpreter):
                     self._resolved = resolved
                     return self._resolved
 
             case _:
                 # auto -> check interpreters -> fallback to installing
-                if resolved := _find_python(
-                    cleaned_interpreter, xy_version
-                ) or self._install_python(cleaned_interpreter):
+                if resolved := _find_python(self.interpreter) or self._install_python(
+                    self.interpreter
+                ):
                     self._resolved = resolved
                     return self._resolved
 
         self._resolved = InterpreterNotFound(self.interpreter)
         raise self._resolved
 
-    def _install_python(self, cleaned_interpreter: str) -> str | None:
+    def _install_python(self, interpreter: str) -> str | None:
         """Install the requested interpreter for this backend, if possible.
 
-        Returns the resolved interpreter on success, or ``None`` on failure.
+        For a version range the floor is installed (e.g. ``>=3.14`` -> ``3.14``);
+        ranges with no installable floor return ``None``. Returns the resolved
+        interpreter on success, or ``None`` on failure.
         """
+        target = _concrete_install_target(interpreter)
+        if target is None:
+            return None
+
+        # Installers want the "pythonX.Y[t]" form for bare versions; names,
+        # pypy, and paths are passed through unchanged.
+        match = re.match(r"^(?P<xy_ver>\d(\.\d+)?)(\.\d+)?(?P<t>t?)$", target)
+        cleaned_interpreter = (
+            f"python{match.group('xy_ver')}{match.group('t')}" if match else target
+        )
+
         if self.venv_backend == "uv":
             has_uv, _, uv_ver = _uv_state()
             if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "dependency-groups>=1.1",
   "humanize>=4",
   "packaging>=22",
+  "python-discovery>=0.1",
   "tomli>=1.1; python_version<'3.11'",
   "virtualenv>=20.15",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
   "dependency-groups>=1.1",
   "humanize>=4",
   "packaging>=22",
+  "platformdirs>=2",
+  "python-discovery>=1",
   "tomli>=1.1; python_version<'3.11'",
   "virtualenv>=20.15",
 ]

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -38,6 +38,7 @@ def test_get_dependencies() -> None:
             "jinja2",
             "nox",
             "packaging",
+            "python-discovery",
             "tox",
             "virtualenv",
         }

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -42,6 +42,8 @@ def test_get_dependencies() -> None:
             "jinja2",
             "nox",
             "packaging",
+            "platformdirs",
+            "python-discovery",
             "tox",
             "virtualenv",
         }

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -114,6 +114,19 @@ def patch_sysfind(
 
         monkeypatch.setattr(shutil, "which", special_which)
 
+        # Also mock python-discovery's get_interpreter for backwards compatibility
+        # with tests that rely on the mocked shutil.which behavior
+        def mock_get_interpreter(*args: object, **kwargs: object) -> None:
+            # For tests, we want to respect who the traditional discovery would have found
+            # Since special_which returns None for unknown interpreters, we also return None
+            return None
+
+        monkeypatch.setattr(
+            nox.virtualenv,
+            "_python_discovery_get_interpreter",
+            lambda: mock_get_interpreter,
+        )
+
         def special_run(cmd: Any, *args: Any, **kwargs: Any) -> TextProcessResult:  # noqa: ARG001
             return TextProcessResult(sysexec_result)
 
@@ -1596,12 +1609,26 @@ def test_download_python_never_missing_interpreter(
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Test that InterpreterNotFound is raised when interpreter is missing."""
+
+    def mock_get_interpreter(*args: object, **kwargs: object) -> None:
+        return None
+
+    # Mock at the nox module level to prevent python-discovery from finding
+    monkeypatch.setattr(
+        nox.virtualenv,
+        "_python_discovery_get_interpreter",
+        lambda: mock_get_interpreter,
+    )
+
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
         download_python="never",
     )
+
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
         _ = venv._resolved_interpreter
 
@@ -1656,7 +1683,19 @@ def test_download_python_auto_missing_interpreter(
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+
+    # Mock python-discovery to return None (simulating missing interpreter)
+    def mock_get_interpreter(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        nox.virtualenv,
+        "_python_discovery_get_interpreter",
+        lambda: mock_get_interpreter,
+    )
+
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
@@ -1688,14 +1727,26 @@ def test_download_python_auto_missing_interpreter(
     "nox.virtualenv.uv_install_python",
     return_value=True,
 )
-@mock.patch.object(shutil, "which", return_value="/usr/bin/python3.11")
+@mock.patch.object(shutil, "which", return_value=None)
 def test_download_python_always_preexisting_interpreter(
     which: mock.Mock,
     uv_install_mock: mock.Mock,
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+
+    # Mock python-discovery to return None (simulating missing interpreter)
+    def mock_get_interpreter(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        nox.virtualenv,
+        "_python_discovery_get_interpreter",
+        lambda: mock_get_interpreter,
+    )
+
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
@@ -1728,17 +1779,27 @@ def test_download_python_failed_install(
     download_python: str,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+
+    # Mock python-discovery to return None (simulating missing interpreter)
+    def mock_get_interpreter(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        nox.virtualenv,
+        "_python_discovery_get_interpreter",
+        lambda: mock_get_interpreter,
+    )
+    monkeypatch.setattr(shutil, "which", lambda _x: None)
+
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
         download_python=download_python,
     )
 
-    with (
-        mock.patch.object(shutil, "which", return_value=None) as _,
-        pytest.raises(nox.virtualenv.InterpreterNotFound),
-    ):
+    with pytest.raises(nox.virtualenv.InterpreterNotFound):
         _ = venv._resolved_interpreter
 
     if venv_backend == "uv":
@@ -1850,8 +1911,20 @@ def test_download_python_uv_unsupported_version(
     uv_install_mock: mock.Mock,
     download_python: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test we dont install for unsupported uv versions"""
+
+    # Mock python-discovery to return None (simulating missing interpreter)
+    def mock_get_interpreter(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        nox.virtualenv,
+        "_python_discovery_get_interpreter",
+        lambda: mock_get_interpreter,
+    )
+
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend="uv",
@@ -1866,3 +1939,23 @@ def test_download_python_uv_unsupported_version(
         which.assert_not_called()
     else:  # auto
         which.assert_any_call("python3.11")
+
+
+@pytest.mark.parametrize(
+    ("spec", "is_version_range"),
+    [
+        (">=3.11,<3.13", True),
+        (">=3.9", True),
+        ("<3.14", True),
+        ("~=3.11", True),
+        ("==3.12.1", True),
+        ("!=3.11", True),
+        ("3.12", False),
+        ("python3.12", False),
+        ("pypy3.10", False),
+    ],
+)
+def test_is_version_range_spec(spec: str, is_version_range: bool) -> None:
+    """Test the _is_version_range_spec function correctly identifies version specs."""
+    result = nox.virtualenv._is_version_range_spec(spec)
+    assert result == is_version_range

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -27,7 +27,9 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn
 from unittest import mock
 
+import platformdirs
 import pytest
+import python_discovery
 from packaging import version
 
 import nox.command
@@ -43,7 +45,6 @@ IS_WINDOWS = sys.platform.startswith("win")
 # ("bin"/"python"), so Windows-layout assertions must exclude this case.
 IS_MINGW = nox.virtualenv._IS_MINGW
 HAS_UV = shutil.which("uv") is not None
-RAISE_ERROR = "RAISE_ERROR"
 VIRTUALENV_VERSION = metadata.version("virtualenv")
 
 has_uv = pytest.mark.skipif(not HAS_UV, reason="Missing uv command.")
@@ -57,9 +58,10 @@ xfail_mingw_uv = pytest.mark.xfail(
 )
 
 
-class TextProcessResult(NamedTuple):
-    stdout: str
-    returncode: int = 0
+class FakeInterpreter(NamedTuple):
+    """Stand-in for python-discovery's ``PythonInfo`` in tests."""
+
+    executable: str
 
 
 @pytest.fixture
@@ -93,44 +95,27 @@ def make_conda(tmp_path: Path) -> Callable[..., tuple[CondaEnv, Path]]:
 
 
 @pytest.fixture
-def patch_sysfind(
+def patch_discover(
     monkeypatch: pytest.MonkeyPatch,
-) -> Callable[[tuple[str, ...], str | None, str], None]:
-    """Provides a function to patch ``sysfind`` with parameters for tests related
-    to locating a Python interpreter in the system ``PATH``.
+) -> Callable[[str | None], list[str]]:
+    """Patch python-discovery's interpreter lookup used by ``_find_python``.
+
+    The returned setter takes the executable path discovery should report (or
+    ``None`` for "not found") and returns the list of specs that get queried, so
+    tests can assert nox forwarded the right spec without probing the system.
     """
 
-    def patcher(
-        only_find: tuple[str, ...], sysfind_result: str | None, sysexec_result: str
-    ) -> None:
-        """Monkeypatches python discovery, causing specific results to be found.
+    def setup(executable: str | None) -> list[str]:
+        specs: list[str] = []
 
-        Args:
-            only_find (Tuple[str]): The strings for which ``shutil.which`` should be successful,
-                e.g. ``("python", "python.exe")``
-            sysfind_result (Optional[str]): The ``path`` string to create the returned
-                mocked ``path`` object with which will represent the found Python interpreter,
-                or ``None``.
-            sysexec_result (str): A string that should be returned when executing the
-                mocked ``path`` object. Usually a Python version string.
-                Use the global ``RAISE_ERROR`` to have ``sysexec`` fail.
-        """
+        def discover(spec: str) -> FakeInterpreter | None:
+            specs.append(spec)
+            return FakeInterpreter(executable) if executable is not None else None
 
-        def special_which(name: str, path: Any = None) -> str | None:  # noqa: ARG001
-            if sysfind_result is None:
-                return None
-            if name.lower() in only_find:
-                return sysfind_result or name
-            return None
+        monkeypatch.setattr(nox.virtualenv, "_discover_interpreter", discover)
+        return specs
 
-        monkeypatch.setattr(shutil, "which", special_which)
-
-        def special_run(cmd: Any, *args: Any, **kwargs: Any) -> TextProcessResult:  # noqa: ARG001
-            return TextProcessResult(sysexec_result)
-
-        monkeypatch.setattr(subprocess, "run", special_run)
-
-    return patcher
+    return setup
 
 
 def test_process_env_constructor() -> None:
@@ -1213,19 +1198,73 @@ def test_allowed_globals(
     assert venv.allowed_globals == ("/some/uv", "/some/uvx")
 
 
-def test_find_python_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_discover_interpreter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_discover_interpreter`` forwards the spec to python-discovery."""
+    sentinel = object()
+
+    def fake_get(spec: str, cache: object = None) -> object:  # noqa: ARG001
+        assert spec == "3.12"
+        return sentinel
+
+    monkeypatch.setattr(python_discovery, "get_interpreter", fake_get)
+    monkeypatch.setattr(nox.virtualenv, "_get_python_discovery_cache", lambda: None)
+
+    assert nox.virtualenv._discover_interpreter("3.12") is sentinel
+
+
+def test_find_python_cached(
+    patch_discover: Callable[[str | None], list[str]],
+) -> None:
     """Repeated interpreter discovery (one lookup per session) is cached."""
-    calls: list[str] = []
+    specs = patch_discover("/usr/bin/python3.99")
 
-    def fake_which(name: str) -> str | None:
-        calls.append(name)
-        return "/usr/bin/python3.99"
+    assert nox.virtualenv._find_python("python3.99") == "/usr/bin/python3.99"
+    assert nox.virtualenv._find_python("python3.99") == "/usr/bin/python3.99"
+    assert specs == ["python3.99"]
 
-    monkeypatch.setattr(shutil, "which", fake_which)
 
-    assert nox.virtualenv._find_python("python3.99", "3.99") == "python3.99"
-    assert nox.virtualenv._find_python("python3.99", "3.99") == "python3.99"
-    assert calls == ["python3.99"]
+def test_get_python_discovery_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(platformdirs, "user_cache_dir", lambda *a, **k: str(tmp_path))
+    nox.virtualenv._get_python_discovery_cache.cache_clear()
+    try:
+        assert isinstance(
+            nox.virtualenv._get_python_discovery_cache(), python_discovery.DiskCache
+        )
+    finally:
+        nox.virtualenv._get_python_discovery_cache.cache_clear()
+
+
+def test_get_python_discovery_cache_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(*args: object, **kwargs: object) -> NoReturn:
+        raise OSError
+
+    monkeypatch.setattr(python_discovery, "DiskCache", boom)
+    nox.virtualenv._get_python_discovery_cache.cache_clear()
+    try:
+        assert nox.virtualenv._get_python_discovery_cache() is None
+    finally:
+        nox.virtualenv._get_python_discovery_cache.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("3.12", "3.12"),
+        ("python3.12", "python3.12"),
+        ("pypy3.11", "pypy3.11"),
+        (">=3.14", "3.14"),
+        (">3.10", "3.10"),
+        ("~=3.11", "3.11"),
+        ("==3.12.*", "3.12"),
+        (">=3.11,<3.13", "3.11"),
+        ("<3.14", None),
+        ("!=3.12", None),
+    ],
+)
+def test_concrete_install_target(spec: str, expected: str | None) -> None:
+    assert nox.virtualenv._concrete_install_target(spec) == expected
 
 
 @pytest.mark.parametrize(
@@ -1403,317 +1442,104 @@ def test__resolved_interpreter_none(
 
 
 @pytest.mark.parametrize(
-    ("input_", "expected"),
-    [
-        ("3", "python3"),
-        ("3.6", "python3.6"),
-        ("3.6.2", "python3.6"),
-        ("3.10", "python3.10"),
-        ("2.7.15", "python2.7"),
-        ("3.13t", "python3.13t"),
-        ("3.14.1t", "python3.14t"),
-    ],
+    "input_",
+    ["3", "3.6", "3.6.2", "3.10", "2.7.15", "3.13t", "3.14.1t", "3.6-32", ">=3.14"],
 )
-@mock.patch("nox.virtualenv._PLATFORM", new="linux")
-@mock.patch.object(shutil, "which", return_value=True)
-def test__resolved_interpreter_numerical_non_windows(
-    which: mock.Mock,
+def test__resolved_interpreter_found(
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
     input_: str,
-    expected: str,
 ) -> None:
+    # Every spec form (versions, free-threaded, arch suffix, ranges) is handed
+    # verbatim to python-discovery, and its executable path is returned.
+    specs = patch_discover("/fake/bin/python")
     venv, _ = make_one(interpreter=input_)
 
-    assert venv._resolved_interpreter == expected
-    which.assert_called_once_with(expected)
+    assert venv._resolved_interpreter == "/fake/bin/python"
+    assert specs == [input_]
 
 
-@pytest.mark.parametrize("input_", ["2.", "2.7."])
-@mock.patch("nox.virtualenv._PLATFORM", new="linux")
-@mock.patch.object(shutil, "which", return_value=False)
-def test__resolved_interpreter_invalid_numerical_id(
-    which: mock.Mock,
+@pytest.mark.parametrize("input_", ["2.", "2.7.", "3.6-32", "goofy", ">=3.99"])
+def test__resolved_interpreter_not_found(
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
     input_: str,
 ) -> None:
-    venv, _ = make_one(interpreter=input_)
-
-    with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        print(venv._resolved_interpreter)
-
-    which.assert_called_once_with(input_)
-
-
-@mock.patch("nox.virtualenv._PLATFORM", new="linux")
-@mock.patch.object(shutil, "which", return_value=False)
-def test__resolved_interpreter_32_bit_non_windows(
-    which: mock.Mock, make_one: Callable[..., tuple[VirtualEnv, Path]]
-) -> None:
-    venv, _ = make_one(interpreter="3.6-32")
-
-    with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        print(venv._resolved_interpreter)
-    which.assert_called_once_with("3.6-32")
-
-
-@mock.patch("nox.virtualenv._PLATFORM", new="linux")
-@mock.patch.object(shutil, "which", return_value=True)
-def test__resolved_interpreter_non_windows(
-    which: mock.Mock, make_one: Callable[..., tuple[VirtualEnv, Path]]
-) -> None:
-    # Establish that the interpreter is simply passed through resolution
-    # on non-Windows.
-    venv, _ = make_one(interpreter="python3.6")
-
-    assert venv._resolved_interpreter == "python3.6"
-    which.assert_called_once_with("python3.6")
-
-
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch.object(shutil, "which")
-def test__resolved_interpreter_windows_full_path(
-    which: mock.Mock, make_one: Callable[..., tuple[VirtualEnv, Path]]
-) -> None:
-    # Establish that if we get a fully-qualified system path (on Windows
-    # or otherwise) and the path exists, that we accept it.
-    venv, _ = make_one(interpreter=r"c:\Python36\python.exe")
-
-    which.return_value = venv.interpreter
-    assert venv._resolved_interpreter == r"c:\Python36\python.exe"
-    which.assert_called_once_with(r"c:\Python36\python.exe")
-
-
-@pytest.mark.parametrize(
-    ("input_", "expected"),
-    [
-        ("3.7", r"c:\python37-x64\python.exe"),
-        ("python3.6", r"c:\python36-x64\python.exe"),
-        ("2.7-32", r"c:\python27\python.exe"),
-    ],
-)
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch.object(subprocess, "run")
-@mock.patch.object(shutil, "which")
-def test__resolved_interpreter_windows_pyexe(
-    which: mock.Mock,
-    run: mock.Mock,
-    make_one: Callable[..., tuple[VirtualEnv, Path]],
-    input_: str,
-    expected: str,
-) -> None:
-    # Establish that if we get a standard pythonX.Y path, we look it
-    # up via the py launcher on Windows.
-    venv, _ = make_one(interpreter=input_)
-
-    if input_ == "3.7":
-        input_ = "python3.7"
-
-    # Trick the system into thinking that it cannot find python3.6
-    # (it likely will on Unix). Also, when the system looks for the
-    # py launcher, give it a dummy that returns our test value when
-    # run.
-    def special_run(cmd: str, *args: str, **kwargs: object) -> TextProcessResult:
-        if cmd[0] == "py":
-            return TextProcessResult(expected)
-        return TextProcessResult("", 1)
-
-    run.side_effect = special_run
-    which.side_effect = lambda x: "py" if x == "py" else None
-
-    # Okay now run the test.
-    assert venv._resolved_interpreter == expected
-    assert which.call_count == 2
-    which.assert_has_calls([mock.call(input_), mock.call("py")])
-
-
-@pytest.mark.parametrize(
-    ("interpreter", "expected_py_arg"),
-    [
-        ("3.10-32", "3.10-32"),
-        # Only a literal "-32" suffix is meaningful to the py launcher.
-        ("3.10-3", ""),
-    ],
-)
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch("nox.virtualenv.locate_using_path_and_version", return_value=None)
-@mock.patch("nox.virtualenv.locate_via_py", return_value=None)
-@mock.patch.object(shutil, "which", return_value=None)
-def test_find_python_windows_32_bit_suffix(
-    which: mock.Mock,  # noqa: ARG001
-    locate_via_py_mock: mock.Mock,
-    locate_using_path_and_version_mock: mock.Mock,  # noqa: ARG001
-    interpreter: str,
-    expected_py_arg: str,
-) -> None:
-    # Only an exact "-32" suffix is preserved for the Windows py launcher.
-    assert nox.virtualenv._find_python(interpreter, "") is None
-    locate_via_py_mock.assert_called_once_with(expected_py_arg)
-
-
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch.object(subprocess, "run")
-@mock.patch.object(shutil, "which")
-def test__resolved_interpreter_windows_pyexe_fails(
-    which: mock.Mock, run: mock.Mock, make_one: Callable[..., tuple[VirtualEnv, Path]]
-) -> None:
-    # Establish that if the py launcher fails, we give the right error.
-    venv, _ = make_one(interpreter="python3.6")
-
-    # Trick the nox.virtualenv into thinking that it cannot find python3.6
-    # (it likely will on Unix). Also, when the nox.virtualenv looks for the
-    # py launcher, give it a dummy that fails.
-    def special_run(cmd: str, *args: str, **kwargs: object) -> TextProcessResult:  # noqa: ARG001
-        return TextProcessResult("", 1)
-
-    run.side_effect = special_run
-    which.side_effect = lambda x: "py" if x == "py" else None
-
-    # Okay now run the test.
-    with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        print(venv._resolved_interpreter)
-
-    which.assert_has_calls([mock.call("python3.6"), mock.call("py")])
-
-
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch("nox.virtualenv.UV_VERSION", new=version.Version("0.3"))
-def test__resolved_interpreter_windows_path_and_version(
-    make_one: Callable[..., tuple[VirtualEnv, Path]],
-    patch_sysfind: Callable[..., None],
-) -> None:
-    # Establish that if we get a standard pythonX.Y path, we look it
-    # up via the path on Windows.
-    venv, _ = make_one(interpreter="3.7")
-
-    # Trick the system into thinking that it cannot find
-    # pythonX.Y up until the python-in-path check at the end.
-    # Also, we don't give it a mock py launcher.
-    # But we give it a mock python interpreter to find
-    # in the system path.
-    correct_path = r"c:\python37-x64\python.exe"
-    patch_sysfind(
-        only_find=("python", "python.exe"),
-        sysfind_result=correct_path,
-        sysexec_result="3.7.3\\n",
-    )
-
-    # Okay, now run the test.
-    assert venv._resolved_interpreter == correct_path
-
-
-@pytest.mark.parametrize("input_", ["2.7", "python3.7", "goofy"])
-@pytest.mark.parametrize("sysfind_result", [r"c:\python37-x64\python.exe", None])
-@pytest.mark.parametrize("sysexec_result", ["3.7.3\\n", RAISE_ERROR])
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch("nox.virtualenv.UV_VERSION", new=version.Version("0.3"))
-def test__resolved_interpreter_windows_path_and_version_fails(
-    input_: str,
-    sysfind_result: None | str,
-    sysexec_result: str,
-    make_one: Callable[..., tuple[VirtualEnv, Path]],
-    patch_sysfind: Callable[..., None],
-) -> None:
-    # Establish that if we get a standard pythonX.Y path, we look it
-    # up via the path on Windows.
+    specs = patch_discover(None)
     venv, _ = make_one(interpreter=input_, download_python="never")
 
-    # Trick the system into thinking that it cannot find
-    # pythonX.Y up until the python-in-path check at the end.
-    # Also, we don't give it a mock py launcher.
-    # But we give it a mock python interpreter to find
-    # in the system path.
-    patch_sysfind(("python", "python.exe"), sysfind_result, sysexec_result)
-
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
         print(venv._resolved_interpreter)
+    assert specs == [input_]
 
 
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch.object(shutil, "which")
-def test__resolved_interpreter_not_found(
-    which: mock.Mock, make_one: Callable[..., tuple[VirtualEnv, Path]]
-) -> None:
-    # Establish that if an interpreter cannot be found at a standard
-    # location on Windows, we raise a useful error.
-    venv, _ = make_one(interpreter="python3.6", download_python="never")
-
-    # We are on Windows, and nothing can be found.
-    which.return_value = None
-
-    # Run the test.
-    with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        print(venv._resolved_interpreter)
-
-
-@mock.patch("nox.virtualenv._PLATFORM", new="win32")
-@mock.patch("nox.virtualenv.locate_via_py", new=lambda _: None)  # type: ignore[untyped-decorator]  # noqa: PT008
-def test__resolved_interpreter_nonstandard(
+def test__resolved_interpreter_full_path(
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
-    # Establish that we do not try to resolve non-standard locations
-    # on Windows.
-    venv, _ = make_one(interpreter="goofy")
+    # A fully-qualified path is passed through to discovery, which accepts it.
+    specs = patch_discover(r"c:\Python36\python.exe")
+    venv, _ = make_one(interpreter=r"c:\Python36\python.exe")
 
-    with pytest.raises(nox.virtualenv.InterpreterNotFound):
-        print(venv._resolved_interpreter)
+    assert venv._resolved_interpreter == r"c:\Python36\python.exe"
+    assert specs == [r"c:\Python36\python.exe"]
 
 
-@mock.patch("nox.virtualenv._PLATFORM", new="linux")
-@mock.patch.object(shutil, "which", return_value=True)
 def test__resolved_interpreter_cache_result(
-    which: mock.Mock, make_one: Callable[..., tuple[VirtualEnv, Path]]
+    make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
+    specs = patch_discover("/fake/bin/python3.6")
     venv, _ = make_one(interpreter="3.6")
 
     assert venv._resolved is None
-    assert venv._resolved_interpreter == "python3.6"
-    which.assert_called_once_with("python3.6")
+    assert venv._resolved_interpreter == "/fake/bin/python3.6"
+    assert specs == ["3.6"]
     # Check the cache and call again to make sure it is used.
-    assert venv._resolved == "python3.6"
-    assert venv._resolved_interpreter == "python3.6"  # type: ignore[unreachable]
-    assert which.call_count == 1
+    assert venv._resolved == "/fake/bin/python3.6"
+    assert venv._resolved_interpreter == "/fake/bin/python3.6"  # type: ignore[unreachable]
+    assert specs == ["3.6"]
 
 
-@mock.patch("nox.virtualenv._PLATFORM", new="linux")
-@mock.patch.object(shutil, "which", return_value=None)
 def test__resolved_interpreter_cache_failure(
-    which: mock.Mock, make_one: Callable[..., tuple[VirtualEnv, Path]]
+    make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
-    venv, _ = make_one(interpreter="3.7-32")
+    specs = patch_discover(None)
+    venv, _ = make_one(interpreter="3.7-32", download_python="never")
 
     assert venv._resolved is None
     with pytest.raises(nox.virtualenv.InterpreterNotFound) as exc_info:
         print(venv._resolved_interpreter)
     caught = exc_info.value
 
-    which.assert_called_once_with("3.7-32")
+    assert specs == ["3.7-32"]
     # Check the cache and call again to make sure it is used.
     assert venv._resolved is caught
     with pytest.raises(nox.virtualenv.InterpreterNotFound):  # type: ignore[unreachable]
         print(venv._resolved_interpreter)
-    assert which.call_count == 1
+    assert specs == ["3.7-32"]
 
 
 @pytest.mark.parametrize("venv_backend", ["uv", "venv", "virtualenv"])
 @mock.patch("nox.virtualenv.pbs_install_python")
 @mock.patch("nox.virtualenv.uv_install_python")
-@mock.patch.object(shutil, "which", return_value="/usr/bin/python3.11")
 def test_download_python_never_preexisting_interpreter(
-    which: mock.Mock,
     uv_install_mock: mock.Mock,
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
+    specs = patch_discover("/usr/bin/python3.11")
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
         download_python="never",
     )
 
-    resolved_interpreter = venv._resolved_interpreter
-    assert resolved_interpreter == "python3.11"
-    which.assert_called_once_with("python3.11")
+    assert venv._resolved_interpreter == "/usr/bin/python3.11"
+    assert specs == ["python3.11"]
 
     # should never try to install
     uv_install_mock.assert_not_called()
@@ -1723,14 +1549,14 @@ def test_download_python_never_preexisting_interpreter(
 @pytest.mark.parametrize("venv_backend", ["uv", "venv", "virtualenv"])
 @mock.patch("nox.virtualenv.pbs_install_python")
 @mock.patch("nox.virtualenv.uv_install_python")
-@mock.patch.object(shutil, "which", return_value=None)
 def test_download_python_never_missing_interpreter(
-    which: mock.Mock,
     uv_install_mock: mock.Mock,
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
+    specs = patch_discover(None)
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
@@ -1739,10 +1565,7 @@ def test_download_python_never_missing_interpreter(
     with pytest.raises(nox.virtualenv.InterpreterNotFound):
         _ = venv._resolved_interpreter
 
-    if IS_WINDOWS:
-        which.assert_called_with("py")
-    else:
-        which.assert_called_with("python3.11")
+    assert specs == ["python3.11"]
 
     # should never try to install
     uv_install_mock.assert_not_called()
@@ -1752,14 +1575,14 @@ def test_download_python_never_missing_interpreter(
 @pytest.mark.parametrize("venv_backend", ["uv", "venv", "virtualenv"])
 @mock.patch("nox.virtualenv.pbs_install_python")
 @mock.patch("nox.virtualenv.uv_install_python")
-@mock.patch.object(shutil, "which", return_value="/usr/bin/python3.11")
 def test_download_python_auto_preexisting_interpreter(
-    which: mock.Mock,
     uv_install_mock: mock.Mock,
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
+    specs = patch_discover("/usr/bin/python3.11")
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
@@ -1770,8 +1593,8 @@ def test_download_python_auto_preexisting_interpreter(
     uv_install_mock.assert_not_called()
     pbs_install_mock.assert_not_called()
 
-    assert venv._resolved_interpreter == "python3.11"
-    which.assert_called_with("python3.11")
+    assert venv._resolved_interpreter == "/usr/bin/python3.11"
+    assert specs == ["python3.11"]
 
 
 @pytest.mark.parametrize("venv_backend", ["uv", "venv", "virtualenv"])
@@ -1783,14 +1606,14 @@ def test_download_python_auto_preexisting_interpreter(
     "nox.virtualenv.uv_install_python",
     return_value=True,
 )
-@mock.patch.object(shutil, "which", return_value=None)
 def test_download_python_auto_missing_interpreter(
-    which: mock.Mock,
     uv_install_mock: mock.Mock,
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
+    specs = patch_discover(None)
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
@@ -1800,7 +1623,7 @@ def test_download_python_auto_missing_interpreter(
     resolved_interpreter = venv._resolved_interpreter
 
     # make sure we tried to find an interpreter first
-    which.assert_any_call("python3.11")
+    assert specs == ["python3.11"]
 
     # the resolved interpreter should be the one we install
     if venv_backend == "uv":
@@ -1822,14 +1645,14 @@ def test_download_python_auto_missing_interpreter(
     "nox.virtualenv.uv_install_python",
     return_value=True,
 )
-@mock.patch.object(shutil, "which", return_value="/usr/bin/python3.11")
 def test_download_python_always_preexisting_interpreter(
-    which: mock.Mock,
     uv_install_mock: mock.Mock,
     pbs_install_mock: mock.Mock,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
+    specs = patch_discover("/usr/bin/python3.11")
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
@@ -1839,7 +1662,7 @@ def test_download_python_always_preexisting_interpreter(
     resolved_interpreter = venv._resolved_interpreter
 
     # We should NOT try to find an existing interpreter
-    which.assert_not_called()
+    assert specs == []
 
     # the resolved interpreter should be the one we install
     if venv_backend == "uv":
@@ -1863,22 +1686,20 @@ def test_download_python_failed_install(
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
     monkeypatch: pytest.MonkeyPatch,
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
     # Pretend uv is available so the uv install path is exercised even on
     # hosts without uv installed (gh-1046).
     monkeypatch.setattr(nox.virtualenv, "HAS_UV", True)
     monkeypatch.setattr(nox.virtualenv, "UV_VERSION", version.Version("0.10.0"))
-
+    patch_discover(None)
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,
         download_python=download_python,
     )
 
-    with (
-        mock.patch.object(shutil, "which", return_value=None) as _,
-        pytest.raises(nox.virtualenv.InterpreterNotFound),
-    ):
+    with pytest.raises(nox.virtualenv.InterpreterNotFound):
         _ = venv._resolved_interpreter
 
     if venv_backend == "uv":
@@ -1887,6 +1708,60 @@ def test_download_python_failed_install(
     else:
         pbs_install_mock.assert_called_once_with("python3.11")
         uv_install_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("venv_backend", ["uv", "venv", "virtualenv"])
+@pytest.mark.parametrize("download_python", ["always", "auto"])
+@mock.patch(
+    "nox.virtualenv.pbs_install_python",
+    return_value="/.local/share/nox/cpython@3.14.0/bin/python3.14",
+)
+@mock.patch("nox.virtualenv.uv_install_python", return_value=True)
+def test_download_python_range_installs_floor(
+    uv_install_mock: mock.Mock,
+    pbs_install_mock: mock.Mock,
+    download_python: str,
+    venv_backend: str,
+    make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
+) -> None:
+    # A range that isn't found installs its floor (">=3.14" -> "python3.14").
+    patch_discover(None)
+    venv, _ = make_one(
+        interpreter=">=3.14",
+        venv_backend=venv_backend,
+        download_python=download_python,
+    )
+
+    resolved_interpreter = venv._resolved_interpreter
+
+    if venv_backend == "uv":
+        uv_install_mock.assert_called_once_with("python3.14")
+        assert resolved_interpreter == "python3.14"
+    else:
+        pbs_install_mock.assert_called_once_with("python3.14")
+        assert resolved_interpreter == "/.local/share/nox/cpython@3.14.0/bin/python3.14"
+
+
+@pytest.mark.parametrize("download_python", ["always", "auto"])
+@mock.patch("nox.virtualenv.pbs_install_python")
+@mock.patch("nox.virtualenv.uv_install_python")
+def test_download_python_range_without_floor(
+    uv_install_mock: mock.Mock,
+    pbs_install_mock: mock.Mock,
+    download_python: str,
+    make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
+) -> None:
+    # An upper-bound-only range has no installable floor: never install, error.
+    patch_discover(None)
+    venv, _ = make_one(interpreter="<3.14", download_python=download_python)
+
+    with pytest.raises(nox.virtualenv.InterpreterNotFound):
+        _ = venv._resolved_interpreter
+
+    uv_install_mock.assert_not_called()
+    pbs_install_mock.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -1945,6 +1820,31 @@ def test_find_pbs_python_missing_interpreter(
         bin_dir.mkdir(parents=True)
 
     assert nox.virtualenv._find_pbs_python("cpython", "3.11") is None
+
+
+def test_find_pbs_python_no_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No previously-installed pbs pythons: the directory does not exist.
+    monkeypatch.setattr("nox.virtualenv.NOX_PBS_PYTHONS", tmp_path / "missing")
+    assert nox.virtualenv._find_pbs_python("cpython", "3.11") is None
+
+
+def test_pbs_install_python_install_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failing pbs install is caught and reported, returning None."""
+    monkeypatch.setattr("nox.virtualenv.NOX_PBS_PYTHONS", tmp_path / "missing")
+    pytest.importorskip("pbs_installer")
+
+    def mock_install(*args: Any, **kwargs: Any) -> NoReturn:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("pbs_installer.install", mock_install)
+
+    assert nox.virtualenv.pbs_install_python("python3.11") is None
+    assert "Failed to install a pbs version" in caplog.text
 
 
 @mock.patch("nox.virtualenv._find_pbs_python", return_value="/existing/python/path")
@@ -2006,14 +1906,14 @@ def test_pbs_install_python_success(
 @mock.patch("nox.virtualenv.HAS_UV", new=True)
 @mock.patch("nox.virtualenv.UV_VERSION", new=version.Version("0.4.0"))
 @mock.patch("nox.virtualenv.uv_install_python", return_value=True)
-@mock.patch.object(shutil, "which", return_value=None)
 def test_download_python_uv_unsupported_version(
-    which: mock.Mock,
     uv_install_mock: mock.Mock,
     download_python: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    patch_discover: Callable[[str | None], list[str]],
 ) -> None:
     """Test we dont install for unsupported uv versions"""
+    specs = patch_discover(None)
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend="uv",
@@ -2025,6 +1925,6 @@ def test_download_python_uv_unsupported_version(
 
     uv_install_mock.assert_not_called()
     if download_python == "always":
-        which.assert_not_called()
+        assert specs == []
     else:  # auto
-        which.assert_any_call("python3.11")
+        assert specs == ["python3.11"]

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1212,6 +1212,28 @@ def test_discover_interpreter(monkeypatch: pytest.MonkeyPatch) -> None:
     assert nox.virtualenv._discover_interpreter("3.12") is sentinel
 
 
+def test_discover_interpreter_cache_unwritable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unwritable cache degrades to uncached discovery, not a hard failure."""
+    sentinel = object()
+    cache = object()
+    calls: list[object] = []
+
+    def fake_get(spec: str, cache: object = None) -> object:
+        assert spec == "3.12"
+        calls.append(cache)
+        if cache is not None:
+            raise PermissionError
+        return sentinel
+
+    monkeypatch.setattr(python_discovery, "get_interpreter", fake_get)
+    monkeypatch.setattr(nox.virtualenv, "_get_python_discovery_cache", lambda: cache)
+
+    assert nox.virtualenv._discover_interpreter("3.12") is sentinel
+    assert calls == [cache, None]
+
+
 def test_find_python_cached(
     patch_discover: Callable[[str | None], list[str]],
 ) -> None:
@@ -1259,6 +1281,9 @@ def test_get_python_discovery_cache_oserror(monkeypatch: pytest.MonkeyPatch) -> 
         ("~=3.11", "3.11"),
         ("==3.12.*", "3.12"),
         (">=3.11,<3.13", "3.11"),
+        ("pypy>=3.10", "pypy3.10"),
+        ("cpython>=3.12", "3.12"),
+        (">=3.13t", "3.13t"),
         ("<3.14", None),
         ("!=3.12", None),
     ],


### PR DESCRIPTION
This enables version ranges to be used. It also can find Pythons from a variety of sources that we didn't support before.

Two user facing changes:

1. The interpreter selected can sometimes be different.
2. Putting the name of an interpreter on the path there the discovery doesn't select won't pick it - full paths required for that case.

* We could check matching names first, which would shortcut the check and behave a bit more like previous (probably affecting 1 above, supporting 2).
* We should also support script python-requires using this

:robot: ~~Assisted-by: OpenCode:Kimi-K2.5~~ (First draft)

Assisted-by: ClaudeCode:claude-opus-4.8
