### PR TITLE
ci: bump conda pin to fix signature-verification plugin conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           channels: conda-forge
           conda-remove-defaults: true
-          conda-version: '25.11.1'
+          conda-version: '26.5.2'
           activate-environment:
       - name: Install Nox-under-test (uv)
         run:  uv pip install --system .


### PR DESCRIPTION
Investigating a fix for the broken CI.

:robot: _AI text below_ :robot:

## Problem

`conda_tests` is failing on all platforms (Ubuntu/macOS/Windows, 3.14 matrix) at `conda create`:

```
PluginError: Conflicting plugins found for `post_solves`:
  - CondaPostSolve(name='signature-verification', ...)
Multiple conda plugins are registered via the `conda_post_solves` hook.
```

## Root cause

The CI pins conda to `25.11.1`, which still ships the **built-in** `conda.plugins.post_solves.signature_verification` plugin. The standalone [`conda-content-trust 0.3.0`](https://github.com/conda/conda-content-trust) package now on conda-forge registers its **own** `post_solves` signature-verification plugin. Both register under the same hook → conda refuses to run. The built-in plugin is only removed in **conda 26.3.0** ([conda/conda#15783](https://github.com/conda/conda/issues/15783)), so the current pin is exactly the version that conflicts.

## Fix

Bump the pin `25.11.1` → `26.5.2` (latest stable). In 26.3.0+ the built-in plugin is gone and `conda-content-trust 0.3.0` is the sole provider, so there is no conflict.