### PR TITLE
fix: create missing parent directories for the session cache dir

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -260,7 +260,7 @@ class Session:
     def cache_dir(self) -> pathlib.Path:
         """Create and return a 'shared cache' directory to be used across sessions."""
         path = pathlib.Path(self._runner.global_config.envdir).joinpath(".cache")
-        path.mkdir(exist_ok=True)
+        path.mkdir(parents=True, exist_ok=True)
         return path
 
     @property

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -174,6 +174,16 @@ class TestSession:
                 ".cache"
             )
 
+    def test_cache_dir_missing_envdir(self) -> None:
+        session, runner = self.make_session_and_runner()
+        with tempfile.TemporaryDirectory() as root:
+            runner.global_config.envdir = os.path.join(root, "missing", ".nox")
+
+            cache_dir = session.cache_dir
+
+            assert cache_dir == Path(runner.global_config.envdir).joinpath(".cache")
+            assert cache_dir.is_dir()
+
     def test_no_bin_paths(self) -> None:
         session, runner = self.make_session_and_runner()
 


### PR DESCRIPTION
I think this can happen if a user sets this to a nested directory. Normally it's just one level deep (`.nox`).

:robot: _AI text below_ :robot:

`Session.cache_dir` created the shared `.cache` directory with `path.mkdir(exist_ok=True)`, so accessing it before the environment directory exists (e.g. a `venv_backend="none"` session on a clean checkout, where nothing has created `.nox` yet) raised `FileNotFoundError`. This passes `parents=True` so the missing parent directories are created as needed, and adds a regression test covering an envdir that does not exist yet.

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
