### PR TITLE
ci: use Miniforge base to speed up conda job setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,15 @@ on:
 
 env:
   FORCE_COLOR: "1"
-  # conda-forge on anaconda.org intermittently returns HTTP 429 for repodata.json
-  # from shared CI IPs. Retry with backoff so a throttle doesn't fail the job.
+  # conda.anaconda.org rate-limits shared CI IPs (HTTP 429), and its sharded
+  # repodata fetch bypasses conda's retry settings, so a single 429 kills the
+  # solve. Resolve conda-forge via the prefix.dev mirror, which isn't throttled.
+  CONDA_CHANNEL_ALIAS: "https://prefix.dev"
+  # Defense in depth: retry the non-sharded repodata fetches with backoff too.
   CONDA_REMOTE_MAX_RETRIES: "8"
   CONDA_REMOTE_BACKOFF_FACTOR: "4"
   # Cache downloaded packages and repodata here, and reuse cached repodata for a
-  # day so repeat runs don't re-fetch repodata.json (the thing that 429s).
+  # day so repeat runs don't re-fetch metadata.
   CONDA_PKGS_DIRS: ~/conda_pkgs_dir
   CONDA_LOCAL_REPODATA_TTL: "86400"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
   # from shared CI IPs. Retry with backoff so a throttle doesn't fail the job.
   CONDA_REMOTE_MAX_RETRIES: "8"
   CONDA_REMOTE_BACKOFF_FACTOR: "4"
+  # Cache downloaded packages and repodata here, and reuse cached repodata for a
+  # day so repeat runs don't re-fetch repodata.json (the thing that 429s).
+  CONDA_PKGS_DIRS: ~/conda_pkgs_dir
+  CONDA_LOCAL_REPODATA_TTL: "86400"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,6 +58,13 @@ jobs:
           allow-prereleases: true
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.2.0
+      - name: Cache conda packages
+        uses: actions/cache@v5.0.5
+        if: matrix.python-version == '3.14'
+        with:
+          path: ~/conda_pkgs_dir
+          key: conda-${{ runner.os }}-${{ hashFiles('requirements-conda-test.txt') }}
+          restore-keys: conda-${{ runner.os }}-
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v4
         if: matrix.python-version == '3.14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v4
         if: matrix.python-version == '3.14'
         with:
-          # Miniforge ships a recent conda-forge-native conda + mamba, so the
-          # base doesn't have to self-update from the runner's old preinstalled
-          # Miniconda (a multi-minute solve on Windows). conda >= 26.3 also drops
-          # the built-in signature-verification plugin that conflicted with
-          # conda-content-trust (see #1103), so no explicit conda-version pin.
           miniforge-version: latest
           channels: conda-forge
           conda-remove-defaults: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,14 @@ jobs:
         uses: conda-incubator/setup-miniconda@v4
         if: matrix.python-version == '3.14'
         with:
+          # Miniforge ships a recent conda-forge-native conda + mamba, so the
+          # base doesn't have to self-update from the runner's old preinstalled
+          # Miniconda (a multi-minute solve on Windows). conda >= 26.3 also drops
+          # the built-in signature-verification plugin that conflicted with
+          # conda-content-trust (see #1103), so no explicit conda-version pin.
+          miniforge-version: latest
           channels: conda-forge
           conda-remove-defaults: true
-          conda-version: '26.5.2'
           activate-environment:
       - name: Install Nox-under-test (uv)
         run:  uv pip install --system .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   FORCE_COLOR: "1"
+  # conda-forge on anaconda.org intermittently returns HTTP 429 for repodata.json
+  # from shared CI IPs. Retry with backoff so a throttle doesn't fail the job.
+  CONDA_REMOTE_MAX_RETRIES: "8"
+  CONDA_REMOTE_BACKOFF_FACTOR: "4"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,8 +89,6 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     )
     env = {"COVERAGE_FILE": coverage_file}
 
-    # Fold requests<99 into the requirements install so it's a single conda
-    # solve (one fewer repodata fetch). Currently the spec doesn't work on
     # Windows either with or without quoting, so it's omitted there.
     extra_specs = [] if sys.platform.startswith("win32") else ["requests<99"]
     session.conda_install(

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,7 +89,7 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     )
     env = {"COVERAGE_FILE": coverage_file}
 
-    # Windows either with or without quoting, so it's omitted there.
+    # Windows breaks currently either with or without quoting, so it's omitted there.
     extra_specs = [] if sys.platform.startswith("win32") else ["requests<99"]
     session.conda_install(
         "--file", "requirements-conda-test.txt", *extra_specs, channel="conda-forge"

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,13 +89,14 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     )
     env = {"COVERAGE_FILE": coverage_file}
 
+    # Fold requests<99 into the requirements install so it's a single conda
+    # solve (one fewer repodata fetch). Currently the spec doesn't work on
+    # Windows either with or without quoting, so it's omitted there.
+    extra_specs = [] if sys.platform.startswith("win32") else ["requests<99"]
     session.conda_install(
-        "--file", "requirements-conda-test.txt", channel="conda-forge"
+        "--file", "requirements-conda-test.txt", *extra_specs, channel="conda-forge"
     )
     session.install("-e.", "--no-deps")
-    # Currently, this doesn't work on Windows either with or without quoting
-    if not sys.platform.startswith("win32"):
-        session.conda_install("requests<99")
 
     session.run("coverage", "erase", env=env)
     session.run(


### PR DESCRIPTION
Looking to see if we can improve this really slow job.

Also moved to the prefix.dev mirror, as the normal one was limiting us (and it's faster, supports sharding effectively, etc).

:robot: _AI text below_ :robot:

## Problem

The `3.14` matrix jobs (the only ones that run conda) are the long pole of CI, driven almost entirely by conda provisioning on Windows. From the last green run on `main`:

| OS | Set up Miniconda | Run Conda tests | Total job |
|----|------------------|-----------------|-----------|
| ubuntu | 14s | 1m20s | 3m13s |
| macOS | 41s | 4m35s | 7m35s |
| **windows** | **4m20s** | 3m45s | **10m56s** |

`Set up Miniconda` on Windows alone is **4m20s**. The cause: `conda-version: '26.5.2'` forces conda to self-update from the runner's old preinstalled Miniconda — a large solve + unpack of many small files, brutal on the Windows filesystem.

## Fix

Use a fresh **Miniforge** base (`miniforge-version: latest`) instead. Miniforge ships a recent conda-forge-native conda plus mamba, so there's no version jump to solve.

Also drop the `conda-version` pin. It only existed (#1103) to dodge the conda-content-trust plugin conflict, which is fixed in conda >= 26.3 — and Miniforge `latest` already ships newer than that. Keeping the pin would re-introduce a (smaller) self-update solve.

## Scope / safety

- Conda tests still run on **all three OSes** — no loss of cross-platform conda coverage.
- `conda` remains the literal command on PATH, so conda-marked tests and the 100% coverage gate are unaffected.
- No shell changes (deliberately avoided a micromamba swap, which would force `bash -el` login shells on Windows and risk the existing uv/nox steps).

Draft so CI can measure the actual setup-time improvement. If Miniforge `latest` ever regresses below conda 26.3, the plugin conflict resurfaces and we'd re-pin `conda-version`.