### PR TITLE
fix: correct python_versions() minimum for major-only and multiple lower bounds

### DIFF
--- a/nox/project.py
+++ b/nox/project.py
@@ -146,10 +146,6 @@ def python_versions(
         msg = 'No "project.requires-python" value set'
         raise ValueError(msg)
 
-    # A requirement can have several lower-bound specifiers (e.g.
-    # ">=3.8,>=3.10"); the effective minimum is the largest of them. A
-    # major-only version (e.g. ">=3", equivalent to ">=3.0" per PEP 440) has an
-    # implicit minor version of 0.
     lower_bounds = [
         int(spec.version.split(".")[1]) if "." in spec.version else 0
         for spec in packaging.specifiers.SpecifierSet(requires_python_str)

--- a/nox/project.py
+++ b/nox/project.py
@@ -146,13 +146,19 @@ def python_versions(
         msg = 'No "project.requires-python" value set'
         raise ValueError(msg)
 
-    for spec in packaging.specifiers.SpecifierSet(requires_python_str):
-        if spec.operator in {">", ">=", "~="}:
-            min_minor_version = int(spec.version.split(".")[1])
-            break
-    else:
+    # A requirement can have several lower-bound specifiers (e.g.
+    # ">=3.8,>=3.10"); the effective minimum is the largest of them. A
+    # major-only version (e.g. ">=3", equivalent to ">=3.0" per PEP 440) has an
+    # implicit minor version of 0.
+    lower_bounds = [
+        int(spec.version.split(".")[1]) if "." in spec.version else 0
+        for spec in packaging.specifiers.SpecifierSet(requires_python_str)
+        if spec.operator in {">", ">=", "~="}
+    ]
+    if not lower_bounds:
         msg = 'No minimum version found in "project.requires-python"'
         raise ValueError(msg)
+    min_minor_version = max(lower_bounds)
 
     max_minor_version = int(max_version.split(".")[1])
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -69,6 +69,25 @@ def test_python_range_no_min() -> None:
         python_versions(pyproject, max_version="3.5")
 
 
+def test_python_range_major_only() -> None:
+    # ">=3" is equivalent to ">=3.0" (PEP 440); a major-only version has an
+    # implicit minor version of 0 and must not crash.
+    pyproject = {"project": {"requires-python": ">=3"}}
+
+    assert python_versions(pyproject, max_version="3.2") == ["3.0", "3.1", "3.2"]
+
+
+def test_python_range_multiple_lower_bounds() -> None:
+    # With several lower-bound specifiers the effective minimum is the largest
+    # one, regardless of the order they appear in.
+    assert python_versions(
+        {"project": {"requires-python": ">=3.8,>=3.10"}}, max_version="3.12"
+    ) == ["3.10", "3.11", "3.12"]
+    assert python_versions(
+        {"project": {"requires-python": ">=3.10,>=3.8"}}, max_version="3.12"
+    ) == ["3.10", "3.11", "3.12"]
+
+
 def test_dependency_groups() -> None:
     example = {
         "dependency-groups": {


### PR DESCRIPTION
## Summary

`nox.project.python_versions(pyproject, max_version=...)` reads the lower
bound of supported Python versions from `requires-python`. It looped over the
`SpecifierSet` and **broke on the first** lower-bound specifier it encountered,
reading the minor version with `spec.version.split(".")[1]`. That logic has two
bugs:

### 1. Crash on a major-only version

A valid `requires-python = ">=3"` (equivalent to `">=3.0"` per PEP 440) has no
minor component, so `"3".split(".")[1]` raises a cryptic `IndexError` straight
out of this public helper:

```python
>>> import nox.project
>>> nox.project.python_versions({"project": {"requires-python": ">=3"}}, max_version="3.13")
Traceback (most recent call last):
  ...
IndexError: list index out of range
```

### 2. Wrong result with multiple lower bounds

For `requires-python = ">=3.8,>=3.10"` the effective minimum is **3.10**, but
breaking on the first lower-bound specifier returns 3.8, so the result claims
support for 3.8 and 3.9 which the metadata explicitly excludes:

```python
>>> nox.project.python_versions({"project": {"requires-python": ">=3.8,>=3.10"}}, max_version="3.12")
['3.8', '3.9', '3.10', '3.11', '3.12']   # should be ['3.10', '3.11', '3.12']
```

The output could even flip depending on specifier iteration order.

## Root cause

Both symptoms come from the same block, which assumed (a) exactly one relevant
lower bound and (b) that a version string always has a `major.minor` shape.

## Fix

Collect **every** lower-bound (`>`, `>=`, `~=`) specifier's minor version,
treat a major-only version as minor `0`, and use the **maximum** as the
effective minimum. When no lower-bound specifier exists, the existing
`ValueError` is still raised.

| `requires-python` | before | after |
|---|---|---|
| `">=3"` | `IndexError` | `['3.0', …, max]` |
| `">=3.8,>=3.10"` (max `3.12`) | `['3.8','3.9','3.10','3.11','3.12']` | `['3.10','3.11','3.12']` |
| `">=3.10,>=3.8"` (max `3.12`) | order-dependent | `['3.10','3.11','3.12']` |
| `">=3.10"` (max `3.12`) | `['3.10','3.11','3.12']` | unchanged |
| `">3.2.1,<3.3"` (max `3.4`) | `['3.2','3.3','3.4']` | unchanged |
| `"==3.3.1"` | `ValueError` | unchanged |

## Tests

Added `test_python_range_major_only` and `test_python_range_multiple_lower_bounds`
to `tests/test_project.py`. Verified they fail on `main` (the first with the
`IndexError`, the second asserting on the wrong `['3.8', '3.9', …]` output) and
pass with the fix.

```
$ python -m pytest tests/test_project.py -q
9 passed

$ python -m pytest -q      # full suite
720 passed, 27 skipped, 1 xpassed
```

`ruff check` and `ruff format --check` are clean on the changed files, and the
change introduces no new `mypy` errors (the 3 reported in `nox/project.py` are
pre-existing and outside this diff).
