### PR TITLE
fix: interpreter-resolution edge cases (pbs exact-version lookup, impl group, -32 suffix)

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -119,7 +119,7 @@ def _find_python(interpreter: str, xy_ver: str) -> str | None:
     # Windows only search for the executable
     if _PLATFORM.startswith("win"):
         # Allow versions of the form ``X.Y-32`` for Windows.
-        match = re.match(r"^\d\.\d+-32?$", interpreter)
+        match = re.match(r"^\d\.\d+-32$", interpreter)
         if match:
             # preserve the "-32" suffix, as the Python launcher expects it.
             xy_ver = interpreter
@@ -184,7 +184,10 @@ def _find_pbs_python(implementation: str, version: str) -> str | None:
 
     if NOX_PBS_PYTHONS.exists():
         for path in NOX_PBS_PYTHONS.iterdir():
-            if path.is_dir() and path.name.startswith(f"{implementation}@{version}."):
+            if path.is_dir() and (
+                path.name == f"{implementation}@{version}"
+                or path.name.startswith(f"{implementation}@{version}.")
+            ):
                 python_exe = path / executable
                 if python_exe.exists():
                     return str(python_exe)
@@ -204,14 +207,16 @@ def pbs_install_python(python_version: str) -> str | None:
         re.IGNORECASE,
     )
 
-    if not match:
+    if not match or match["xyz_ver"] is None:
         logger.warning(f"{python_version=} is not a valid version to install with pbs")
         return None
 
+    # A bare version with no implementation prefix means CPython.
+    impl = match["impl"] or "cpython"
     implementation: Literal["cpython", "pypy"] = (
-        "cpython" if match.group("impl").lower() in ("cpython", "python") else "pypy"
+        "pypy" if impl.lower() == "pypy" else "cpython"
     )
-    xyz_ver = match.group("xyz_ver")
+    xyz_ver: str = match["xyz_ver"]
 
     if python_exe := _find_pbs_python(implementation, xyz_ver):
         return python_exe

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1416,6 +1416,30 @@ def test__resolved_interpreter_windows_pyexe(
     which.assert_has_calls([mock.call(input_), mock.call("py")])
 
 
+@pytest.mark.parametrize(
+    ("interpreter", "expected_py_arg"),
+    [
+        ("3.10-32", "3.10-32"),
+        # Only a literal "-32" suffix is meaningful to the py launcher.
+        ("3.10-3", ""),
+    ],
+)
+@mock.patch("nox.virtualenv._PLATFORM", new="win32")
+@mock.patch("nox.virtualenv.locate_using_path_and_version", return_value=None)
+@mock.patch("nox.virtualenv.locate_via_py", return_value=None)
+@mock.patch.object(shutil, "which", return_value=None)
+def test_find_python_windows_32_bit_suffix(
+    which: mock.Mock,  # noqa: ARG001
+    locate_via_py_mock: mock.Mock,
+    locate_using_path_and_version_mock: mock.Mock,  # noqa: ARG001
+    interpreter: str,
+    expected_py_arg: str,
+) -> None:
+    # Only an exact "-32" suffix is preserved for the Windows py launcher.
+    assert nox.virtualenv._find_python(interpreter, "") is None
+    locate_via_py_mock.assert_called_once_with(expected_py_arg)
+
+
 @mock.patch("nox.virtualenv._PLATFORM", new="win32")
 @mock.patch.object(subprocess, "run")
 @mock.patch.object(shutil, "which")
@@ -1756,6 +1780,10 @@ def test_download_python_failed_install(
         ("pypy", "3.8", "pypy@3.8.16", True),
         ("cpython", "3.12", "cpython@3.11.5", False),
         ("pypy", "3.11", "cpython@3.11.5", False),
+        # Exact X.Y.Z installs are stored without a suffix (version_dir=True)
+        ("cpython", "3.13.2", "cpython@3.13.2", True),
+        ("pypy", "3.10.14", "pypy@3.10.14", True),
+        ("cpython", "3.1", "cpython@3.13.2", False),
     ],
 )
 def test_find_pbs_python(
@@ -1810,6 +1838,24 @@ def test_pbs_install_python_already_installed(find_pbs_mock: mock.Mock) -> None:
 
     assert result == "/existing/python/path"
     find_pbs_mock.assert_called_once_with("cpython", "3.11")
+
+
+@mock.patch("nox.virtualenv._find_pbs_python", return_value="/existing/python/path")
+def test_pbs_install_python_no_implementation(find_pbs_mock: mock.Mock) -> None:
+    """A bare version with no implementation prefix defaults to CPython."""
+    result = nox.virtualenv.pbs_install_python("3.12")
+
+    assert result == "/existing/python/path"
+    find_pbs_mock.assert_called_once_with("cpython", "3.12")
+
+
+@pytest.mark.parametrize("python_version", ["", "cpython", "not-a-python"])
+def test_pbs_install_python_invalid_version(
+    python_version: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Version-less or unparsable requests warn and return None."""
+    assert nox.virtualenv.pbs_install_python(python_version) is None
+    assert "not a valid version" in caplog.text
 
 
 def test_pbs_install_python_success(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This fixes three related bugs in interpreter resolution in `nox/virtualenv.py`, each with a regression test.

### 1. pbs lookup misses exact-version installs

`_find_pbs_python` matched directories with `path.name.startswith(f"{implementation}@{version}.")` — with a trailing dot. `pbs_installer.install(..., version_dir=True)` creates directories named exactly `cpython@3.13.2`, so for a spec whose version is already full `X.Y.Z` (e.g. `python="pypy3.10.14"` or `"cpython3.12.5"`, which bypass the X.Y-stripping regex in `_resolved_interpreter` because of the implementation prefix), the lookup failed both before and *after* a successful install. Nox then reported `InterpreterNotFound` and re-downloaded the interpreter on every run. The lookup now matches with a `.`-or-end boundary.

### 2. `AttributeError` on missing implementation group

In `pbs_install_python` (public API), the `impl` regex group is optional, so `match.group("impl").lower()` raised `AttributeError` for inputs like `"3.12"`, `"-3.12"`, or `""`. A bare version now defaults to CPython (matching pbs-installer's own default), and a version-less request (e.g. `""` or `"cpython"`) takes the normal "not a valid version" warning path instead of falling through to a confusing install failure.

### 3. Windows py-launcher `-32` suffix regex typo

The regex `r"^\d\.\d+-32?$"` made the `2` optional, so `3.10-3` was treated like a 32-bit suffix and passed verbatim to the py launcher. The intent is the literal `-32` suffix; it is now `r"^\d\.\d+-32$"`.

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
