### PR TITLE
fix: script-mode pip resolution on Windows and --download-python fallback

### DIFF
--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -171,11 +171,14 @@ def run_script_mode(
     venv.create()
     env = {k: v for k, v in venv._get_env({}).items() if v is not None}
     env["NOX_SCRIPT_MODE"] = "none"
-    cmd = (
-        [nox.virtualenv.UV, "pip", "install"]
-        if venv.venv_backend == "uv"
-        else ["pip", "install"]
-    )
+    if venv.venv_backend == "uv":
+        cmd = [nox.virtualenv.UV, "pip", "install"]
+    else:
+        # On Windows, subprocess resolves the executable against the parent
+        # process's PATH, not the child env's, so resolve pip explicitly.
+        pip_cmd = shutil.which("pip", path=env["PATH"])
+        assert pip_cmd is not None, "pip must be discoverable in the environment"
+        cmd = [pip_cmd, "install"]
     subprocess.run([*cmd, *dependencies], env=env, check=True)
     nox_cmd = shutil.which("nox", path=env["PATH"])
     assert nox_cmd is not None, "Nox must be discoverable when installed"
@@ -249,9 +252,10 @@ def _main(*, main_ep: bool) -> None:
                     or (
                         toml_config.get("tool", {})
                         .get("nox", {})
-                        .get("script-download-python", "auto")
+                        .get("script-download-python")
                     )
                     or args.download_python
+                    or "auto"
                 )
 
                 if download_python not in ("auto", "never", "always"):

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import dataclasses
 import importlib.metadata
 import importlib.util
+import os
+import shutil
+import subprocess
 import sys
 import typing
 from types import SimpleNamespace
@@ -12,6 +15,7 @@ import packaging.version
 import pytest
 
 import nox._cli
+import nox.virtualenv
 
 if typing.TYPE_CHECKING:
     from pathlib import Path
@@ -156,6 +160,109 @@ def test_dependencies_with_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not nox._cli.check_dependencies(
         ["nox @ git+https://github.com/other/nox@2024.10.09"]
     )
