### PR TITLE
refactor: assorted simplifications and dead-code removal

### DIFF
--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -80,7 +80,7 @@ def get_dependencies(
 
     def expand(
         req: packaging.requirements.Requirement,
-    ) -> Generator[packaging.requirements.Requirement, None, None]:
+    ) -> Iterator[packaging.requirements.Requirement]:
         # Skip the metadata read and re-expansion for requirements already
         # visited with the same extras; this avoids rescanning shared
         # dependencies reachable through multiple extras and guards against

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -29,22 +29,11 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", bound=Callable[..., Any])
 
-__all__ = ["Call", "Func", "FunctionDecorator", "_copy_func"]
+__all__ = ["Call", "Func", "_copy_func"]
 
 
 def __dir__() -> list[str]:
     return __all__
-
-
-class FunctionDecorator:
-    """This is a function decorator."""
-
-    def __new__(  # noqa: PYI034
-        cls: Any, func: Callable[..., Any], *args: Any, **kwargs: Any
-    ) -> FunctionDecorator:
-        self = super().__new__(cls)
-        functools.update_wrapper(self, func)
-        return cast("FunctionDecorator", self)
 
 
 def _copy_func(src: T, name: str | None = None) -> T:
@@ -63,8 +52,15 @@ def _copy_func(src: T, name: str | None = None) -> T:
     return cast("T", dst)
 
 
-class Func(FunctionDecorator):
+class Func:
     """This is a function decorator that adds additional Nox-specific metadata."""
