### PR TITLE
docs: fix typo in README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can also use [pip][] in your global python:
 python3 -m pip install nox
 ```
 
-You may want to user the [user-site][] to avoid messing with your Global python install:
+You may want to use the [user-site][] to avoid messing with your Global python install:
 
 ```shell
 python3 -m pip install --user nox


### PR DESCRIPTION
## What

Fix a single-word typo in the README installation section.

- Before: `You may want to user the [user-site][]`
- After: `You may want to use the [user-site][]`

## Why

The word "user" should be "use" — a small but noticeable grammatical error in the installation instructions.

## How verified

Simple one-word text change; no logic or tests affected.