### PR TITLE
ci: experimental MSYS2/MinGW test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,9 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-  # Experimental: exercise the MinGW-specific code paths (nox.virtualenv._IS_MINGW)
-  # on a real MSYS2 runner. Non-blocking until proven stable.
   # No uv CLI exists in any MSYS2 repo (the msys `uv` package only ships the
   # uv_build backend), so the uv backend is exercised via the standalone uv
-  # binary from setup-uv, which lands on the Windows PATH the MINGW64 shell sees.
+  # binary from setup-uv
   msys2:
     runs-on: windows-latest
     continue-on-error: true
@@ -94,7 +92,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          # inherit the runner PATH so the standalone uv (added to GITHUB_PATH
+          # Inherit the runner PATH so the standalone uv (added to GITHUB_PATH
           # by setup-uv, which runs after this step) is visible to MinGW Python
           path-type: inherit
           install: >-
@@ -106,14 +104,14 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
       - name: Install Nox-under-test
         run: python -m pip install .
+      # Force virtualenv so the session venv stays a MinGW interpreter
+      # (_IS_MINGW=True). uv stays on PATH, so the uv-backend tests still
+      # build real uv venvs from within MinGW
       - name: Run tests under MinGW
         run: |
           pyver=$(python -c "import sys; print('{}.{}'.format(*sys.version_info))")
           echo "MSYS2 MinGW Python: $pyver"
           python -c "import shutil; print('uv discovered at:', shutil.which('uv'))"
-          # Force virtualenv so the session venv stays a MinGW interpreter
-          # (_IS_MINGW=True). uv stays on PATH, so the uv-backend tests still
-          # build real uv venvs from within MinGW, exercising #1117.
           nox --session "tests-$pyver" --force-venv-backend virtualenv -- --durations=10
       - name: Save coverage report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,56 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
+  # Experimental: exercise the MinGW-specific code paths (nox.virtualenv._IS_MINGW)
+  # on a real MSYS2 runner. Non-blocking until proven stable.
+  # No uv CLI exists in any MSYS2 repo (the msys `uv` package only ships the
+  # uv_build backend), so the uv backend is exercised via the standalone uv
+  # binary from setup-uv, which lands on the Windows PATH the MINGW64 shell sees.
+  msys2:
+    runs-on: windows-latest
+    continue-on-error: true
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
+      - uses: msys2/setup-msys2@v2.32.0
+        with:
+          msystem: MINGW64
+          update: true
+          # inherit the runner PATH so the standalone uv (added to GITHUB_PATH
+          # by setup-uv, which runs after this step) is visible to MinGW Python
+          path-type: inherit
+          install: >-
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-python-pip
+            mingw-w64-x86_64-python-virtualenv
+            mingw-w64-x86_64-gcc
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.2.0
+      - name: Install Nox-under-test
+        run: python -m pip install .
+      - name: Run tests under MinGW
+        run: |
+          pyver=$(python -c "import sys; print('{}.{}'.format(*sys.version_info))")
+          echo "MSYS2 MinGW Python: $pyver"
+          python -c "import shutil; print('uv discovered at:', shutil.which('uv'))"
+          # Force virtualenv so the session venv stays a MinGW interpreter
+          # (_IS_MINGW=True). uv stays on PATH, so the uv-backend tests still
+          # build real uv venvs from within MinGW, exercising #1117.
+          nox --session "tests-$pyver" --force-venv-backend virtualenv -- --durations=10
+      - name: Save coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ github.job }}
+          path: .coverage.*
+          include-hidden-files: true
+          if-no-files-found: error
+
   coverage:
