### PR TITLE
fix: hash fully non-ASCII session names instead of returning the envdir

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -91,11 +91,19 @@ def _normalize_path(envdir: str, path: str | bytes) -> str:
     if isinstance(path, bytes):
         path = path.decode("utf-8")
 
+    orig_path = path
     path = unicodedata.normalize("NFKD", path).encode("ascii", "ignore")
     path = path.decode("ascii")
     path = re.sub(r"[^\w\s-]", "-", path).strip().lower()
     path = re.sub(r"[-\s]+", "-", path)
     path = path.strip("-")
+
+    if not path:
+        path = hashlib.sha1(orig_path.encode("utf-8")).hexdigest()[:8]  # noqa: S324
+        logger.warning(
+            "The virtualenv name was hashed because it contains no usable "
+            "ASCII characters."
+        )
 
     full_path = os.path.join(envdir, path)
     if len(full_path) > 100 - len("bin/pythonX.Y"):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -102,6 +102,20 @@ def test__normalize_path_give_up() -> None:
     assert "any-path" in norm_path
 
 
+def test__normalize_path_non_ascii() -> None:
+    envdir = "envdir"
+    normalize = nox.sessions._normalize_path
+
+    norm_path = normalize(envdir, "测试")
+    # The result must be a subdirectory of envdir, not envdir itself.
+    assert os.path.dirname(norm_path) == envdir
+    assert os.path.basename(norm_path)
+    # The result must be stable across calls.
+    assert normalize(envdir, "测试") == norm_path
+    # Two different non-ASCII names must not collide.
+    assert normalize(envdir, "тест") != norm_path
+
+
 class FakeEnv(mock.MagicMock):
     _get_env = nox.virtualenv.VirtualEnv._get_env
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

A session whose name contains no ASCII word characters (e.g. `@nox.session(name="测试")`) ends up with the **envdir itself** as its virtualenv location. `_normalize_path` in `nox/sessions.py` normalizes the name with NFKD, encodes it with `ascii`/`ignore`, and applies regex substitutions — for a fully non-ASCII name this yields the empty string, so `os.path.join(envdir, "")` returns `.nox/` itself.

Consequences:

- The session's virtualenv `location` is `.nox/` itself.
- Two such sessions silently share a single environment.
- Worst of all, `VirtualEnv._clean_location()` calls `shutil.rmtree(self.location)` when the environment is not being reused — **deleting every other session's virtualenv under `.nox`**.

## Root cause

`_normalize_path` had no guard for the normalized name coming out empty; the empty basename made the "safe" path collapse to the envdir.

## Fix

When the normalized name is empty, reuse the existing sha1-hash fallback (previously only used for over-long paths), hashing the original UTF-8 name so the result is a stable, unique subdirectory of the envdir. A warning is logged explaining why the name was hashed.

Regression tests added: a fully non-ASCII name must not return the envdir itself, must be stable across calls, and two different non-ASCII names must not collide.

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
