### PR TITLE
perf: lazy modules on Python 3.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/henryiii/flake8-lazy
+    rev: v0.8.2
+    hooks:
+      - id: flake8-lazy
+        args: ["--apply=set"]
+        files: '^nox/'
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.24.1"
     hooks:

--- a/nox/__init__.py
+++ b/nox/__init__.py
@@ -14,6 +14,15 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "nox._cli",
+    "nox._options",
+    "nox._parametrize",
+    "nox.registry",
+    "nox.sessions",
+    "types",
+}
+
 from types import ModuleType
 
 from nox import project

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -16,6 +16,26 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "importlib",
+    "importlib.metadata",
+    "nox._options",
+    "nox._version",
+    "nox.command",
+    "nox.logger",
+    "nox.project",
+    "nox.registry",
+    "nox.virtualenv",
+    "packaging",
+    "packaging.requirements",
+    "packaging.utils",
+    "pathlib",
+    "shutil",
+    "subprocess",
+    "urllib",
+    "urllib.parse",
+}
+
 import importlib.metadata
 import os
 import shutil

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"copy", "functools", "inspect", "types"}
+
 import copy
 import functools
 import inspect

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -18,6 +18,8 @@ and surfaced in documentation."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {"argcomplete", "argparse", "functools"}
+
 import argparse
 import functools
 import os

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"itertools", "nox.tasks"}
+
 import argparse
 import functools
 import itertools

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"functools", "itertools"}
+
 import functools
 import itertools
 from collections.abc import Iterable

--- a/nox/_resolver.py
+++ b/nox/_resolver.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"itertools"}
+
 import itertools
 from collections.abc import Hashable, Iterable, Iterator, Mapping
 from typing import TypeVar

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -14,6 +14,15 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "ast",
+    "contextlib",
+    "importlib",
+    "packaging",
+    "packaging.specifiers",
+    "packaging.version",
+}
+
 import ast
 import contextlib
 from importlib import metadata

--- a/nox/command.py
+++ b/nox/command.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"nox.logger", "shlex", "shutil"}
+
 import os
 import shlex
 import shutil

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"ast", "itertools", "nox._resolver", "nox.sessions", "operator"}
+
 import ast
 import functools
 import itertools

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"contextlib", "locale"}
+
 import contextlib
 import locale
 import subprocess

--- a/nox/project.py
+++ b/nox/project.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "dependency_groups",
+    "packaging",
+    "packaging.requirements",
+    "packaging.specifiers",
+    "pathlib",
+    "tomllib",
+}
+
 import re
 import sys
 from pathlib import Path

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"copy", f"{__spec__.parent}._decorators", "functools", "warnings"}
+
 import copy
 import functools
 import warnings

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -14,6 +14,21 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "datetime",
+    "hashlib",
+    "humanize",
+    "inspect",
+    "nox.logger",
+    "nox.popen",
+    "nox.virtualenv",
+    "pathlib",
+    "re",
+    "shutil",
+    "subprocess",
+    "unicodedata",
+}
+
 import contextlib
 import datetime
 import enum

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -14,6 +14,19 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "ast",
+    "colorlog",
+    "colorlog.escape_codes",
+    "importlib",
+    "importlib.util",
+    "json",
+    "nox._resolver",
+    "nox._version",
+    "nox.logger",
+    "nox.manifest",
+}
+
 import ast
 import importlib.util
 import json

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -16,6 +16,15 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "argparse",
+    "configparser",
+    "functools",
+    "pathlib",
+    "re",
+    "subprocess",
+}
+
 import argparse
 import functools
 import os

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -14,6 +14,18 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "json",
+    "nox.command",
+    "nox.logger",
+    "packaging",
+    "re",
+    "shutil",
+    "socket",
+    "subprocess",
+}
+
 import abc
 import contextlib
 import functools


### PR DESCRIPTION
This is using (my) flake8-lazy, run directly with autofix.

Drops the response time on Python 3.15.0b2 from 50ms to 35ms for `--help`.

Last item from, closes #1102. (different solution than the one proposed there, though).