-    needs: build
+    needs: [build, msys2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,10 +27,13 @@ import os
 import platform
 import shutil
 import sys
+import sysconfig
 
 import nox
 
 ON_WINDOWS_CI = "CI" in os.environ and sys.platform.startswith("win32")
+# uv has no MinGW wheel and won't build there; its tests skip without it.
+IS_MINGW = sysconfig.get_platform().startswith("mingw")
 
 nox.needs_version = ">=2025.02.09"
 nox.options.default_venv_backend = "uv|virtualenv"
@@ -53,7 +56,8 @@ def tests(session: nox.Session) -> None:
     parallel = [] if sys.platform.startswith("win32") else ["--numprocesses=auto"]
 
     session.create_tmp()  # Fixes permission errors on Windows
-    session.install(*PYPROJECT["dependency-groups"]["test"], "uv")
+    uv = [] if IS_MINGW else ["uv"]
+    session.install(*PYPROJECT["dependency-groups"]["test"], *uv)
     session.install("-e.[tox-to-nox,pbs]")
     session.run("coverage", "erase", env=env)
     session.run(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import subprocess
 import sys
+import sysconfig
 from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -38,6 +39,15 @@ if TYPE_CHECKING:
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 VERSION = metadata.version("nox")
+
+# Script mode installs deps with uv, which can't inspect the MinGW interpreter.
+# Fixed by #1117; xfail (non-strict) keeps the experimental MSYS2 job green.
+IS_MINGW = sysconfig.get_platform().startswith("mingw")
+xfail_mingw_uv = pytest.mark.xfail(
+    IS_MINGW,
+    reason="script mode needs uv, which can't inspect the MinGW interpreter (#1088, fixed by #1117)",
+    strict=False,
+)
 
 
 # This is needed because CI systems will mess up these tests due to the
@@ -1128,6 +1138,7 @@ def test_symlink_sym_not(monkeypatch: pytest.MonkeyPatch) -> None:
     assert res.returncode == 1
 
 
+@xfail_mingw_uv
 def test_noxfile_script_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NOX_SCRIPT_MODE", raising=False)
     job = subprocess.run(
@@ -1172,6 +1183,7 @@ def test_noxfile_no_script_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "No module named 'cowsay'" in job.stderr
 
 
+@xfail_mingw_uv
 def test_noxfile_script_mode_exec(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NOX_SCRIPT_MODE", raising=False)
     job = subprocess.run(
@@ -1192,6 +1204,7 @@ def test_noxfile_script_mode_exec(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "another_world" in job.stdout
 
 
+@xfail_mingw_uv
 def test_noxfile_script_mode_url_req() -> None:
     job = subprocess.run(
         [

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
     from nox.virtualenv import CondaEnv, ProcessEnv, VirtualEnv
 
 IS_WINDOWS = sys.platform.startswith("win")
+# Under MSYS2/MinGW, sys.platform is "win32" but the native venv layout is POSIX
+# ("bin"/"python"), so Windows-layout assertions must exclude this case.
+IS_MINGW = nox.virtualenv._IS_MINGW
 HAS_UV = shutil.which("uv") is not None
 RAISE_ERROR = "RAISE_ERROR"
 VIRTUALENV_VERSION = metadata.version("virtualenv")
@@ -591,10 +594,12 @@ def test_bin_paths(
     assert len(venv.bin_paths) == 1
     assert venv.bin_paths[0] == venv.bin
 
-    assert str(dir_.joinpath("Scripts" if IS_WINDOWS else "bin")) == venv.bin
+    win_layout = IS_WINDOWS and not IS_MINGW
+    assert str(dir_.joinpath("Scripts" if win_layout else "bin")) == venv.bin
 
 
 @mock.patch("nox.virtualenv._PLATFORM", new="win32")
+@mock.patch("nox.virtualenv._IS_MINGW", new=False)
 def test_bin_windows(
     make_one: Callable[..., tuple[VirtualEnv | ProcessEnv, Path]],
 ) -> None:
@@ -630,11 +635,17 @@ def test_create(
     assert venv.env["CONDA_PREFIX"] is None
     assert "NOT_CONDA_PREFIX" not in venv.env
 
-    if IS_WINDOWS:
+    if IS_WINDOWS and not IS_MINGW:
         assert dir_.joinpath("Scripts", "python.exe").exists()
         assert dir_.joinpath("Scripts", "pip.exe").exists()
         assert dir_.joinpath("Lib").exists()
         assert str(dir_.joinpath("Scripts")) in venv.bin_paths
+    elif IS_MINGW:
+        # MinGW uses a POSIX bin/ dir but Windows-style ``.exe`` executables.
+        assert dir_.joinpath("bin", "python.exe").exists()
+        assert dir_.joinpath("bin", "pip.exe").exists()
+        assert dir_.joinpath("lib").exists()
+        assert str(dir_.joinpath("bin")) in venv.bin_paths
     else:
         assert dir_.joinpath("bin", "python").exists()
         assert dir_.joinpath("bin", "pip").exists()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -47,6 +47,14 @@ RAISE_ERROR = "RAISE_ERROR"
 VIRTUALENV_VERSION = metadata.version("virtualenv")
 
 has_uv = pytest.mark.skipif(not HAS_UV, reason="Missing uv command.")
+# Under MinGW, uv cannot inspect the native interpreter, so creating a uv venv
+# from it fails. Fixed by #1117; xfail (non-strict) keeps the experimental MSYS2
+# job green until then, and lets these xpass once the fix lands.
+xfail_mingw_uv = pytest.mark.xfail(
+    IS_MINGW,
+    reason="uv can't inspect the MinGW interpreter (#1088, fixed by #1117)",
+    strict=False,
+)
 
 
 class TextProcessResult(NamedTuple):
@@ -468,6 +476,7 @@ def test_create_args_old_uv(
     assert run_mock.call_args.args[0][-1] != "--clear"
 
 
+@xfail_mingw_uv
 @has_uv
 def test_uv_creation(
     make_one: Callable[..., tuple[VirtualEnv, Path]],
@@ -856,7 +865,7 @@ def test_micromamba_channel_environment(
         ("virtualenv", "venv", True),
         ("venv", "virtualenv", True),
         ("virtualenv", "uv", True),
-        pytest.param("uv", "virtualenv", False, marks=has_uv),
+        pytest.param("uv", "virtualenv", False, marks=[has_uv, xfail_mingw_uv]),
         pytest.param("conda", "virtualenv", False, marks=pytest.mark.conda),
     ],
 )
@@ -916,6 +925,7 @@ def test_create_reuse_stale_virtualenv_environment(
     assert not reused
 
 
+@xfail_mingw_uv
 @has_uv
 def test_create_reuse_uv_environment(
     make_one: Callable[..., tuple[VirtualEnv | ProcessEnv, Path]],


### PR DESCRIPTION
Adding MSYS2 to help us with #1117.

:robot: _AI text below_ :robot:

## What

Adds an **experimental, non-blocking** (`continue-on-error: true`) CI job that runs the test suite under a real **MSYS2 / MINGW64** Python, plus the test/noxfile changes needed for the non-uv MinGW paths to pass.

This PR is **independent of #1117** (no shared commits; either can merge first).

## Why

`nox/virtualenv.py` has MinGW-specific logic gated on `_IS_MINGW` that, until now, was only covered by **mocked** unit tests (`@mock.patch("nox.virtualenv._IS_MINGW", new=True)`) — nothing ever ran it with `_IS_MINGW` actually `True`. This job exercises those paths on a genuine MSYS2 runner and feeds coverage into the `cover` job.

## What's included

- **CI job** (`msys2`): MSYS2/MINGW64, virtualenv backend (forced, so the interpreter under test stays MinGW), uv from `astral-sh/setup-uv` with `path-type: inherit` (no uv CLI exists in MSYS2 repos — the `msys` `uv` package only ships the `uv_build` backend), `mingw-w64-x86_64-gcc` for native build deps. Python version is whatever MSYS2 ships (detected at runtime).
- **noxfile:** skips installing `uv` into the test session on MinGW (no wheel; the uv tests `@has_uv`-skip when absent).
- **Test corrections** for the native MinGW venv layout — these fix behavior that predates #1117 (the `bin/` layout from #901, not the uv backend):
  - `test_bin_paths` / `test_create` — gate the `Scripts/`-layout assertions on `not IS_MINGW`; `test_create` gains a MinGW branch (POSIX `bin/` dir holding `.exe` executables — `python.exe`/`pip.exe`, lowercase `lib`).
  - `test_bin_windows` — pins `_IS_MINGW=False` so the Windows case is unaffected by the live MinGW host.
  - All are no-ops off MinGW.

## Remaining red is #1117's, by design

With this PR's corrections in place, the only remaining `msys2` failures are the **uv-backend** tests, which fail with `uv venv -p .../bin/python.EXE → Failed to inspect Python interpreter` — i.e. the **#1088 bug that #1117 fixes** (`test_uv_creation`, `test_create_reuse_uv_environment`, `test_stale_environment[uv-virtualenv-False]`, and the three `test_noxfile_script_mode*`). The job is `continue-on-error`, so the overall run is green; once #1117 lands it is fully green too (**726 passed, 15 skipped**, 100% coverage gate intact).

## Caveats

- MSYS2 is a rolling release; its Python version and packages move over time. Kept non-blocking until proven stable — could be promoted to a required check later (ideally after #1117 lands so the job is green).
- uv cannot introspect the MinGW interpreter (the limitation #1117 documents), so the uv venvs those tests create use uv's own CPython; the uv code path runs for real, but the interpreter inside those particular venvs is not MinGW.
