### PR TITLE
fix: prevent coverage data corruption from artifact name collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
-          merge-multiple: true
       - name: Display structure of downloaded files
         run: ls -aR
       - name: Run coverage

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,9 @@
 from __future__ import annotations
 
 import functools
+import glob
 import os
+import platform
 import shutil
 import sys
 
@@ -41,7 +43,9 @@ ALL_PYTHONS = nox.project.python_versions(PYPROJECT)
 def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
 
-    coverage_file = f".coverage.pypi.{sys.platform}.{session.python}"
+    coverage_file = (
+        f".coverage.pypi.{sys.platform}.{platform.machine()}.{session.python}"
+    )
     env = {
         "PYTHONWARNDEFAULTENCODING": "1",
         "COVERAGE_FILE": coverage_file,
@@ -80,7 +84,9 @@ def minimums(session: nox.Session) -> None:
 def xonda_tests(session: nox.Session, xonda: str) -> None:
     """Run test suite set up with conda/mamba/etc."""
 
-    coverage_file = f".coverage.{xonda}.{sys.platform}.{session.python}"
+    coverage_file = (
+        f".coverage.{xonda}.{sys.platform}.{platform.machine()}.{session.python}"
+    )
     env = {"COVERAGE_FILE": coverage_file}
 
     session.conda_install(
@@ -131,7 +137,11 @@ def cover(session: nox.Session) -> None:
         return
 
     session.install("coverage[toml]>=7.3")
-    session.run("coverage", "combine")
+    # CI downloads each job's artifact into its own coverage-* subdirectory
+    # (no merge-multiple), so no two jobs can clobber a same-named data file.
+    # Fall back to the current directory for local runs.
+    paths = sorted(glob.glob("coverage-*")) or ["."]
+    session.run("coverage", "combine", *paths)
     session.run("coverage", "report", "--fail-under=100", "--show-missing")
     session.run("coverage", "erase")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -137,9 +137,6 @@ def cover(session: nox.Session) -> None:
         return
 
     session.install("coverage[toml]>=7.3")
-    # CI downloads each job's artifact into its own coverage-* subdirectory
-    # (no merge-multiple), so no two jobs can clobber a same-named data file.
-    # Fall back to the current directory for local runs.
     paths = sorted(glob.glob("coverage-*")) or ["."]
     session.run("coverage", "combine", *paths)
     session.run("coverage", "report", "--fail-under=100", "--show-missing")


### PR DESCRIPTION
I hope this fixes the failure we've seen occasionally in CI after multiprocessing in the test suite.

:robot: _AI text below_ :robot:

## Problem

The `coverage` (combine) job intermittently fails with:

```
nox > coverage combine
Couldn't use data file '/home/runner/work/nox/nox/.coverage': database disk image is malformed
nox > Command coverage combine failed with exit code 1
```

(e.g. [this run](https://github.com/wntrblm/nox/actions/runs/27457461064/job/81164952793)).

## Cause

`macos-latest` (arm64) and `macos-15-intel` (x86_64) both run Python 3.12, and the coverage filename is built only from `sys.platform` + version — so both jobs produce `.coverage.pypi.darwin.3.12`. The `cover` job then downloads artifacts with `merge-multiple: true`, which extracts them **concurrently into one directory**. Two jobs writing the same path can tear the SQLite data file (→ "database disk image is malformed"), or one silently clobbers the other's coverage. The timing dependence is why it only fails occasionally; the parallel/xdist tests just made the corruption more visible, they aren't the trigger.

## Fix

- Add `platform.machine()` to the `tests`/`conda` coverage filenames so arm64 and x86_64 no longer collide (also restores the mac coverage that was being silently dropped).
- Drop `merge-multiple: true` so each artifact lands in its own `coverage-*` subdirectory; the `cover` session now globs those subdirs and passes them to `coverage combine` (with a `["."]` fallback for local runs).

No change to the fast test setup — xdist, the `sysmon` core, and `run.patch=["subprocess"]` are untouched. The 100% `--fail-under` gate is unchanged.

Verified locally that `coverage combine <dir> <dir>` reads data files inside per-artifact subdirs and combines cleanly.