### PR TITLE
ci: reduce the number of times we contact conda-forge servers on non-windows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -89,9 +89,7 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     )
     env = {"COVERAGE_FILE": coverage_file}
 
-    # Fold requests<99 into the requirements install so it's a single conda
-    # solve (one fewer repodata fetch). Currently the spec doesn't work on
-    # Windows either with or without quoting, so it's omitted there.
+    # Windows breaks currently either with or without quoting, so it's omitted there.
     extra_specs = [] if sys.platform.startswith("win32") else ["requests<99"]
     session.conda_install(
         "--file", "requirements-conda-test.txt", *extra_specs, channel="conda-forge"

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,13 +89,14 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     )
     env = {"COVERAGE_FILE": coverage_file}
 
+    # Fold requests<99 into the requirements install so it's a single conda
+    # solve (one fewer repodata fetch). Currently the spec doesn't work on
+    # Windows either with or without quoting, so it's omitted there.
+    extra_specs = [] if sys.platform.startswith("win32") else ["requests<99"]
     session.conda_install(
-        "--file", "requirements-conda-test.txt", channel="conda-forge"
+        "--file", "requirements-conda-test.txt", *extra_specs, channel="conda-forge"
     )
     session.install("-e.", "--no-deps")
-    # Currently, this doesn't work on Windows either with or without quoting
-    if not sys.platform.startswith("win32"):
-        session.conda_install("requests<99")
 
     session.run("coverage", "erase", env=env)
     session.run(


### PR DESCRIPTION
I've pulled out just the reduced number of conda-forge server interactions from #1118, which is an easy win and should make the other parts of that PR easier to review on thier own.
