### PR TITLE
fix(project): return empty dict from load_toml when script file missing

### DIFF
--- a/nox/project.py
+++ b/nox/project.py
@@ -74,7 +74,12 @@ def _load_toml_file(filepath: Path) -> dict[str, Any]:
 
 def _load_script_block(filepath: Path, *, missing_ok: bool) -> dict[str, Any]:
     name = "script"
-    script = filepath.read_text(encoding="utf-8")
+    try:
+        script = filepath.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        if missing_ok:
+            return {}
+        raise
     matches = list(filter(lambda m: m.group("type") == name, REGEX.finditer(script)))
 
     if not matches:

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -109,3 +109,14 @@ def test_load_non_recognised_extension() -> None:
     msg = "Extension must be .py or .toml, got .txt"
     with pytest.raises(ValueError, match=msg):
         nox.project.load_toml("some.txt")
+
+
+def test_load_missing_script_missing_ok(tmp_path: Path) -> None:
+    filepath = tmp_path / "noxfile.py"
+    assert nox.project.load_toml(filepath, missing_ok=True) == {}
+
+
+def test_load_missing_script_default_raises(tmp_path: Path) -> None:
+    filepath = tmp_path / "noxfile.py"
+    with pytest.raises(FileNotFoundError):
+        nox.project.load_toml(filepath)


### PR DESCRIPTION
Closes #1094.

`load_toml("noxfile.py", missing_ok=True)` is called from `_cli.py` to scan for a PEP 723 script block, but it leaked `FileNotFoundError` when the noxfile didn't exist instead of falling back to the friendly "Failed to load Noxfile ... no such file exists" message produced later in `load_nox_module`. Treat a missing file the same as a missing script block when `missing_ok=True` so the existing handler runs.