### PR TITLE
ci: add Python 3.15 to the test matrix and classifiers

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -49,5 +49,5 @@ jobs:
           python-version: 3.12
       - uses: ./
         with:
-          python-versions: "pypy-2.7, pypy-3.8, pypy-3.9, pypy-3.10, pypy-3.11, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.13t, 3.14t"
+          python-versions: "pypy-2.7, pypy-3.8, pypy-3.9, pypy-3.10, pypy-3.11, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.15, 3.13t, 3.14t, 3.15t"
       - run: nox --session github_actions_all_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - "3.10"
           - "3.12"
           - "3.14"
+          - "3.15"
         include:
           - os: ubuntu-22.04
             python-version: "3.11"

--- a/noxfile.py
+++ b/noxfile.py
@@ -209,6 +209,7 @@ def _check_python_version(session: nox.Session) -> None:
         "pypy-3.11",
         "3.13t",
         "3.14t",
+        "3.15t",
     ],
     default=False,
     tags=["gha"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development :: Testing",
 ]
 dependencies = [
@@ -115,7 +116,7 @@ lint.flake8-builtins.ignorelist = [ "copyright" ]
 lint.flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.mypy]
 mypy_path = [ ".github" ]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds Python 3.15 support:

- Add the `3.15` classifier and bump `max_supported_python` (this flows into `ALL_PYTHONS`, which is derived from the classifiers).
- Add `3.15` to the CI test matrix.
- Add `3.15` and `3.15t` to the Action's `python-versions` smoke test.
- Add `3.15t` to the free-threaded list in `github_actions_default_tests`.

The conda test job is left pinned to 3.14, since conda-forge often lags on brand-new releases.