### PR TITLE
Sort classifier-derived Python versions

### DIFF
--- a/nox/project.py
+++ b/nox/project.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import packaging.requirements
 import packaging.specifiers
+import packaging.version
 from dependency_groups import resolve
 
 if TYPE_CHECKING:
@@ -94,7 +95,7 @@ def _load_script_block(filepath: Path, *, missing_ok: bool) -> dict[str, Any]:
 
 
 def python_versions(
-    pyproject: dict[str, Any], *, max_version: str | None = None
+    pyproject: dict[str, Any], *, max_version: str | None = None, sort: bool = True
 ) -> list[str]:
     """
     Read a list of supported Python versions. Without ``max_version``, this
@@ -102,6 +103,9 @@ def python_versions(
     will read the requires-python setting for a lower bound, and will use the
     value of ``max_version`` as the upper bound. (Reminder: you should never
     set an upper bound in ``requires-python``).
+
+    Classifier-derived versions are sorted by default. Set ``sort=False`` to
+    preserve classifier order.
 
     Example:
 
@@ -123,6 +127,8 @@ def python_versions(
             if c.startswith("Programming Language :: Python :: 3.")
         ]
         if from_classifiers:
+            if sort:
+                return sorted(from_classifiers, key=packaging.version.Version)
             return from_classifiers
         msg = 'No Python version classifiers found in "project.classifiers"'
         raise ValueError(msg)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -23,6 +23,34 @@ def test_classifiers() -> None:
     assert python_versions(pyproject) == ["3.10", "3.11", "3.12"]
 
 
+def test_classifiers_are_sorted_by_default() -> None:
+    pyproject = {
+        "project": {
+            "classifiers": [
+                "Programming Language :: Python :: 3.12",
+                "Programming Language :: Python :: 3.10",
+                "Programming Language :: Python :: 3.11",
+            ],
+        }
+    }
+
+    assert python_versions(pyproject) == ["3.10", "3.11", "3.12"]
+
+
+def test_classifiers_can_preserve_order() -> None:
+    pyproject = {
+        "project": {
+            "classifiers": [
+                "Programming Language :: Python :: 3.12",
+                "Programming Language :: Python :: 3.10",
+                "Programming Language :: Python :: 3.11",
+            ],
+        }
+    }
+
+    assert python_versions(pyproject, sort=False) == ["3.12", "3.10", "3.11"]
+
+
 def test_no_classifiers() -> None:
     pyproject = {"project": {"requires-python": ">=3.10"}}
     with pytest.raises(ValueError, match="No Python version classifiers"):


### PR DESCRIPTION
## Summary
- sort classifier-derived `python_versions()` results by default
- add `sort=False` to preserve classifier order when callers need it
- cover both default sorted behavior and opt-out behavior in tests

Closes #1074.

## Validation
- temporary venv `python -m pytest tests/test_project.py`
- `python -m compileall -q nox`
- git diff --check