### PR TITLE
test: isolate run_nox envdir to fix flaky test_main_requires

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -493,9 +493,16 @@ def test_main_session_with_names(
 
 @pytest.fixture
 def run_nox(
-    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> Callable[..., tuple[int, str, str]]:
     def _run_nox(*args: str) -> tuple[int, str, str]:
+        # Give each invocation its own envdir so sessions that build real
+        # virtualenvs don't collide with other xdist workers sharing the
+        # noxfile's default ``.nox`` directory.
+        if not any(arg.startswith("--envdir") for arg in args):
+            args = (*args, "--envdir", str(tmp_path / ".nox"))
         monkeypatch.setattr(sys, "argv", ["nox", *args])
 
         with mock.patch("sys.exit") as sys_exit:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes the flaky `tests/test_main.py::test_main_requires*` failures reported in #1130.

The `run_nox` fixture runs nox against `noxfile_requires.py`, whose `v`/`w` sessions build real virtualenvs in the noxfile's default `.nox` directory. Under `pytest-xdist`, multiple workers create the same `u-django-*` env dirs concurrently and clobber each other, producing intermittent `failed to build image pip` / `FileNotFoundError` errors.

The fix gives each `run_nox` invocation its own `--envdir` under `tmp_path`, so parallel workers never share an env directory. As a side benefit, the suite no longer writes virtualenvs into `tests/resources/`.

Reproduced reliably by running the affected tests with `-n 8` (failed every time before, passes consistently after); the full `test_main.py` suite continues to pass.

Closes #1130

https://claude.ai/code/session_01R8KnkHPTvLxoAVeJHztGyu