+
+    def __new__(  # noqa: PYI034
+        cls, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Func:
+        self = super().__new__(cls)
+        functools.update_wrapper(self, func)
+        return self
 
     def __init__(
         self,

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -22,7 +22,6 @@ import argparse
 import functools
 import os
 from argparse import ArgumentError, ArgumentParser, Namespace
-from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 import argcomplete

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -548,7 +548,6 @@ options.add_options(
     _option_set.Option(
         "download_python",
         "--download-python",
-        "--download-python",
         noxfile=True,
         group=options.groups["python"],
         default=lambda: os.getenv("NOX_DOWNLOAD_PYTHON"),

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -69,9 +69,7 @@ class Param:
     def __str__(self) -> str:
         if self.id:
             return self.id
-        call_spec = self.call_spec
-        args = [f"{k}={call_spec[k]!r}" for k in call_spec]
-        return ", ".join(args)
+        return ", ".join(f"{k}={v!r}" for k, v in self.call_spec.items())
 
     __repr__ = __str__
     __hash__ = None  # type: ignore[assignment]

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -155,7 +155,6 @@ def lazy_stable_topo_sort(
         Raises:
             ValueError: If a dependency cycle is encountered.
         """
-        nonlocal visited
         # We would like for ``walk`` to be an ordered set so that we get (a) O(1) ``node
         # in walk`` and (b) so that we can use the order to report to the user what the
         # dependency cycle is, if one is encountered. The standard library does not have
@@ -172,8 +171,6 @@ def lazy_stable_topo_sort(
                 for dependency in dependencies[node]
             )
             yield node
-        else:
-            return
 
     def extend_walk(walk: dict[Node, None], node: Node) -> dict[Node, None]:
         """Extend a walk by a node, checking for dependency cycles.
@@ -204,7 +201,5 @@ def lazy_stable_topo_sort(
 
     sort = prepended_by_dependencies(root)
     if drop_root:
-        return filter(
-            lambda node: not (node == root and hash(node) == hash(root)), sort
-        )
+        return (node for node in sort if node != root)
     return sort

--- a/nox/command.py
+++ b/nox/command.py
@@ -19,7 +19,6 @@ import shlex
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Literal, overload
 
 from nox.logger import logger

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -30,6 +30,10 @@ SESSION_INFO = logging.WARNING - 1
 SUCCESS = logging.INFO + 5
 OUTPUT = logging.DEBUG - 1
 
+logging.addLevelName(SESSION_INFO, "SESSION_INFO")
+logging.addLevelName(SUCCESS, "SUCCESS")
+logging.addLevelName(OUTPUT, "OUTPUT")
+
 
 def _get_format(*, colorlog: bool, add_timestamp: bool) -> str:
     if colorlog:
@@ -43,18 +47,23 @@ def _get_format(*, colorlog: bool, add_timestamp: bool) -> str:
     return "%(name)s > %(message)s"
 
 
-class NoxFormatter(logging.Formatter):
-    def __init__(self, *, add_timestamp: bool = False) -> None:
-        super().__init__(fmt=_get_format(colorlog=False, add_timestamp=add_timestamp))
-        self._simple_fmt = logging.Formatter("%(message)s")
+class _SimpleOutputMixin(logging.Formatter):
+    """Format ``OUTPUT``-level records as plain, unprefixed messages."""
 
-    def format(self, record: Any) -> str:
+    _simple_fmt = logging.Formatter("%(message)s")
+
+    def format(self, record: logging.LogRecord) -> str:
         if record.levelname == "OUTPUT":
             return self._simple_fmt.format(record)
         return super().format(record)
 
 
-class NoxColoredFormatter(ColoredFormatter):
+class NoxFormatter(_SimpleOutputMixin, logging.Formatter):
+    def __init__(self, *, add_timestamp: bool = False) -> None:
+        super().__init__(fmt=_get_format(colorlog=False, add_timestamp=add_timestamp))
+
+
+class NoxColoredFormatter(_SimpleOutputMixin, ColoredFormatter):
     def __init__(
         self,
         *,
@@ -73,21 +82,9 @@ class NoxColoredFormatter(ColoredFormatter):
             reset=reset,
             secondary_log_colors=secondary_log_colors,
         )
-        self._simple_fmt = logging.Formatter("%(message)s")
-
-    def format(self, record: Any) -> str:
-        if record.levelname == "OUTPUT":
-            return self._simple_fmt.format(record)
-        return super().format(record)
 
 
 class LoggerWithSuccessAndOutput(logging.getLoggerClass()):  # type: ignore[misc]
-    def __init__(self, name: str, level: int = logging.NOTSET) -> None:
-        super().__init__(name, level)
-        logging.addLevelName(SESSION_INFO, "SESSION_INFO")
-        logging.addLevelName(SUCCESS, "SUCCESS")
-        logging.addLevelName(OUTPUT, "OUTPUT")
-
     def session_info(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.isEnabledFor(SESSION_INFO):  # pragma: no cover
             self._log(SESSION_INFO, msg, args, **kwargs)

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -395,9 +395,6 @@ class Manifest:
         # Return the list of sessions.
         return sessions
 
-    def next(self) -> SessionRunner:
-        return next(self)
-
     def notify(
         self, session: str | SessionRunner, posargs: Iterable[str] | None = None
     ) -> bool:

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -80,18 +80,20 @@ class Manifest:
                 self.add_session(session)
 
     def __contains__(self, needle: str | SessionRunner) -> bool:
-        if needle in self._queue or needle in self._consumed:
-            return True
-        for session in self._queue + self._consumed:
-            if session.name == needle or needle in session.signatures:
-                return True
-        return False
+        return (
+            needle in self._queue
+            or needle in self._consumed
+            or any(
+                session.name == needle or needle in session.signatures
+                for session in itertools.chain(self._queue, self._consumed)
+            )
+        )
 
     def __iter__(self) -> Manifest:
         return self
 
     def __getitem__(self, key: str) -> SessionRunner:
-        for session in self._queue + self._consumed:
+        for session in itertools.chain(self._queue, self._consumed):
             if session.name == key or key in session.signatures:
                 return session
         raise KeyError(key)
@@ -102,7 +104,7 @@ class Manifest:
         Raises:
             StopIteration: If the queue has been entirely consumed.
         """
-        if not len(self._queue):
+        if not self._queue:
             raise StopIteration
         session = self._queue.pop(0)
         self._consumed.append(session)

--- a/nox/project.py
+++ b/nox/project.py
@@ -80,7 +80,7 @@ def _load_script_block(filepath: Path, *, missing_ok: bool) -> dict[str, Any]:
         if missing_ok:
             return {}
         raise
-    matches = list(filter(lambda m: m.group("type") == name, REGEX.finditer(script)))
+    matches = [m for m in REGEX.finditer(script) if m.group("type") == name]
 
     if not matches:
         if missing_ok:

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -116,13 +116,13 @@ def session_decorator(
     if python is None:
         python = py
 
-    final_name = name or func.__name__
+    reg_name = name or func.__name__
 
     fn = Func(
         func,
         python,
         reuse_venv,
-        final_name,
+        reg_name,
         venv_backend,
         venv_params,
         tags=tags,
@@ -130,7 +130,6 @@ def session_decorator(
         requires=requires,
         download_python=download_python,
     )
-    reg_name = name or func.__name__
     if reg_name in _REGISTRY:
         msg = (
             f"The session {reg_name!r} has already been registered; "

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -86,14 +86,10 @@ def _chdir(path: str) -> Generator[None, None, None]:
         os.chdir(cwd)
 
 
-def _normalize_path(envdir: str, path: str | bytes) -> str:
+def _normalize_path(envdir: str, path: str) -> str:
     """Normalizes a string to be a "safe" filesystem path for a virtualenv."""
-    if isinstance(path, bytes):
-        path = path.decode("utf-8")
-
     orig_path = path
-    path = unicodedata.normalize("NFKD", path).encode("ascii", "ignore")
-    path = path.decode("ascii")
+    path = unicodedata.normalize("NFKD", path).encode("ascii", "ignore").decode("ascii")
     path = re.sub(r"[^\w\s-]", "-", path).strip().lower()
     path = re.sub(r"[-\s]+", "-", path)
     path = path.strip("-")

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -293,7 +293,7 @@ class Session:
         """
         Install dependencies and run a Python script.
         """
-        deps = (nox.project.load_toml(script) or {}).get("dependencies", [])
+        deps = nox.project.load_toml(script).get("dependencies", [])
         self.install(*deps)
 
         return self.run(
@@ -791,7 +791,7 @@ class Session:
             return
 
         # Escape args that should be (conda-specific; pip install does not need this)
-        if sys.platform.startswith("win32"):
+        if sys.platform.startswith("win"):
             args = _dblquote_pkg_install_args(args)
 
         if silent is None:

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -113,10 +113,7 @@ def main() -> None:
 
         for option in "skip_install", "use_develop":
             if section.get(option):
-                if section[option] == "False":
-                    config[name][option] = False
-                else:
-                    config[name][option] = True
+                config[name][option] = section[option] != "False"
 
         if os.path.isabs(section["base_python"]) or re.match(
             r"py\d+", section["base_python"]

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -460,14 +460,17 @@ def locate_using_path_and_version(version: str) -> str | None:
     script = "import platform; print(platform.python_version())"
     path_python = shutil.which("python")
     if path_python:
-        prefix = f"{version}"
         ret = subprocess.run(
             [path_python, "-c", script],
             check=False,
             text=True,
             capture_output=True,
         )
-        if ret.returncode == 0 and ret.stdout and ret.stdout.strip().startswith(prefix):
+        if (
+            ret.returncode == 0
+            and ret.stdout
+            and ret.stdout.strip().startswith(version)
+        ):
             return path_python
 
     return None
@@ -539,7 +542,7 @@ class CondaEnv(ProcessEnv):
         self.location = os.path.abspath(location)
         self.interpreter = interpreter
         self.reuse_existing = reuse_existing
-        self.venv_params = venv_params or []
+        self.venv_params = list(venv_params)
         self.conda_cmd = conda_cmd
         super().__init__(env={"CONDA_PREFIX": self.location, "VIRTUAL_ENV": None})
 
@@ -630,10 +633,10 @@ class CondaEnv(ProcessEnv):
         """
         try:
             # DNS resolution to detect situation (1) or (2).
-            host = gethostbyname("repo.anaconda.com")
+            gethostbyname("repo.anaconda.com")
         except OSError:  # pragma: no cover
             return True
-        return host is None
+        return False
 
     @property
     def venv_backend(self) -> str:
@@ -689,7 +692,7 @@ class VirtualEnv(ProcessEnv):
         self._resolved: None | str | InterpreterNotFound = None
         self.reuse_existing = reuse_existing
         self._venv_backend = venv_backend
-        self.venv_params = venv_params or []
+        self.venv_params = list(venv_params)
         self.download_python = download_python
         if venv_backend not in {"virtualenv", "venv", "uv"}:
             msg = f"venv_backend {venv_backend!r} not recognized"

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -840,53 +840,45 @@ class VirtualEnv(ProcessEnv):
             t = match.group("t")
             cleaned_interpreter = f"python{xy_version}{t}"
 
-        match self.download_python, self.venv_backend:
+        match self.download_python:
             # never -> check for interpreters
-            case "never", _:
+            case "never":
                 if resolved := _find_python(cleaned_interpreter, xy_version):
                     self._resolved = resolved
                     return self._resolved
 
             # always -> skip check, always install
-            case "always", "uv":
-                has_uv, _, uv_ver = _uv_state()
-                if has_uv and version.Version("0.4.16") <= uv_ver:
-                    uv_python_success = uv_install_python(cleaned_interpreter)
-                    if uv_python_success:
-                        self._resolved = cleaned_interpreter
-                        return self._resolved
-
-            case "always", "venv" | "virtualenv":
-                pbs_python_path = pbs_install_python(cleaned_interpreter)
-                if pbs_python_path:
-                    self._resolved = pbs_python_path
+            case "always":
+                if resolved := self._install_python(cleaned_interpreter):
+                    self._resolved = resolved
                     return self._resolved
 
             case _:
                 # auto -> check interpreters -> fallback to installing
-                venv_backend = self.venv_backend
-                if resolved := _find_python(cleaned_interpreter, xy_version):
+                if resolved := _find_python(
+                    cleaned_interpreter, xy_version
+                ) or self._install_python(cleaned_interpreter):
                     self._resolved = resolved
                     return self._resolved
 
-                has_uv, _, uv_ver = _uv_state()
-                if (
-                    venv_backend == "uv"
-                    and has_uv
-                    and version.Version("0.4.16") <= uv_ver
-                ):
-                    uv_python_success = uv_install_python(cleaned_interpreter)
-                    if uv_python_success:
-                        self._resolved = cleaned_interpreter
-                        return self._resolved
-                elif venv_backend in {"venv", "virtualenv"}:
-                    pbs_python_path = pbs_install_python(cleaned_interpreter)
-                    if pbs_python_path:
-                        self._resolved = pbs_python_path
-                        return self._resolved
-
         self._resolved = InterpreterNotFound(self.interpreter)
         raise self._resolved
+
+    def _install_python(self, cleaned_interpreter: str) -> str | None:
+        """Install the requested interpreter for this backend, if possible.
+
+        Returns the resolved interpreter on success, or ``None`` on failure.
+        """
+        if self.venv_backend == "uv":
+            has_uv, _, uv_ver = _uv_state()
+            if (
+                has_uv
+                and version.Version("0.4.16") <= uv_ver
+                and uv_install_python(cleaned_interpreter)
+            ):
+                return cleaned_interpreter
+            return None
+        return pbs_install_python(cleaned_interpreter)
 
     @property
     def bin_paths(self) -> list[str]:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -139,9 +139,8 @@ def test_iteration() -> None:
     assert len(manifest._consumed) == 1
     assert len(manifest._queue) == 1
 
-    # The .next() or .__next__() methods can be called directly according
-    # to Python's data model.
-    bar = manifest.next()
+    # The second item should be our "bar" session.
+    bar = next(manifest)
     assert bar.func == sessions["bar"]
     assert bar in manifest._consumed
     assert bar not in manifest._queue

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -79,7 +79,6 @@ def test__normalize_path() -> None:
     envdir = "envdir"
     normalize = nox.sessions._normalize_path
     assert normalize(envdir, "hello") == os.path.join("envdir", "hello")
-    assert normalize(envdir, b"hello") == os.path.join("envdir", "hello")
     assert normalize(envdir, "hello(world)") == os.path.join("envdir", "hello-world")
     assert normalize(envdir, "hello(world, meep)") == os.path.join(
         "envdir", "hello-world-meep"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1158,6 +1158,7 @@ class TestSessionRunner:
         func = mock.Mock()
         func.python = None
         func.venv_backend = None
+        func.venv_params = []
         func.reuse_venv = False
         func.requires = []
         return nox.sessions.SessionRunner(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A batch of reviewed, behavior-preserving simplifications, grouped into four commits. The only user-visible change is the first one.

### User-visible fix
- **`nox/_options.py`**: the `--download-python` flag string was passed twice to its `Option`, so `nox --help` rendered it as "`--download-python, --download-python`". One copy removed; argparse behavior is otherwise identical.

### Deduplication
- **`nox/virtualenv.py`**: the uv-install and python-build-standalone-install blocks in `VirtualEnv._resolved_interpreter` were duplicated verbatim between the `"always"` match arms and the `"auto"` default. They are now a single private `_install_python` helper; the `match` only needs `download_python` since the backend dispatch lives in the helper (backends are validated to `{uv, venv, virtualenv}` in `__init__`).
- **`nox/logger.py`**: `NoxFormatter` and `NoxColoredFormatter` had byte-identical `format()` bodies and `_simple_fmt` setup — factored into a `_SimpleOutputMixin`. The idempotent `logging.addLevelName` calls moved from `LoggerWithSuccessAndOutput.__init__` to module level next to the level constants (they ran on every logger instantiation; module import registers them once before any logger exists).
- **`nox/registry.py`**: `name or func.__name__` was computed twice into two variables; now computed once.
- **`nox/manifest.py`**: `__contains__`/`__getitem__` built throwaway `self._queue + self._consumed` lists; both now iterate `itertools.chain(...)`, and `__contains__` shares the same match expression via `any()`.
- **`nox/_parametrize.py`**: `Param.__str__` builds its output with a single generator expression instead of two intermediates.

### Micro-simplifications
- **`nox/virtualenv.py`**: `CondaEnv.is_offline()` checked `gethostbyname(...) is None`, but `gethostbyname` returns a `str` or raises — the check was always `False`, so the success path now returns `False` directly (the `# pragma: no cover` on the DNS-failure path is unchanged). Also dropped a redundant `f"{version}"` wrapper, and `venv_params or []` (default `()`) is now `list(venv_params)`, which is equivalent for every existing caller but always stores an owned list.
- **`nox/command.py` / `nox/_option_set.py`**: deleted runtime `collections.abc` imports that duplicated the `TYPE_CHECKING` imports; the names are annotation-only under `from __future__ import annotations`.
- **`nox/sessions.py`**: `nox.project.load_toml()` always returns a `dict`, so the `or {}` fallback was dead; `sys.platform.startswith("win32")` switched to the codebase's usual `startswith("win")` (equivalent on CPython, where the Windows value is exactly `"win32"`).
- **`nox/_resolver.py`**: removed a no-op trailing `else: return` and an unnecessary `nonlocal visited` (only item-assignment), and replaced the post-sort filter's redundant `hash(node) == hash(root)` clause (equality already implies equal hashes; the root is an `object()` sentinel) with a plain generator expression.
- **`nox/manifest.py`**: `if not len(self._queue)` → `if not self._queue`.
- **`nox/tox_to_nox.py`**: the `skip_install`/`use_develop` if/else collapses to `config[name][option] = section[option] != "False"` under the existing truthiness guard — identical semantics for the string values tox emits.
- **`nox/project.py`**: `list(filter(lambda ...))` → list comprehension.
- **`tests/test_sessions.py`**: the `SessionRunner` mock func now sets `venv_params = []` to match the real `Func` API (it previously leaked a bare `Mock` into `VirtualEnv`).

### Vestigial removals
- **`nox/sessions.py`**: `_normalize_path`'s `isinstance(path, bytes)` decode branch was a Python 2 leftover — the only caller passes `str`. Branch removed, annotation narrowed to `str`, and the bytes case dropped from its direct unit test.
- **`nox/manifest.py`**: `Manifest.next()` was a Python 2-style alias for `__next__`, referenced only by its own test (not in docs). Removed; the test uses the `next()` builtin.
- **`nox/_decorators.py`**: `FunctionDecorator` was a one-method class whose only subclass anywhere was `Func`; its `__new__` is folded into `Func` and the `cast` dropped. Nothing else imports it (checked `nox/`, `tests/`, `docs/`).

### Skipped items
- None — all 17 reviewed items were applied.

### Verification
- `pytest tests/` — 688 passed locally (macOS), plus the tox-gated `test_tox_to_nox.py` suite run with tox installed.
- Coverage compared against `main` with `coverage run -m pytest -m "not conda"`: no new uncovered lines or branches on any touched file; remaining misses are the pre-existing Windows-/conda-/extra-gated regions.
- `prek -a` — all hooks pass (ruff, strict mypy, codespell, etc.).

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
