### PR TITLE
Clarify session.notify target docs

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -350,7 +350,9 @@ invoking Nox in :doc:`usage`.
 Queuing sessions
 -----------------
 
-If you want to queue up (or "notify") another session from the current one, you can use the ``session.notify`` function:
+If you want to queue up (or "notify") another session from the current one, you
+can use the ``session.notify`` function. Pass the session name string, the same
+name you would use with ``nox --session``:
 
 .. code-block:: python
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -943,9 +943,9 @@ class Session:
         Now if you run `nox -s test`, the coverage session will run afterwards.
 
         Args:
-            target (Union[str, Callable]): The session to be notified. This
-                may be specified as the appropriate string (same as used for
-                ``nox -s``) or using the function object.
+            target (str): The session name to notify, as used for ``nox -s``.
+                Passing the decorated function object is not currently
+                supported.
             posargs (Optional[Iterable[str]]): If given, sets the positional
                 arguments *only* for the queued session. Otherwise, the
                 standard globally available positional arguments will be


### PR DESCRIPTION
## Summary
- Clarify that session.notify() expects a session name string, matching 
ox -s / 
ox --session.
- Remove wording that suggested decorated function objects are currently supported.
- Update the tutorial wording to match the API docs.

## Tests
- git diff --check
- python -m py_compile nox\\sessions.py
- python -m pytest tests\\test_sessions.py::TestSession::test_notify tests\\test_manifest.py::test_notify tests\\test_manifest.py::test_notify_noop tests\\test_manifest.py::test_notify_with_posargs tests\\test_manifest.py::test_notify_error -q (5 passed, isolated temp venv)

Addresses #748.