### PR TITLE
fix(tox-to-nox): handle '=' in set_env values and out-of-tree change_dir

### DIFF
--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -89,7 +89,7 @@ def main() -> None:
         # Convert set_env from string to dict
         set_env = {}
         for var in section.get("set_env", "").strip().splitlines():
-            k, v = var.split("=")
+            k, v = var.split("=", 1)
             if k not in {
                 "PYTHONHASHSEED",
                 "PIP_DISABLE_PIP_VERSION_CHECK",
@@ -125,11 +125,16 @@ def main() -> None:
             config[name]["base_python"] = impl + section["py_dot_ver"]
 
         change_dir = Path(section.get("change_dir", ""))
-        rel_to_cwd = change_dir.relative_to(Path.cwd())
-        if str(rel_to_cwd) == ".":
-            config[name]["change_dir"] = None
+        try:
+            rel_to_cwd = change_dir.relative_to(Path.cwd())
+        except ValueError:
+            # change_dir is outside the project root, keep the absolute path
+            config[name]["change_dir"] = change_dir
         else:
-            config[name]["change_dir"] = rel_to_cwd
+            if str(rel_to_cwd) == ".":
+                config[name]["change_dir"] = None
+            else:
+                config[name]["change_dir"] = rel_to_cwd
 
     output = _TEMPLATE.render(config=config, wrapjoin=wrapjoin, fixname=fixname)
 

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -234,6 +234,39 @@ def test_env(makeconfig: Callable[[str], str]) -> None:
     )
 
 
+def test_env_with_equals_sign_in_value(makeconfig: Callable[[str], str]) -> None:
+    result = makeconfig(
+        textwrap.dedent(
+            f"""
+    [tox]
+    envlist = lint
+
+    [testenv:lint]
+    basepython = python{PYTHON_VERSION}
+    setenv =
+        URL=https://example.com/?a=1&b=2
+        TEST=meep=morp
+    """
+        )
+    )
+
+    assert (
+        result
+        == textwrap.dedent(
+            f"""
+    import nox
+
+
+    @nox.session(python='python{PYTHON_VERSION}')
+    def lint(session):
+        session.env['TEST'] = 'meep=morp'
+        session.env['URL'] = 'https://example.com/?a=1&b=2'
+        session.install('.')
+    """
+        ).lstrip()
+    )
+
+
 def test_chdir(makeconfig: Callable[[str], str]) -> None:
     result = makeconfig(
         textwrap.dedent(
@@ -259,6 +292,40 @@ def test_chdir(makeconfig: Callable[[str], str]) -> None:
     def lint(session):
         session.install('.')
         session.chdir('docs')
+    """
+        ).lstrip()
+    )
+
+
+def test_chdir_outside_project(
+    makeconfig: Callable[[str], str], tmp_path: Path
+) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    result = makeconfig(
+        textwrap.dedent(
+            f"""
+    [tox]
+    envlist = lint
+
+    [testenv:lint]
+    basepython = python{PYTHON_VERSION}
+    changedir = {outside}
+    """
+        )
+    )
+
+    assert (
+        result
+        == textwrap.dedent(
+            f"""
+    import nox
+
+
+    @nox.session(python='python{PYTHON_VERSION}')
+    def lint(session):
+        session.install('.')
+        session.chdir('{outside}')
     """
         ).lstrip()
     )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This fixes two crashes in `tox-to-nox` when converting real-world `tox.ini` files:

1. **`set_env` values containing `=`** — `var.split("=")` raised `ValueError: too many values to unpack` for any entry whose value contains an `=` (URLs with query strings, `FOO=a=b`, etc.). Now splits on the first `=` only (`var.split("=", 1)`).

2. **`change_dir` outside the project root** — `change_dir.relative_to(Path.cwd())` raised `ValueError` when tox's `change_dir` points outside the current directory. Now falls back to emitting the absolute path in the generated `session.chdir(...)` instead of crashing.

Regression tests added for both cases.

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
