### PR TITLE
fix: enforce --error-on-external-run even when log=False

### DIFF
--- a/nox/command.py
+++ b/nox/command.py
@@ -163,24 +163,24 @@ def run(
     if log:
         logger.info(full_cmd)
 
-        is_external_tool = paths is not None and not any(
-            cmd_path.startswith(str(path)) for path in paths
-        )
-        if is_external_tool:
-            if external == "error":
-                logger.error(
-                    f"Error: {cmd} is not installed into the virtualenv, it is located"
-                    f" at {cmd_path}. Pass external=True into run() to explicitly allow"
-                    " this."
-                )
-                msg = "External program disallowed."
-                raise CommandFailed(msg)
-            if external is False:
-                logger.warning(
-                    f"Warning: {cmd} is not installed into the virtualenv, it is"
-                    f" located at {cmd_path}. This might cause issues! Pass"
-                    " external=True into run() to silence this message."
-                )
+    is_external_tool = paths is not None and not any(
+        cmd_path.startswith(str(path)) for path in paths
+    )
+    if is_external_tool:
+        if external == "error":
+            logger.error(
+                f"Error: {cmd} is not installed into the virtualenv, it is located"
+                f" at {cmd_path}. Pass external=True into run() to explicitly allow"
+                " this."
+            )
+            msg = "External program disallowed."
+            raise CommandFailed(msg)
+        if external is False and log:
+            logger.warning(
+                f"Warning: {cmd} is not installed into the virtualenv, it is"
+                f" located at {cmd_path}. This might cause issues! Pass"
+                " external=True into run() to silence this message."
+            )
 
     env = _clean_env(env)
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -232,6 +232,33 @@ def test_run_external_raises(tmp_path: Path, caplog: pytest.LogCaptureFixture) -
     assert "external=True" in caplog.text
 
 
+def test_run_external_raises_without_log(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(nox.command.CommandFailed):
+        nox.command.run(
+            [PYTHON, "--version"],
+            silent=True,
+            paths=[tmp_path],
+            external="error",
+            log=False,
+        )
+
+    assert "external=True" in caplog.text
+
+
+def test_run_external_no_warning_without_log(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING)
+
+    nox.command.run([PYTHON, "--version"], silent=True, paths=[tmp_path], log=False)
+
+    assert "external=True" not in caplog.text
+
+
 def test_exit_codes() -> None:
     assert nox.command.run([PYTHON, "-c", "import sys; sys.exit(0)"])
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## The bug

In `nox/command.py`, the `is_external_tool` computation and the `external == "error"` enforcement were nested inside `if log:`. As a result, `session.run(..., log=False)` bypassed `--error-on-external-run` entirely — the flag's documented contract ("Error if `run()` is used to execute a program that isn't installed in the session's virtualenv") was silently broken for any unlogged command.

## The fix

Hoist the external-tool detection and the `external == "error"` hard-error path (including its `logger.error` message, so the failure reason still surfaces when command echo is suppressed) out of the `if log:` block. The informational command echo and the external-program *warning* remain conditional on `log`, so all `log=True` paths behave exactly as before and `log=False` still suppresses purely informational output.

## Tests

- `test_run_external_raises_without_log`: mirrors the existing `test_run_external_raises` with `log=False`; fails on `main`, passes with this fix.
- `test_run_external_no_warning_without_log`: verifies the warning (non-error) path stays silent with `log=False`, covering the new branch.

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
