### PR TITLE
fix: don't crash when a parametrized session has an empty parameter list

### DIFF
--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -264,6 +264,14 @@ class Manifest:
             for session in sessions_by_id.values()
         }
 
+        # Sessions without any signatures (e.g. the placeholder session created
+        # when a parametrized session has an empty list of parameters) are not
+        # in ``sessions_by_id``, so add any missing queued sessions to the graph.
+        for session in self._queue:
+            dependency_graph.setdefault(
+                session, session.get_direct_dependencies(sessions_by_id)
+            )
+
         # Resolve the dependency graph.
         root = cast("SessionRunner", object())  # sentinel
         try:

--- a/tests/resources/noxfile_empty_parametrize.py
+++ b/tests/resources/noxfile_empty_parametrize.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import nox
+
+
+@nox.session(venv_backend="none")
+def regular(session):
+    print(session.name)
+
+
+@nox.session(venv_backend="none")
+@nox.parametrize("param", [])
+def no_params(session, param):
+    print(session.name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -634,6 +634,27 @@ def test_main_requries_modern_param(
     assert returncode == 0
 
 
+def test_main_list_with_empty_parametrize(
+    run_nox: Callable[..., tuple[Any, Any, Any]],
+) -> None:
+    noxfile = os.path.join(RESOURCES, "noxfile_empty_parametrize.py")
+    returncode, stdout, _ = run_nox(f"--noxfile={noxfile}", "--list")
+    assert returncode == 0
+    assert "regular" in stdout
+    assert "no_params" in stdout
+
+
+def test_main_run_with_empty_parametrize(
+    run_nox: Callable[..., tuple[Any, Any, Any]],
+) -> None:
+    noxfile = os.path.join(RESOURCES, "noxfile_empty_parametrize.py")
+    returncode, stdout, stderr = run_nox(f"--noxfile={noxfile}")
+    assert returncode == 0
+    assert stdout == "regular\n"
+    assert "Session regular was successful." in stderr
+    assert "This session had no parameters available." in stderr
+
+
 def test_main_duplicate_session(
     run_nox: Callable[..., tuple[Any, Any, Any]],
 ) -> None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -388,6 +388,28 @@ def test_add_session_parametrized_noop() -> None:
     assert session.func == _null_session_func
 
 
+def test_add_dependencies_with_empty_parametrize() -> None:
+    manifest = Manifest({}, create_mock_config())
+
+    # Define a session without any parameters available.
+    @nox.parametrize("param", ())
+    def empty(session: nox.Session, param: object) -> None:
+        pass
+
+    # Add the placeholder session and a regular session to the manifest.
+    for session in manifest.make_session("empty", Func(empty, python=None)):
+        manifest.add_session(session)
+    for session in manifest.make_session("regular", Func(lambda _: None)):
+        manifest.add_session(session)
+    assert len(manifest) == 2
+
+    # The placeholder session has no signatures, but dependency resolution
+    # must still account for it.
+    manifest.add_dependencies()
+
+    assert [session.name for session in manifest._queue] == ["empty", "regular"]
+
+
 def test_notify() -> None:
     manifest = Manifest({}, create_mock_config())
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

A noxfile containing a parametrized session whose parameter list is empty:

```python
import nox

@nox.session
def regular(session):
    ...

@nox.session
@nox.parametrize("x", [])
def empty(session, x):
    ...
```

makes **every** nox invocation — including `nox -l` — fail with exit code 3:

```
nox > Error while resolving session dependencies.
nox > Session(name=empty, signatures=)
```

This is a regression relative to nox 2024.4.15 (before the `requires` dependency-resolution feature), which ran the other sessions normally and reported the empty session as skipped ("This session had no parameters available.").

## Root cause

When a parametrize produces no calls, `Manifest.make_session()` creates a placeholder no-op session with `signatures=[]`. `Manifest.add_dependencies()` builds the dependency graph only from `all_sessions_by_signature.values()`, so the signature-less placeholder sits in the queue but never enters the graph. `lazy_stable_topo_sort()` then looks up `visited[node]` for the queued placeholder and raises a raw `KeyError` whose argument is the `SessionRunner` itself, which `filter_manifest` reports as the dependency-resolution error above.

## Fix

After building the graph from the signature map, add any queued sessions that are missing from it (with their direct dependencies, still resolved lazily). The placeholder session now resolves normally again: it appears in `nox -l` listings and reports as skipped while the other sessions run, matching the 2024.4.15 behavior.

Regression tests are added at both levels: a `Manifest.add_dependencies()` unit test, and `nox --list` / full-run integration tests against a new `noxfile_empty_parametrize.py` resource.

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