+
+
+@pytest.mark.parametrize("backend", ["uv", "virtualenv"])
+def test_run_script_mode_pip_resolution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, backend: str
+) -> None:
+    """pip must be resolved against the venv's PATH (Windows searches the parent's)."""
+    calls: list[list[str]] = []
+
+    fake_venv = SimpleNamespace(
+        venv_backend=backend,
+        create=lambda: None,
+        _get_env=lambda _env: {"PATH": "/fake/venv/bin"},
+    )
+    monkeypatch.setattr(
+        nox.virtualenv, "get_virtualenv", lambda *_args, **_kwargs: fake_venv
+    )
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(list(cmd))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(shutil, "which", lambda cmd, path=None: f"{path}/{cmd}")
+
+    def fake_execle(_path: str, *_args: object) -> typing.NoReturn:
+        raise SystemExit(0)
+
+    monkeypatch.setattr(os, "execle", fake_execle)
+    monkeypatch.setattr(sys, "argv", ["nox"])
+
+    with pytest.raises(SystemExit):
+        nox._cli.run_script_mode(
+            "noxfile.py",
+            tmp_path,
+            reuse=False,
+            dependencies=["nox", "cowsay"],
+            venv_backend=backend,
+            download_python="never",
+        )
+
+    expected = (
+        [nox.virtualenv.UV, "pip", "install"]
+        if backend == "uv"
+        else ["/fake/venv/bin/pip", "install"]
+    )
+    assert calls[0] == [*expected, "nox", "cowsay"]
+
+
+@pytest.mark.parametrize(
+    ("script_env", "global_env", "toml_value", "cli_args", "expected"),
+    [
+        ("always", "never", "never", ["--download-python", "never"], "always"),
+        (None, None, "always", ["--download-python", "never"], "always"),
+        (None, None, None, ["--download-python", "never"], "never"),
+        (None, "always", None, [], "always"),
+        (None, None, None, [], "auto"),
+    ],
+)
+def test_script_mode_download_python_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    script_env: str | None,
+    global_env: str | None,
+    toml_value: str | None,
+    cli_args: list[str],
+    expected: str,
+) -> None:
+    for var, value in (
+        ("NOX_SCRIPT_DOWNLOAD_PYTHON", script_env),
+        ("NOX_DOWNLOAD_PYTHON", global_env),
+    ):
+        if value is None:
+            monkeypatch.delenv(var, raising=False)
+        else:
+            monkeypatch.setenv(var, value)
+    monkeypatch.delenv("NOX_SCRIPT_MODE", raising=False)
+    monkeypatch.delenv("NOX_SCRIPT_VENV_BACKEND", raising=False)
+    monkeypatch.setattr(sys, "argv", ["nox", *cli_args])
+    # This will return pytest's filename instead, so patching it to None
+    monkeypatch.setattr(nox._cli, "get_main_filename", lambda: None)
+    monkeypatch.setattr(nox._cli, "check_dependencies", lambda _deps: False)
+
+    captured: dict[str, object] = {}
+
+    def fake_run_script_mode(*_args: object, **kwargs: object) -> typing.NoReturn:
+        captured.update(kwargs)
+        raise SystemExit(0)
+
+    monkeypatch.setattr(nox._cli, "run_script_mode", fake_run_script_mode)
+    monkeypatch.chdir(tmp_path)
+    toml_line = (
+        f"# tool.nox.script-download-python = '{toml_value}'\n" if toml_value else ""
+    )
+    tmp_path.joinpath("noxfile.py").write_text(
+        f"# /// script\n# dependencies=['nox']\n{toml_line}# ///",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        nox._cli.main()
+
+    assert captured["download_python"] == expected
 
 
 def test_dependencies_with_version(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This fixes two bugs in PEP 723 script mode (`nox/_cli.py`), with regression tests.

## Bug 1: wrong `pip` resolved on Windows in `run_script_mode`

The non-uv branch ran `subprocess.run(["pip", "install", ...], env=env)`. On POSIX this works because CPython resolves the executable using the *child* env's `PATH` (the script venv comes first). On Windows, however, `CreateProcess` searches the **parent** process's `PATH`, not `lpEnvironment`, so the outer `pip` was found — installing the script's dependencies into the wrong environment — or no `pip` was found at all.

The fix resolves pip explicitly with `shutil.which("pip", path=env["PATH"])`, the same pattern already used three lines later to locate the `nox` executable. The bug is Windows-specific, but the new code path is identical on all platforms (and the new unit test covers both backends cross-platform by asserting the exact command passed to `subprocess.run`).

## Bug 2: `--download-python` ignored in script mode

```python
download_python = (
    os.environ.get("NOX_SCRIPT_DOWNLOAD_PYTHON")
    or (toml_config.get("tool", {}).get("nox", {}).get("script-download-python", "auto"))
    or args.download_python
)
```

The TOML `.get()` had a truthy default of `"auto"`, so `or args.download_python` was unreachable — the `--download-python` flag (and `NOX_DOWNLOAD_PYTHON`, which feeds the option default) was always ignored for the script-mode environment, even though the code clearly intends it as a fallback.

Fixed by dropping the `.get()` default and appending `or "auto"`, giving the intended precedence:

1. `NOX_SCRIPT_DOWNLOAD_PYTHON` env var
2. `tool.nox.script-download-python` in the script's TOML block
3. `--download-python` / `NOX_DOWNLOAD_PYTHON`
4. `"auto"`

## Tests

- `test_run_script_mode_pip_resolution` (parametrized over `uv`/`virtualenv`) mocks `subprocess.run` and asserts the resolved install command, covering both backend branches directly (previously only exercised indirectly via subprocess tests).
- `test_script_mode_download_python_precedence` covers the full precedence chain, including the previously broken case (no env var, no TOML key, CLI flag set).

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
