### PR TITLE
feat: split environments from tasks (env:task)

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -518,22 +518,24 @@ declare them separately so several tasks share one environment:
 
     import nox
 
-    tooling = nox.env("tooling", python="3.12")
+    tooling = nox.env(
+        "tooling",
+        python="3.12",
+        dependencies=["prek", "mypy"],
+    )
 
     @tooling.task
     def lint(session):
         """Run the linters."""
-        session.install("prek")
         session.run("prek", "run", "--all-files", *session.posargs)
 
     @tooling.task(tags=["check"], default=False)
     def typecheck(session):
-        session.install("mypy")
         session.run("mypy", "src")
 
 Each task is a session named ``environment:task`` — here ``tooling:lint``
 and ``tooling:typecheck`` — and all of an environment's tasks run in one
-shared virtualenv, created once per invocation. A classic
+shared virtualenv, created and provisioned once per invocation. A classic
 ``@nox.session`` is exactly an environment and a task sharing one name, so
 ``nox -s tests`` and ``requires=["tests"]`` keep working unchanged.
 
@@ -549,10 +551,91 @@ are deprecated (existing ones keep working with a warning).
 ``nox.env()`` accepts the environment-level options of ``@nox.session`` —
 ``python``, ``venv_backend``, ``venv_params``, ``reuse_venv``,
 ``download_python``, and ``tags`` (tags are inherited by the environment's
-tasks). Listing multiple Pythons
+tasks) — plus the provisioning options below. Listing multiple Pythons
 creates one environment instance per interpreter: ``tests-3.11:run``,
 ``tests-3.12:run``, and so on. ``@nox.parametrize`` works on tasks, but
 ``python`` must be set on the environment, not parametrized on a task.
+
+Declarative dependencies and staleness
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unlike classic sessions, declarative environments record their provisioning
+inputs in a stamp file (``.nox-env.json``) inside the environment. On the
+next run the environment is reused, and if the stamp still matches — same
+dependency list, same lock file contents, same backend and Python — the
+installation step is skipped entirely, making repeat runs fast by default.
+If the inputs changed, lock file environments are re-synced in place (their
+syncs are exact), while a plain ``dependencies`` list recreates the
+environment, so removed dependencies actually disappear.
+``--reuse-venv=never`` forces full recreation, and ``-R``/``--no-install``
+skip installs as usual.
+
+For install-time logic that can't be expressed declaratively, add a setup
+hook. It runs after the declared dependencies are installed, and only when
+the environment is created or stale:
+
+.. code-block:: python
+
+    @tooling.setup
+    def _(session):
+        if sys.platform == "linux":
+            session.install("pyenchant")
+
+Since Nox cannot see when a hook's *effect* changes, an environment with a
+setup hook is re-synced on every run unless you pass a ``setup_stamp``
+string to ``nox.env()`` and bump it whenever the hook's behavior changes.
+
+Using ``session.install()`` inside a task still works, but for environments
+with more than one task it warns, since run-time installs into a shared
+environment are invisible to the staleness check.
+
+Lock files
+~~~~~~~~~~
+
+Specialized environment types install from lock files instead of a
+dependency list:
+
+.. code-block:: python
+
+    # PEP 751 pylock file, installed exactly with `uv pip sync`:
+    ci = nox.env.pylock("ci", lockfile="pylock.toml")
+
+    # A uv project's uv.lock, synced with `uv sync --locked`
+    # (requires the "uv" backend, which is the default here):
+    dev = nox.env.uv("dev", groups=["dev"], location=".venv")
+
+``nox.env.uv()`` accepts ``lockfile`` (default ``uv.lock``; the project is
+the lock file's directory), ``groups``, ``extras``, ``all_extras``,
+``no_default_groups``, ``no_install_project``, and ``sync_args`` for
+anything else. It requires the ``uv`` backend and refuses to sync under
+``--force-venv-backend``/``--no-venv``, since ``uv sync`` would otherwise
+target the project's own ``.venv``. The lock file's contents are part of
+the environment stamp, so editing the lock triggers a re-sync on the next
+run.
+
+Other formats can be supported by subclassing :class:`nox.Environment` and
+overriding ``stamp_data()`` (return the content hashes of your inputs, or
+``None`` to always re-sync) and ``sync(session)`` (run the install
+commands). Instantiating the subclass registers it, so a package like a
+poetry integration can simply ship its own environment type.
+
+Environment location
+~~~~~~~~~~~~~~~~~~~~
+
+By default environments live under ``--envdir`` (``.nox``). Pass
+``location=`` to place one somewhere specific — for example ``.venv``, so
+your editor and Nox share an environment:
+
+.. code-block:: python
+
+    dev = nox.env.uv("dev", location=".venv")
+
+The path is relative to the noxfile's directory. Environments with multiple
+Pythons must include a ``{name}`` or ``{python}`` placeholder (e.g.
+``location=".venvs/{name}"``) — two selected environment instances may
+never resolve to the same location. Nox will adopt an existing virtualenv
+at the location, but refuses to touch a non-empty directory that isn't one,
+and never writes ``.gitignore`` or ``CACHEDIR.TAG`` outside ``--envdir``.
 
 Aliases
 ~~~~~~~

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -504,6 +504,81 @@ More sophisticated tag assignment can be performed by passing a generator to the
 In this example, the ``quick`` tag is assigned to the single combination of the latest version of the dependency along with the SQLite database backend, allowing a developer to run the tests in a single configuration as a basic sanity test.  The ``standard`` tag, in contrast, selects combinations targeting either the latest version of the dependency *or* the SQLite database backend.  If the developer runs ``tox --tags standard``, the tests will be run against all supported versions of the dependency with the SQLite backend, as well as against all supported database backends under the latest version of the dependency, giving much more comprehensive test coverage while using only five of the potential nine test matrix combinations.
 
 
+.. _environments:
+
+Environments and tasks
+----------------------
+
+A session is really two things: an *environment* (a virtualenv and the
+packages installed into it) and a *task* (the thing you want to do, like
+running pytest). ``@nox.session`` fuses the two under one name; you can also
+declare them separately so several tasks share one environment:
+
+.. code-block:: python
+
+    import nox
+
+    tooling = nox.env("tooling", python="3.12")
+
+    @tooling.task
+    def lint(session):
+        """Run the linters."""
+        session.install("prek")
+        session.run("prek", "run", "--all-files", *session.posargs)
+
+    @tooling.task(tags=["check"], default=False)
+    def typecheck(session):
+        session.install("mypy")
+        session.run("mypy", "src")
+
+Each task is a session named ``environment:task`` — here ``tooling:lint``
+and ``tooling:typecheck`` — and all of an environment's tasks run in one
+shared virtualenv, created once per invocation. A classic
+``@nox.session`` is exactly an environment and a task sharing one name, so
+``nox -s tests`` and ``requires=["tests"]`` keep working unchanged.
+
+Environment names (and aliases, below) are globally unique and share a
+namespace with classic session names; task names only need to be unique
+within their environment. On the command line and in ``requires``, you can
+refer to a task by its full ``env:task`` id, by its bare task name if that's
+unambiguous across environments, or by the environment name to select the
+environment's default tasks. See :doc:`usage` for details. Because session
+names share this grammar, new session names containing ``:`` or parentheses
+are deprecated (existing ones keep working with a warning).
+
+``nox.env()`` accepts the environment-level options of ``@nox.session`` —
+``python``, ``venv_backend``, ``venv_params``, ``reuse_venv``,
+``download_python``, and ``tags`` (tags are inherited by the environment's
+tasks). Listing multiple Pythons
+creates one environment instance per interpreter: ``tests-3.11:run``,
+``tests-3.12:run``, and so on. ``@nox.parametrize`` works on tasks, but
+``python`` must be set on the environment, not parametrized on a task.
+
+Aliases
+~~~~~~~
+
+An alias gives a globally unique name to one or more sessions and can be
+used anywhere a session name can — on the command line, in ``requires``, or
+in ``nox.options.sessions``:
+
+.. code-block:: python
+
+    nox.alias("check", "tooling:lint", "tooling:typecheck")
+    nox.alias("style", "tooling:lint")
+
+Aliases are expanded recursively at selection time (a cycle is an error)
+and don't appear as sessions themselves. An alias that shadows an existing
+task name takes precedence, with a warning.
+
+Environment API reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: nox.Environment
+    :members:
+
+.. autofunction:: nox.alias
+
+
 The session object
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -78,6 +78,24 @@ By default Nox will run all sessions defined in the Noxfile. However, you can ch
 
 Nox will run these sessions in the same order they are specified.
 
+For tasks defined in an explicit :ref:`environment <environments>`, a session
+is identified as ``environment:task``. You can select one with its full id, or
+use several shorthands:
+
+.. code-block:: console
+
+    nox -s tooling:lint       # one specific task
+    nox -s tooling            # all default tasks of the environment
+    nox -s tests-3.12         # all default tasks of one Python instance
+    nox -s lint               # a bare task name, if unambiguous
+    nox -s check              # an alias
+
+A bare task name that exists in more than one environment is an error listing
+the qualified candidates, and selecting an environment with no default tasks
+is an error rather than a silent no-op. The same identifiers (including
+aliases) work in a session's ``requires`` list and in
+:func:`session.notify() <nox.sessions.Session.notify>`.
+
 If you have a :ref:`configured session's virtualenv <virtualenv config>`, you can choose to run only sessions with given Python versions:
 
 .. tabs::

--- a/nox/__init__.py
+++ b/nox/__init__.py
@@ -18,6 +18,7 @@ __lazy_modules__ = {
     "nox._cli",
     "nox._options",
     "nox._parametrize",
+    "nox.environments",
     "nox.registry",
     "nox.sessions",
     "types",
@@ -30,13 +31,18 @@ from nox._cli import main
 from nox._options import noxfile_options as options
 from nox._parametrize import Param as param  # noqa: N813
 from nox._parametrize import parametrize_decorator as parametrize
+from nox.environments import Environment, env
+from nox.registry import alias
 from nox.registry import session_decorator as session
 from nox.sessions import Session
 
 needs_version: str | None = None
 
 __all__ = [
+    "Environment",
     "Session",
+    "alias",
+    "env",
     "main",
     "needs_version",
     "options",

--- a/nox/_completers.py
+++ b/nox/_completers.py
@@ -71,6 +71,8 @@ def python_completer(
     config = _expand(parsed_args)
     module = load_nox_module(config)
     manifest = discover_manifest(module, config)
+    if isinstance(manifest, int):
+        return ()
     return filter(
         None,
         (
@@ -89,6 +91,8 @@ def session_completer(
     config.list_sessions = True
     module = load_nox_module(config)
     manifest = discover_manifest(module, config)
+    if isinstance(manifest, int):
+        return []
     filtered_manifest = filter_manifest(manifest, config)
     if isinstance(filtered_manifest, int):
         return []
@@ -105,6 +109,8 @@ def tag_completer(
     config = _expand(parsed_args)
     module = load_nox_module(config)
     manifest = discover_manifest(module, config)
+    if isinstance(manifest, int):
+        return ()
     return itertools.chain.from_iterable(
         filter(None, (session.tags for session, _ in manifest.list_all_sessions()))
     )

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
     from . import _typing
     from ._parametrize import Param
+    from .environments import Environment
 
 T = TypeVar("T", bound=Callable[..., Any])
 
@@ -56,6 +57,10 @@ def _copy_func(src: T, name: str | None = None) -> T:
 
 class Func:
     """This is a function decorator that adds additional Nox-specific metadata."""
+
+    # Set when this function is a task attached to an environment.
+    task_name: str | None = None
+    env: Environment | None = None
 
     def __new__(  # noqa: PYI034
         cls, func: Callable[..., Any], *args: Any, **kwargs: Any

--- a/nox/environments.py
+++ b/nox/environments.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+__lazy_modules__ = {f"{__spec__.parent}._decorators", "functools"}
+
+import functools
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
+
+from ._decorators import Func
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from ._typing import Python
+
+    RawFunc = Callable[..., Any]
+
+__all__ = [
+    "Environment",
+    "RegistryData",
+    "alias",
+    "env",
+    "get_registry_data",
+    "register_env",
+    "register_session_pair",
+    "register_task",
+    "reset_registry",
+    "validate_name",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def validate_name(name: str, kind: str = "An environment") -> None:
+    """Reject names that would break ``env:task`` identifiers."""
+    if not name:
+        msg = f"{kind} name cannot be empty."
+        raise ValueError(msg)
+    for char in ":()":
+        if char in name:
+            msg = f"{kind} name cannot contain {char!r}: {name!r}"
+            raise ValueError(msg)
+
+
+class Environment:
+    """A declarative environment (virtualenv + how to provision it).
+
+    Tasks are attached with the :meth:`task` decorator and run inside this
+    environment, sharing a single virtualenv. Instantiating an ``Environment``
+    registers it globally; subclasses can customize provisioning.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        python: Python = None,
+        venv_backend: str | None = None,
+        venv_params: Sequence[str] = (),
+        reuse_venv: bool | None = None,
+        download_python: Literal["auto", "never", "always"] | None = None,
+        tags: Sequence[str] | None = None,
+        register: bool = True,
+    ) -> None:
+        self.name = name
+        self.python = python
+        self.venv_backend = venv_backend
+        self.venv_params = venv_params
+        self.reuse_venv = reuse_venv
+        self.download_python = download_python
+        self.tags = list(tags or [])
+        # True for environments implicitly created by @nox.session; drives
+        # the legacy naming/envdir behavior.
+        self._session_compat = False
+
+        if register:
+            register_env(self)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(name={self.name!r})"
+
+    @overload
+    def task(self, func: RawFunc | Func, /) -> Func: ...
+
+    @overload
+    def task(
+        self,
+        func: None = ...,
+        /,
+        *,
+        name: str | None = ...,
+        tags: Sequence[str] | None = ...,
+        default: bool = ...,
+        requires: Sequence[str] | None = ...,
+    ) -> Callable[[RawFunc | Func], Func]: ...
+
+    def task(
+        self,
+        func: RawFunc | Func | None = None,
+        /,
+        *,
+        name: str | None = None,
+        tags: Sequence[str] | None = None,
+        default: bool = True,
+        requires: Sequence[str] | None = None,
+    ) -> Func | Callable[[RawFunc | Func], Func]:
+        """Designate the decorated function as a task in this environment.
+
+        Works with and without parentheses, like ``@nox.session``.
+        """
+        if func is None:
+            return functools.partial(
+                self.task, name=name, tags=tags, default=default, requires=requires
+            )
+
+        if isinstance(func, Func):
+            func = func.func
+
+        task_name = name or func.__name__
+        validate_name(task_name, "A task")
+
+        fn = Func(
+            func,
+            # Interpreter/venv settings are environment-level; they are filled
+            # in from the (expanded) environment when the manifest is built.
+            name=f"{self.name}:{task_name}",
+            tags=tags,
+            default=default,
+            requires=requires,
+        )
+        fn.task_name = task_name
+        fn.env = self
+
+        register_task(self, task_name, fn)
+        return fn
+
+
+class _EnvAPI:
+    """The ``nox.env`` callable namespace.
+
+    Calling it creates a plain declarative :class:`Environment`; specialized
+    environment types (lock file support, etc.) hang off it as attributes.
+    """
+
+    def __call__(self, name: str, /, **kwargs: Any) -> Environment:
+        return Environment(name, **kwargs)
+
+
+env = _EnvAPI()
+
+
+class RegistryData(NamedTuple):
+    """The full contents of the session registry."""
+
+    envs: dict[str, Environment]
+    tasks: dict[str, dict[str, Func]]
+    aliases: dict[str, tuple[str, ...]]
+
+
+_ENVS: dict[str, Environment] = {}
+_TASKS: dict[str, dict[str, Func]] = {}
+_ALIASES: dict[str, tuple[str, ...]] = {}
+
+
+def reset_registry() -> None:
+    _ENVS.clear()
+    _TASKS.clear()
+    _ALIASES.clear()
+
+
+def _check_global_name(name: str, kind: str) -> None:
+    if name in _ENVS:
+        what = "session" if _ENVS[name]._session_compat else "environment"
+        msg = f"A {what} named {name!r} is already registered; cannot register {kind} {name!r}."
+        raise ValueError(msg)
+    if name in _ALIASES:
+        msg = f"An alias named {name!r} is already registered; cannot register {kind} {name!r}."
+        raise ValueError(msg)
+
+
+def register_env(environment: Environment) -> None:
+    """Register an environment in the global registry."""
+    validate_name(environment.name)
+    _check_global_name(environment.name, "environment")
+    _ENVS[environment.name] = environment
+    _TASKS.setdefault(environment.name, {})
+
+
+def register_task(environment: Environment, task_name: str, fn: Func) -> None:
+    """Register a task under its environment."""
+    if environment.name not in _ENVS:
+        msg = f"The environment {environment.name!r} is not registered."
+        raise ValueError(msg)
+    tasks = _TASKS[environment.name]
+    if task_name in tasks:
+        msg = (
+            f"The task {task_name!r} is already registered in "
+            f"environment {environment.name!r}."
+        )
+        raise ValueError(msg)
+    tasks[task_name] = fn
+
+
+def register_session_pair(environment: Environment, fn: Func) -> None:
+    """Register a classic session: an environment/task pair sharing a name.
+
+    The name is not validated, since classic session names predate the
+    ``env:task`` grammar; ``@nox.session`` warns about conflicting names.
+    """
+    environment._session_compat = True
+    _ENVS[environment.name] = environment
+    _TASKS[environment.name] = {environment.name: fn}
+    fn.task_name = environment.name
+    fn.env = environment
+
+
+def alias(name: str, /, *targets: str) -> None:
+    """Register a global alias that expands to one or more sessions.
+
+    Args:
+        name: The alias name; shares a namespace with environments.
+        targets: One or more session identifiers (e.g. ``"tooling:lint"``).
+    """
+    validate_name(name, "An alias")
+    if not targets:
+        msg = f"Alias {name!r} needs at least one target."
+        raise ValueError(msg)
+    _check_global_name(name, "alias")
+    _ALIASES[name] = targets
+
+
+def get_registry_data() -> RegistryData:
+    """Return a shallow copy of the full registry."""
+    return RegistryData(
+        envs=dict(_ENVS),
+        tasks={name: dict(tasks) for name, tasks in _TASKS.items()},
+        aliases=dict(_ALIASES),
+    )

--- a/nox/environments.py
+++ b/nox/environments.py
@@ -14,10 +14,19 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = {f"{__spec__.parent}._decorators", "functools"}
+__lazy_modules__ = {
+    f"{__spec__.parent}._decorators",
+    "functools",
+    "hashlib",
+    "nox.virtualenv",
+}
 
 import functools
+import hashlib
+import os
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
+
+import nox.virtualenv
 
 from ._decorators import Func
 
@@ -25,12 +34,15 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from ._typing import Python
+    from .sessions import Session
 
     RawFunc = Callable[..., Any]
 
 __all__ = [
     "Environment",
+    "PylockEnvironment",
     "RegistryData",
+    "UvProjectEnvironment",
     "alias",
     "env",
     "get_registry_data",
@@ -57,6 +69,16 @@ def validate_name(name: str, kind: str = "An environment") -> None:
             raise ValueError(msg)
 
 
+def _file_hash(path: str, *, kind: str) -> str:
+    """Hash a provisioning input file for the environment stamp."""
+    try:
+        with open(path, "rb") as file:
+            return hashlib.sha256(file.read()).hexdigest()
+    except FileNotFoundError:
+        msg = f"The {kind} {path!r} does not exist."
+        raise FileNotFoundError(msg) from None
+
+
 class Environment:
     """A declarative environment (virtualenv + how to provision it).
 
@@ -75,6 +97,9 @@ class Environment:
         reuse_venv: bool | None = None,
         download_python: Literal["auto", "never", "always"] | None = None,
         tags: Sequence[str] | None = None,
+        dependencies: Sequence[str] = (),
+        location: str | os.PathLike[str] | None = None,
+        setup_stamp: str | None = None,
         register: bool = True,
     ) -> None:
         self.name = name
@@ -84,6 +109,10 @@ class Environment:
         self.reuse_venv = reuse_venv
         self.download_python = download_python
         self.tags = list(tags or [])
+        self.dependencies = list(dependencies)
+        self.location = os.fspath(location) if location is not None else None
+        self.setup_func: Callable[[Session], None] | None = None
+        self.setup_stamp = setup_stamp
         # True for environments implicitly created by @nox.session; drives
         # the legacy naming/envdir behavior.
         self._session_compat = False
@@ -93,6 +122,57 @@ class Environment:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r})"
+
+    def setup(self, func: Callable[[Session], None]) -> Callable[[Session], None]:
+        """Designate the decorated function as this environment's setup hook.
+
+        The hook runs after the declarative dependencies are synced, and only
+        when the environment is created or out of date. Since nox cannot know
+        when the hook's *effect* changes, an environment with a setup hook is
+        re-synced on every run unless ``setup_stamp`` is set; bump that value
+        whenever the hook's behavior changes.
+        """
+        if self.setup_func is not None:
+            msg = f"The environment {self.name!r} already has a setup function."
+            raise ValueError(msg)
+        self.setup_func = func
+        return func
+
+    def stamp_data(self) -> dict[str, Any] | None:
+        """The provisioning inputs, used to decide when to re-sync.
+
+        Returning ``None`` marks the environment as unstampable: it is synced
+        on every run. Subclasses should extend the returned dict with the
+        content hashes of their inputs (e.g. a lock file).
+        """
+        if self.setup_func is not None and self.setup_stamp is None:
+            return None
+        data: dict[str, Any] = {
+            "kind": "dependencies",
+            "dependencies": list(self.dependencies),
+        }
+        if self.setup_stamp is not None:
+            data["setup_stamp"] = self.setup_stamp
+        return data
+
+    @property
+    def sync_is_exact(self) -> bool:
+        """Whether :meth:`sync` makes the environment exactly match its inputs.
+
+        When False (plain pip installs are additive), a stale environment is
+        recreated instead of re-synced in place, so removed dependencies
+        actually disappear.
+        """
+        return False
+
+    def sync(self, session: Session) -> None:
+        """Install this environment's declared dependencies.
+
+        Subclasses override this to install from lock files; the base
+        implementation installs ``dependencies`` with pip/uv.
+        """
+        if self.dependencies:
+            session.install(*self.dependencies)
 
     @overload
     def task(self, func: RawFunc | Func, /) -> Func: ...
@@ -150,12 +230,152 @@ class Environment:
         return fn
 
 
+class PylockEnvironment(Environment):
+    """An environment installed from a PEP 751 ``pylock.toml`` file.
+
+    The lock file is installed with ``uv pip sync``, so the environment
+    exactly matches the lock; extra ``dependencies`` are installed after.
+    Available as ``nox.env.pylock``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        lockfile: str | os.PathLike[str] = "pylock.toml",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(name, **kwargs)
+        self.lockfile = os.fspath(lockfile)
+
+    def stamp_data(self) -> dict[str, Any] | None:
+        data = super().stamp_data()
+        if data is None:
+            return None
+        data["kind"] = "pylock"
+        data["lockfile"] = self.lockfile
+        data["lockfile_hash"] = _file_hash(self.lockfile, kind="lock file")
+        return data
+
+    @property
+    def sync_is_exact(self) -> bool:
+        # `uv pip sync` is exact; extra dependencies are installed after it,
+        # additively.
+        return not self.dependencies
+
+    def sync(self, session: Session) -> None:
+        if not nox.virtualenv.HAS_UV:
+            msg = (
+                f"Environment {self.name!r} installs from a pylock file, "
+                "which requires uv to be available."
+            )
+            raise RuntimeError(msg)
+        if not session.virtualenv.is_sandboxed or session.venv_backend not in {
+            "uv",
+            "virtualenv",
+            "venv",
+        }:
+            msg = (
+                f"Environment {self.name!r} installs from a pylock file, which "
+                f"requires a virtualenv-style backend, not {session.venv_backend!r}."
+            )
+            raise RuntimeError(msg)
+        # uv targets the session's venv through the VIRTUAL_ENV variable.
+        session.run_install(
+            nox.virtualenv.UV, "pip", "sync", self.lockfile, external=True, silent=True
+        )
+        super().sync(session)
+
+
+class UvProjectEnvironment(Environment):
+    """An environment synced from a uv project's ``uv.lock``.
+
+    Runs ``uv sync --locked`` against the project owning the lock file,
+    targeting this environment. Available as ``nox.env.uv``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        lockfile: str | os.PathLike[str] = "uv.lock",
+        groups: Sequence[str] = (),
+        extras: Sequence[str] = (),
+        all_extras: bool = False,
+        no_default_groups: bool = False,
+        no_install_project: bool = False,
+        sync_args: Sequence[str] = (),
+        venv_backend: str = "uv",
+        **kwargs: Any,
+    ) -> None:
+        if venv_backend != "uv":
+            msg = f"Environment {name!r} syncs a uv project and requires the 'uv' venv backend."
+            raise ValueError(msg)
+        super().__init__(name, venv_backend="uv", **kwargs)
+        self.lockfile = os.fspath(lockfile)
+        self.groups = list(groups)
+        self.extras = list(extras)
+        self.all_extras = all_extras
+        self.no_default_groups = no_default_groups
+        self.no_install_project = no_install_project
+        self.sync_args = list(sync_args)
+
+    def _sync_command(self) -> list[str]:
+        project_dir = os.path.dirname(os.path.abspath(self.lockfile))
+        command = ["sync", "--locked", f"--project={project_dir}"]
+        command.extend(f"--group={group}" for group in self.groups)
+        command.extend(f"--extra={extra}" for extra in self.extras)
+        if self.all_extras:
+            command.append("--all-extras")
+        if self.no_default_groups:
+            command.append("--no-default-groups")
+        if self.no_install_project:
+            command.append("--no-install-project")
+        command.extend(self.sync_args)
+        return command
+
+    def stamp_data(self) -> dict[str, Any] | None:
+        data = super().stamp_data()
+        if data is None:
+            return None
+        data["kind"] = "uv"
+        data["lockfile"] = self.lockfile
+        data["lockfile_hash"] = _file_hash(self.lockfile, kind="lock file")
+        data["command"] = self._sync_command()
+        return data
+
+    @property
+    def sync_is_exact(self) -> bool:
+        # `uv sync` is exact; extra dependencies are installed after it,
+        # additively.
+        return not self.dependencies
+
+    def sync(self, session: Session) -> None:
+        # uv targets the session's venv through UV_PROJECT_ENVIRONMENT, which
+        # only the uv backend sets; on any other backend `uv sync` would fall
+        # back to the *project's* own .venv and clobber it.
+        if session.venv_backend != "uv":
+            msg = (
+                f"Environment {self.name!r} syncs a uv project and must run "
+                f"on the 'uv' venv backend, not {session.venv_backend!r} "
+                "(is --force-venv-backend or --no-venv overriding it?)."
+            )
+            raise RuntimeError(msg)
+        session.run_install(
+            nox.virtualenv.UV, *self._sync_command(), external=True, silent=True
+        )
+        super().sync(session)
+
+
 class _EnvAPI:
     """The ``nox.env`` callable namespace.
 
     Calling it creates a plain declarative :class:`Environment`; specialized
     environment types (lock file support, etc.) hang off it as attributes.
     """
+
+    pylock = PylockEnvironment
+    uv = UvProjectEnvironment
 
     def __call__(self, name: str, /, **kwargs: Any) -> Environment:
         return Environment(name, **kwargs)

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -28,6 +28,7 @@ import ast
 import functools
 import itertools
 import operator
+import os
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
 
@@ -109,6 +110,45 @@ class Manifest:
             for name, func in session_functions.items():
                 for session in self.make_session(name, func):
                     self.add_session(session)
+
+    def check_location_collisions(self) -> None:
+        """Error if two selected environment instances share one location.
+
+        Checked over the selected sessions (not all sessions), so an
+        unselected environment cannot break an unrelated invocation — e.g.
+        --force-python temporarily multiplying a located environment.
+        """
+        locations: dict[str, str] = {}
+        location_bases: dict[str, str | None] = {}
+        seen_runners: set[int] = set()
+        for session in self._queue:
+            env_runner = session.env_runner
+            environment = env_runner.environment
+            if (
+                environment is None
+                or environment.location is None
+                or id(env_runner) in seen_runners
+            ):
+                continue
+            seen_runners.add(id(env_runner))
+            resolved = os.path.normpath(env_runner.envdir)
+            other = locations.setdefault(resolved, env_runner.friendly_name)
+            other_base = location_bases.setdefault(resolved, session.env_base_name)
+            if other == env_runner.friendly_name:
+                continue
+            if other_base == session.env_base_name:
+                msg = (
+                    f"Multiple instances of environment "
+                    f"{session.env_base_name!r} resolve to the location "
+                    f"{resolved!r}; add a {{name}} or {{python}} placeholder "
+                    "to its location."
+                )
+            else:
+                msg = (
+                    f"Environments {other!r} and {env_runner.friendly_name!r} "
+                    f"both resolve to the location {resolved!r}."
+                )
+            raise ValueError(msg)
 
     def __contains__(self, needle: str | SessionRunner) -> bool:
         return (
@@ -538,6 +578,8 @@ class Manifest:
                         env_runner = runner.env_runner
                         env_runner._name = dir_name
                         env_runner._func = func
+                        env_runner.environment = env
+                        env_runner.shared = len(tasks) > 1
                     else:
                         runner.env_runner = env_runner
                     runners.append(runner)
@@ -554,7 +596,9 @@ class Manifest:
         """Copy a task function and fill in the environment-level settings."""
         func = task_func.copy(task_func.name)
         func.python = python
-        func.reuse_venv = env.reuse_venv
+        # Declarative environments are reused (and re-synced when their
+        # inputs change) by default; --reuse-venv=never still recreates.
+        func.reuse_venv = True if env.reuse_venv is None else env.reuse_venv
         func.venv_backend = env.venv_backend
         func.venv_params = env.venv_params
         func.download_python = env.download_python

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -14,7 +14,15 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = {"ast", "itertools", "nox._resolver", "nox.sessions", "operator"}
+__lazy_modules__ = {
+    "ast",
+    "itertools",
+    "nox._resolver",
+    "nox.logger",
+    "nox.registry",
+    "nox.sessions",
+    "operator",
+}
 
 import ast
 import functools
@@ -25,12 +33,16 @@ from typing import TYPE_CHECKING, Any, cast
 
 from nox._decorators import Call, Func
 from nox._resolver import CycleError, lazy_stable_topo_sort
+from nox.logger import logger
+from nox.registry import RegistryData
 from nox.sessions import Session, SessionRunner
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
 
     from nox._options import NoxConfig
+    from nox._typing import Python
+    from nox.environments import Environment
 
 __all__ = ["WARN_PYTHONS_IGNORED", "Manifest", "keyword_match"]
 
@@ -67,7 +79,7 @@ class Manifest:
 
     def __init__(
         self,
-        session_functions: Mapping[str, Func],
+        session_functions: Mapping[str, Func] | RegistryData,
         global_config: NoxConfig,
         module_docstring: str | None = None,
     ) -> None:
@@ -76,11 +88,27 @@ class Manifest:
         self._consumed: list[SessionRunner] = []
         self._config: NoxConfig = global_config
         self.module_docstring: str | None = module_docstring
+        self._aliases: dict[str, tuple[str, ...]] = {}
+        self._extra_requirements_cache: dict[str, list[str]] | None = None
 
         # Create the sessions based on the provided session functions.
-        for name, func in session_functions.items():
-            for session in self.make_session(name, func):
-                self.add_session(session)
+        if isinstance(session_functions, RegistryData):
+            self._aliases = dict(session_functions.aliases)
+            for env_name, env in session_functions.envs.items():
+                tasks = session_functions.tasks.get(env_name, {})
+                if env._session_compat:
+                    # Classic sessions keep the historical expansion (and
+                    # per-session environment directories) exactly.
+                    for session in self.make_session(env_name, tasks[env_name]):
+                        self.add_session(session)
+                else:
+                    for session in self._make_env_sessions(env, tasks):
+                        self.add_session(session)
+            self._warn_shadowing_aliases()
+        else:
+            for name, func in session_functions.items():
+                for session in self.make_session(name, func):
+                    self.add_session(session)
 
     def __contains__(self, needle: str | SessionRunner) -> bool:
         return (
@@ -156,11 +184,17 @@ class Manifest:
         """
         if session not in self._all_sessions:
             self._all_sessions.append(session)
+            self._extra_requirements_cache = None
         if session not in self._queue:
             self._queue.append(session)
 
     def filter_by_name(self, specified_sessions: Iterable[str]) -> None:
         """Filter sessions in the queue based on the user-specified names.
+
+        A specified name may be a session/task identifier (``env:task`` or a
+        classic session name), an alias, an environment name (which selects
+        the environment's default tasks), or a bare task name if that task
+        name only exists in one environment.
 
         Args:
             specified_sessions (Sequence[str]): A list of specified
@@ -168,36 +202,67 @@ class Manifest:
 
         Raises:
             KeyError: If any explicitly listed sessions are not found.
+            ValueError: If a bare task name is ambiguous across environments.
         """
+        expanded = self._expand_aliases(specified_sessions)
+
+        kinds = {name: self._id_kind(name) for name in dict.fromkeys(expanded)}
+
         # Filter the sessions remaining in the queue based on
         # whether they are individually specified.
         self._queue = [
             session
-            for session_name in specified_sessions
+            for session_name in expanded
             for session in self._queue
-            if _normalized_session_match(session_name, session)
+            if _matches_kind(session_name, kinds[session_name], session)
         ]
 
         # If a session was requested and was not found, complain loudly.
-        all_sessions = set(
-            map(
-                _normalize_arg,
-                (
-                    itertools.chain(
-                        [x.name for x in self._all_sessions if x.name],
-                        *[x.signatures for x in self._all_sessions],
-                    )
-                ),
-            )
-        )
-        missing_sessions = [
-            session_name
-            for session_name in specified_sessions
-            if _normalize_arg(session_name) not in all_sessions
-        ]
+        missing_sessions = [name for name, kind in kinds.items() if kind is None]
         if missing_sessions:
             msg = f"Sessions not found: {', '.join(missing_sessions)}"
             raise KeyError(msg)
+
+    def _id_kind(self, name: str) -> str | None:
+        """Classify a user-specified identifier.
+
+        Returns ``"exact"`` (session name/signature), ``"env"`` (environment
+        selector), ``"task"`` (unambiguous bare task name), or ``None`` if
+        nothing matches. Earlier kinds take precedence.
+
+        Raises:
+            ValueError: If ``name`` is an ambiguous bare task name.
+        """
+        if any(
+            _normalized_session_match(name, session) for session in self._all_sessions
+        ):
+            return "exact"
+        env_matches = [
+            session
+            for session in self._all_sessions
+            if session.task_name is not None
+            and name in {session.env_base_name, session.env_instance_name}
+        ]
+        if env_matches:
+            if not any(session.func.default for session in env_matches):
+                msg = (
+                    f"Environment {name!r} has no default tasks; use "
+                    f"'{name}:<task>' to select a task."
+                )
+                raise ValueError(msg)
+            return "env"
+        task_envs = {
+            session.env_base_name
+            for session in self._all_sessions
+            if session.task_name == name
+        }
+        if len(task_envs) > 1:
+            candidates = ", ".join(sorted(f"{env}:{name}" for env in task_envs if env))
+            msg = f"Task {name!r} is ambiguous: {candidates}. Use 'environment:task'."
+            raise ValueError(msg)
+        if task_envs:
+            return "task"
+        return None
 
     def filter_by_default(self) -> None:
         """Filter sessions in the queue based on the default flag."""
@@ -224,7 +289,15 @@ class Manifest:
         self._queue = [
             x
             for x in self._queue
-            if keyword_match(keywords, [*x.signatures, *x.tags, x.name])
+            if keyword_match(
+                keywords,
+                [
+                    *x.signatures,
+                    *x.tags,
+                    x.name,
+                    *filter(None, (x.task_name, x.env_base_name, x.env_instance_name)),
+                ],
+            )
         ]
 
     def filter_by_tags(self, tags: Iterable[str]) -> None:
@@ -264,6 +337,20 @@ class Manifest:
             parent_sessions.add(parent_session)
             sessions_by_id[parent_name] = parent_session
 
+        # Aliases, environment selectors, and unambiguous bare task names are
+        # also allowed in ``requires``; represent each as a fake parent that
+        # depends on its expansion.
+        for extra_name, targets in self._extra_requirements().items():
+            if extra_name in sessions_by_id:
+                continue
+            parent_func = _null_session_func.copy()
+            parent_func.requires = targets
+            parent_session = SessionRunner(
+                extra_name, [], parent_func, self._config, self, multi=False
+            )
+            parent_sessions.add(parent_session)
+            sessions_by_id[extra_name] = parent_session
+
         # Construct the dependency graph. Note that this is done lazily with iterators
         # so that we won't raise if a session that doesn't actually need to run declares
         # missing/improper dependencies.
@@ -296,6 +383,244 @@ class Manifest:
         self._queue = [
             session for session in resolved_graph if session not in parent_sessions
         ]
+
+    def _expand_aliases(self, names: Iterable[str]) -> list[str]:
+        """Recursively expand aliases; a cycle leaves the name unresolved."""
+        expanded: list[str] = []
+
+        def expand(name: str, seen: frozenset[str]) -> None:
+            if name in self._aliases and name not in seen:
+                for target in self._aliases[name]:
+                    expand(target, seen | {name})
+            else:
+                expanded.append(name)
+
+        for name in names:
+            expand(name, frozenset())
+        return expanded
+
+    def _warn_shadowing_aliases(self) -> None:
+        for alias_name in self._aliases:
+            shadowed = sorted(
+                {
+                    f"{session.env_base_name}:{session.task_name}"
+                    for session in self._all_sessions
+                    if session.task_name == alias_name
+                }
+            )
+            if shadowed:
+                logger.warning(
+                    f"Alias {alias_name!r} shadows the task(s) "
+                    f"{', '.join(shadowed)}; the alias takes precedence."
+                )
+
+    def _extra_requirements(self) -> dict[str, list[str]]:
+        """Identifiers usable in ``requires`` beyond signatures and names.
+
+        Maps aliases, environment selectors (which expand to the environment
+        or instance's default tasks), and unambiguous bare task names to the
+        identifiers they expand to.
+        """
+        if self._extra_requirements_cache is not None:
+            return self._extra_requirements_cache
+        extra: dict[str, list[str]] = {
+            name: list(targets) for name, targets in self._aliases.items()
+        }
+
+        env_tasks: dict[str, dict[str, bool]] = {}
+        instance_tasks: dict[str, dict[str, bool]] = {}
+        task_envs: dict[str, dict[str, None]] = {}
+        for session in self._all_sessions:
+            if session.task_name is None:
+                continue
+            assert session.env_base_name is not None
+            env_defaults = env_tasks.setdefault(session.env_base_name, {})
+            env_defaults[session.name] = (
+                env_defaults.get(session.name, False) or session.func.default
+            )
+            if session.env_instance_name != session.env_base_name:
+                assert session.env_instance_name is not None
+                instance_tasks.setdefault(session.env_instance_name, {})[
+                    f"{session.env_instance_name}:{session.task_name}"
+                ] = session.func.default
+            task_envs.setdefault(session.task_name, {})[session.env_base_name] = None
+
+        for env_name, canonical_names in env_tasks.items():
+            defaults = [name for name, default in canonical_names.items() if default]
+            if defaults:
+                extra.setdefault(env_name, defaults)
+        for instance_name, signature_names in instance_tasks.items():
+            defaults = [name for name, default in signature_names.items() if default]
+            if defaults:
+                extra.setdefault(instance_name, defaults)
+        for task_name, envs in task_envs.items():
+            if len(envs) == 1:
+                (env_name,) = envs
+                extra.setdefault(task_name, [f"{env_name}:{task_name}"])
+
+        self._extra_requirements_cache = extra
+        return extra
+
+    def resolve_requirement(
+        self, requirement: str, _seen: frozenset[str] = frozenset()
+    ) -> list[SessionRunner]:
+        """Resolve a ``requires`` entry to the sessions it refers to.
+
+        Raises:
+            KeyError: If the requirement cannot be resolved.
+        """
+        by_signature = self.all_sessions_by_signature
+        if requirement in by_signature:
+            return [by_signature[requirement]]
+        by_name = self.parametrized_sessions_by_name
+        if requirement in by_name:
+            return list(by_name[requirement])
+        extra = self._extra_requirements()
+        if requirement in extra and requirement not in _seen:
+            seen = _seen | {requirement}
+            return [
+                session
+                for target in extra[requirement]
+                for session in self.resolve_requirement(target, seen)
+            ]
+        raise KeyError(requirement)
+
+    def _make_env_sessions(
+        self, env: Environment, tasks: Mapping[str, Func]
+    ) -> list[SessionRunner]:
+        """Create task runners for an explicit environment.
+
+        All tasks of one concrete environment instance (i.e. per interpreter,
+        after expanding a python list) share a single :class:`EnvRunner`.
+        """
+        runners: list[SessionRunner] = []
+
+        backend = (
+            self._config.force_venv_backend
+            or env.venv_backend
+            or self._config.default_venv_backend
+        )
+        python: Python = env.python
+        env_should_warn: dict[str, Any] = {}
+        if backend == "none" and isinstance(python, (list, tuple, set)):
+            env_should_warn[WARN_PYTHONS_IGNORED] = python
+            python = False
+
+        if self._config.extra_pythons:
+            extra_pythons: list[str] = self._config.extra_pythons
+            if isinstance(python, (list, tuple, set)):
+                python = _unique_list(*python, *extra_pythons)
+            elif python:
+                assert isinstance(python, str)
+                python = _unique_list(python, *extra_pythons)
+            elif not python and self._config.force_pythons:
+                python = _unique_list(*extra_pythons)
+
+        multi = isinstance(python, (list, tuple, set))
+        pythons = list(python) if isinstance(python, (list, tuple, set)) else [python]
+
+        for py in pythons:
+            # The on-disk name only gets a python suffix for a python list
+            # (matching classic sessions), but the selector always does, so
+            # `-s tooling-3.12` works for pinned environments too.
+            dir_name = f"{env.name}-{py}" if multi and py else env.name
+            selector_name = f"{env.name}-{py}" if py else env.name
+            env_runner = None
+            for task_name, task_func in tasks.items():
+                func = self._bind_task_func(task_func, env, py, env_should_warn)
+                for runner in self._make_task_runners(
+                    env.name, task_name, func, multi=multi
+                ):
+                    runner.task_name = task_name
+                    runner.env_base_name = env.name
+                    runner.env_instance_name = selector_name
+                    if env_runner is None:
+                        env_runner = runner.env_runner
+                        env_runner._name = dir_name
+                        env_runner._func = func
+                    else:
+                        runner.env_runner = env_runner
+                    runners.append(runner)
+
+        return runners
+
+    def _bind_task_func(
+        self,
+        task_func: Func,
+        env: Environment,
+        python: Python,
+        env_should_warn: Mapping[str, Any],
+    ) -> Func:
+        """Copy a task function and fill in the environment-level settings."""
+        func = task_func.copy(task_func.name)
+        func.python = python
+        func.reuse_venv = env.reuse_venv
+        func.venv_backend = env.venv_backend
+        func.venv_params = env.venv_params
+        func.download_python = env.download_python
+        func.tags = _unique_list(*env.tags, *task_func.tags)
+        func.should_warn.update(env_should_warn)
+        return func
+
+    def _make_task_runners(
+        self, env_name: str, task_name: str, func: Func, *, multi: bool
+    ) -> list[SessionRunner]:
+        """Create the runner(s) for one task in one concrete environment.
+
+        Mirrors the signature scheme of :meth:`make_session`, with the python
+        suffix attached to the environment part of the ``env:task`` id.
+        """
+        canonical = f"{env_name}:{task_name}"
+        instance_id = f"{env_name}-{func.python}:{task_name}" if func.python else None
+
+        if not hasattr(func, "parametrize"):
+            long_names = []
+            if not multi:
+                long_names.append(canonical)
+            if instance_id:
+                long_names.append(instance_id)
+            return [
+                SessionRunner(
+                    canonical, long_names, func, self._config, self, multi=multi
+                )
+            ]
+
+        sessions = []
+        calls = Call.generate_calls(func, func.parametrize)
+        for call in calls:
+            if call.python != func.python:
+                msg = (
+                    f"Task {canonical!r} cannot parametrize 'python'; "
+                    "set python on the environment instead."
+                )
+                raise ValueError(msg)
+            long_names = []
+            if not multi or (
+                self._config.force_pythons
+                and call.python in (self._config.extra_pythons or ())
+            ):
+                long_names.append(f"{canonical}{call.session_signature}")
+            if instance_id:
+                long_names.append(f"{instance_id}{call.session_signature}")
+                # Ensure that specifying environment-python will run all
+                # parameterizations.
+                long_names.append(instance_id)
+            sessions.append(
+                SessionRunner(
+                    canonical, long_names, call, self._config, self, multi=multi
+                )
+            )
+
+        # Edge case: If the parameters made it such that there were no valid
+        # calls, add an empty, do-nothing session.
+        if not calls:
+            sessions.append(
+                SessionRunner(
+                    canonical, [], _null_session_func, self._config, self, multi=multi
+                )
+            )
+
+        return sessions
 
     def make_session(
         self, name: str, func: Func, *, multi: bool = False
@@ -437,6 +762,24 @@ class Manifest:
                 self._queue.append(s)
                 return True
 
+        # Fall back to the shared identifier grammar (aliases, environment
+        # selectors, bare task names).
+        if isinstance(session, str):
+            try:
+                resolved = self.resolve_requirement(session)
+            except KeyError:
+                pass
+            else:
+                added = False
+                for runner in resolved:
+                    if runner in self._queue or runner in self._consumed:
+                        continue
+                    if posargs is not None:
+                        runner.posargs = list(posargs)
+                    self._queue.append(runner)
+                    added = True
+                return added
+
         # The session was not found in the list of sessions.
         msg = f"Session {session} not found."
         raise ValueError(msg)
@@ -481,7 +824,7 @@ def _normalized_session_match(session_name: str, session: SessionRunner) -> bool
     if session_name == session.name or session_name in session.signatures:
         return True
     normalized_name = _normalize_arg(session_name)
-    for name in session.signatures:
+    for name in (session.name, *session.signatures):
         equal_rep = normalized_name == _normalize_arg(name)
         if equal_rep:
             return True
@@ -489,9 +832,34 @@ def _normalized_session_match(session_name: str, session: SessionRunner) -> bool
     return False
 
 
+def _matches_kind(session_name: str, kind: str | None, session: SessionRunner) -> bool:
+    """Checks if session_name, classified by Manifest._id_kind, matches session."""
+    if kind == "exact":
+        return _normalized_session_match(session_name, session)
+    if kind == "env":
+        # Selecting an environment runs its default tasks.
+        return (
+            session.task_name is not None
+            and session_name in {session.env_base_name, session.env_instance_name}
+            and session.func.default
+        )
+    if kind == "task":
+        return session.task_name == session_name
+    return False
+
+
 @functools.cache
 def _normalize_arg(arg: str) -> str:
     """Normalize arg for comparison."""
+    # For env:task ids only the task part is Python-like; normalize it alone.
+    # A colon after "(" is parametrize-argument content, not a separator.
+    head, sep, tail = arg.partition(":")
+    if sep and "(" not in head:
+        return f"{head}:{_normalize_call(tail)}"
+    return _normalize_call(arg)
+
+
+def _normalize_call(arg: str) -> str:
     try:
         return str(ast.dump(ast.parse(arg)))
     except (TypeError, SyntaxError):

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -14,22 +14,35 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = {"copy", f"{__spec__.parent}._decorators", "functools", "warnings"}
+__lazy_modules__ = {
+    f"{__spec__.parent}._decorators",
+    f"{__spec__.parent}.environments",
+    "functools",
+    "warnings",
+}
 
-import copy
 import functools
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+from . import environments
 from ._decorators import Func
+from .environments import Environment, RegistryData, alias
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ._typing import Python
 
-__all__ = ["get", "reset", "session_decorator"]
+__all__ = [
+    "RegistryData",
+    "alias",
+    "get",
+    "get_registry",
+    "reset",
+    "session_decorator",
+]
 
 
 def __dir__() -> list[str]:
@@ -38,11 +51,28 @@ def __dir__() -> list[str]:
 
 RawFunc = Callable[..., Any]
 
-_REGISTRY: dict[str, Func] = {}
-
 
 def reset() -> None:
-    _REGISTRY.clear()
+    environments.reset_registry()
+
+
+def get_registry() -> RegistryData:
+    """Return a shallow copy of the full registry."""
+    return environments.get_registry_data()
+
+
+def get() -> dict[str, Func]:
+    """Return the registered sessions as a name-to-function mapping.
+
+    Only includes classic sessions (same-name environment/task pairs), for
+    backward compatibility. Use :func:`get_registry` for the full registry.
+    """
+    data = environments.get_registry_data()
+    return {
+        name: data.tasks[name][name]
+        for name, env in data.envs.items()
+        if env._session_compat and name in data.tasks.get(name, {})
+    }
 
 
 @overload
@@ -84,7 +114,10 @@ def session_decorator(
     download_python: Literal["auto", "never", "always"] | None = None,
     allow_parallel: bool | None = None,
 ) -> Func | Callable[[RawFunc | Func], Func]:
-    """Designate the decorated function as a session."""
+    """Designate the decorated function as a session.
+
+    A session is an environment and a task sharing one name.
+    """
     # If `func` is provided, then this is the decorator call with the function
     # being sent as part of the Python syntax (`@nox.session`).
     # If `func` is None, however, then this is a plain function call, and it
@@ -123,6 +156,14 @@ def session_decorator(
 
     reg_name = name or func.__name__
 
+    if any(char in reg_name for char in ":()"):
+        msg = (
+            f"The session name {reg_name!r} contains characters used by "
+            "environment:task identifiers (':', '(', ')'); this will become "
+            "an error in a future version of nox."
+        )
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+
     fn = Func(
         func,
         python,
@@ -136,21 +177,28 @@ def session_decorator(
         download_python=download_python,
         allow_parallel=allow_parallel,
     )
-    if reg_name in _REGISTRY:
+
+    if reg_name in environments._ENVS:
+        if not environments._ENVS[reg_name]._session_compat:
+            msg = (
+                f"An environment named {reg_name!r} is already registered; "
+                "sessions and environments share one namespace."
+            )
+            raise ValueError(msg)
         msg = (
             f"The session {reg_name!r} has already been registered; "
             "this will be an error in a future version of nox. "
             "Overriding the old session for now."
         )
+        # Overwriting below keeps the original registration order.
         warnings.warn(msg, FutureWarning, stacklevel=2)
-    _REGISTRY[reg_name] = fn
+    elif reg_name in environments._ALIASES:
+        msg = (
+            f"An alias named {reg_name!r} is already registered; "
+            "sessions and aliases share one namespace."
+        )
+        raise ValueError(msg)
+
+    env = Environment(reg_name, python=python, register=False)
+    environments.register_session_pair(env, fn)
     return fn
-
-
-def get() -> dict[str, Func]:
-    """Return a shallow copy of the registry.
-
-    This ensures that the registry is not accidentally modified by
-    calling code that retrieves a registry and mutates it.
-    """
-    return copy.copy(_REGISTRY)

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -19,6 +19,8 @@ __lazy_modules__ = {
     "hashlib",
     "humanize",
     "inspect",
+    "json",
+    "nox.environments",
     "nox.logger",
     "nox.popen",
     "nox.virtualenv",
@@ -34,6 +36,7 @@ import datetime
 import enum
 import hashlib
 import inspect
+import json
 import os
 import pathlib
 import re
@@ -48,6 +51,7 @@ import humanize
 
 import nox.command
 import nox.virtualenv
+from nox.environments import Environment
 from nox.logger import logger
 from nox.popen import DEFAULT_INTERRUPT_TIMEOUT, DEFAULT_TERMINATE_TIMEOUT
 from nox.virtualenv import (
@@ -915,6 +919,19 @@ class Session:
         if self._runner.global_config.no_install and venv._reused:
             return
 
+        env_runner = self._runner.env_runner
+        if (
+            env_runner.shared
+            and not env_runner._syncing
+            and not env_runner._install_warned
+        ):
+            env_runner._install_warned = True
+            logger.warning(
+                f"'{self._runner.friendly_name}' installs packages at run time"
+                f" into the shared environment '{env_runner.friendly_name}';"
+                " prefer declaring dependencies on the environment."
+            )
+
         if silent is None:
             silent = not self._runner.global_config.verbose
 
@@ -1078,10 +1095,15 @@ def resolve_reuse_existing_venv(global_config: NoxConfig, func: Func) -> bool:
 class EnvRunner:
     """Owns the virtualenv shared by the task(s) that run in it.
 
-    Currently paired 1:1 with a :class:`SessionRunner` and reads its
-    identity and configuration through it; this inverts once environments
-    become first-class objects that multiple tasks share.
+    For classic sessions this is paired 1:1 with a :class:`SessionRunner`
+    and reads its identity and configuration through it; the tasks of an
+    explicit :class:`~nox.environments.Environment` share one instance.
     """
+
+    # Set for explicit environments; None for classic sessions.
+    environment: Environment | None = None
+    # True when more than one task is attached to this environment.
+    shared: bool = False
 
     def __init__(self, owner: SessionRunner, name: str | None = None) -> None:
         self._owner = owner
@@ -1089,6 +1111,9 @@ class EnvRunner:
         self._func: Func | None = None
         self.venv: ProcessEnv | None = None
         self._ensured = False
+        self._provisioned = False
+        self._syncing = False
+        self._install_warned = False
         self._error: BaseException | None = None
 
     @property
@@ -1109,7 +1134,17 @@ class EnvRunner:
 
     @property
     def envdir(self) -> str:
+        if self.environment is not None and self.environment.location is not None:
+            location = self.environment.location.format(
+                name=self.friendly_name, python=self.func.python or ""
+            )
+            root = os.path.realpath(os.path.dirname(self.global_config.noxfile))
+            return os.path.normpath(os.path.join(root, location))
         return _normalize_path(os.fspath(self.global_config.envdir), self.friendly_name)
+
+    @property
+    def _stamp_path(self) -> str:
+        return os.path.join(self.envdir, ".nox-env.json")
 
     def ensure(self) -> None:
         """Create the virtualenv if this runner hasn't already done so.
@@ -1129,17 +1164,141 @@ class EnvRunner:
             raise
         self._ensured = True
 
-    def _create_venv(self) -> None:
+    def _create_venv(self, *, reuse_existing: bool | None = None) -> None:
+        if reuse_existing is None:
+            reuse_existing = self.reuse_existing_venv()
+        custom_location = (
+            self.environment is not None and self.environment.location is not None
+        )
+        if custom_location:
+            self._check_location_ownership()
+
         self.venv = get_virtualenv(
             *resolve_venv_backends(self.global_config, self.func),
             download_python=resolve_download_python(self.global_config, self.func),
             envdir=self.envdir,
-            reuse_existing=self.reuse_existing_venv(),
+            reuse_existing=reuse_existing,
             interpreter=self.func.python,
             venv_params=self.func.venv_params,
+            manage_parent_dir=not custom_location,
         )
 
         self.venv.create()
+
+    def _check_location_ownership(self) -> None:
+        """Never delete or reuse a user path that isn't a virtual environment."""
+        location = self.envdir
+        if not os.path.isdir(location) or not os.listdir(location):
+            return
+        if os.path.isfile(os.path.join(location, "pyvenv.cfg")):
+            return
+        if os.path.isdir(os.path.join(location, "conda-meta")):
+            return
+        msg = (
+            f"Refusing to use {location!r} for environment "
+            f"{self.friendly_name!r}: the directory exists, is not empty, and "
+            "does not look like a virtual environment."
+        )
+        raise OSError(msg)
+
+    def provision(self, session: Session) -> None:
+        """Sync the environment's declared dependencies, once, if stale.
+
+        No-op for classic sessions. A failure is remembered so later tasks
+        sharing this environment fail fast.
+        """
+        if self._error is not None:
+            raise self._error
+        if self._provisioned or self.environment is None:
+            self._provisioned = True
+            return
+        try:
+            self._provision(session)
+        except BaseException as exc:
+            if not isinstance(exc, KeyboardInterrupt):
+                self._error = exc
+            raise
+        self._provisioned = True
+
+    def _provision(self, session: Session) -> None:
+        environment = self.environment
+        assert environment is not None
+        if isinstance(self.venv, PassthroughEnv) and (
+            environment.dependencies
+            or environment.setup_func is not None
+            or type(environment) is not Environment
+        ):
+            msg = (
+                f"Environment {environment.name!r} declares dependencies but "
+                "does not have a virtualenv (venv_backend 'none')."
+            )
+            raise ValueError(msg)
+        reused = self.venv is not None and self.venv._reused
+        if self.global_config.no_install and reused:
+            return
+
+        stamp = self._stamp_content()
+        if stamp is not None and reused:
+            if self._read_stamp() == stamp:
+                logger.debug(f"Environment {self.friendly_name} is already up to date.")
+                return
+            if not environment.sync_is_exact:
+                # An additive sync would leave removed dependencies behind;
+                # start over so the environment matches its declaration.
+                logger.info(
+                    f"Recreating environment {self.friendly_name}: its "
+                    "provisioning inputs changed."
+                )
+                self._create_venv(reuse_existing=False)
+
+        # Remove the stamp first so an interrupted sync reads as stale.
+        with contextlib.suppress(OSError):
+            os.remove(self._stamp_path)
+
+        self._syncing = True
+        try:
+            environment.sync(session)
+            if environment.setup_func is not None:
+                environment.setup_func(session)
+        finally:
+            self._syncing = False
+
+        # Under --install-only a setup hook's session.run() calls are
+        # skipped, so only then could the sync be incomplete.
+        if stamp is not None and not (
+            self.global_config.install_only and environment.setup_func is not None
+        ):
+            self._write_stamp(stamp)
+
+    def _stamp_content(self) -> dict[str, Any] | None:
+        assert self.environment is not None
+        data = self.environment.stamp_data()
+        if data is None:
+            return None
+        return {
+            "version": 1,
+            "backend": self.venv.venv_backend if self.venv is not None else None,
+            "python": self.func.python,
+            "venv_params": list(self.func.venv_params),
+            "env": data,
+        }
+
+    def _read_stamp(self) -> dict[str, Any] | None:
+        try:
+            with open(self._stamp_path, encoding="utf-8") as stamp_file:
+                content = json.load(stamp_file)
+        except (OSError, ValueError):
+            return None
+        return content if isinstance(content, dict) else None
+
+    def _write_stamp(self, stamp: dict[str, Any]) -> None:
+        temp_path = self._stamp_path + ".tmp"
+        try:
+            with open(temp_path, "w", encoding="utf-8") as stamp_file:
+                json.dump(stamp, stamp_file)
+            os.replace(temp_path, self._stamp_path)
+        except OSError:  # pragma: no cover
+            logger.debug(f"Failed to write {self._stamp_path}")
 
     def reuse_existing_venv(self) -> bool:
         """
@@ -1284,6 +1443,7 @@ class SessionRunner:
                 self._create_venv()
                 session = Session(self)
                 session.env["NOX_CURRENT_SESSION"] = session.name
+                self.env_runner.provision(session)
                 self.func(session)
 
             # Nothing went wrong; return a success.

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -80,7 +80,7 @@ if typing.TYPE_CHECKING:
     from nox.command import ExternalType
     from nox.manifest import Manifest
 
-__all__ = ["Result", "Session", "SessionRunner", "Status", "nox"]
+__all__ = ["EnvRunner", "Result", "Session", "SessionRunner", "Status", "nox"]
 
 
 def __dir__() -> list[str]:
@@ -1075,6 +1075,66 @@ def resolve_reuse_existing_venv(global_config: NoxConfig, func: Func) -> bool:
     )
 
 
+class EnvRunner:
+    """Owns the virtualenv shared by the task(s) that run in it.
+
+    Currently paired 1:1 with a :class:`SessionRunner` and reads its
+    identity and configuration through it; this inverts once environments
+    become first-class objects that multiple tasks share.
+    """
+
+    def __init__(self, owner: SessionRunner) -> None:
+        self._owner = owner
+        self.venv: ProcessEnv | None = None
+        self._ensured = False
+
+    @property
+    def func(self) -> Func:
+        return self._owner.func
+
+    @property
+    def global_config(self) -> NoxConfig:
+        return self._owner.global_config
+
+    @property
+    def friendly_name(self) -> str:
+        return self._owner.friendly_name
+
+    @property
+    def envdir(self) -> str:
+        return _normalize_path(os.fspath(self.global_config.envdir), self.friendly_name)
+
+    def ensure(self) -> None:
+        """Create the virtualenv if this runner hasn't already done so."""
+        if self._ensured:
+            return
+        self._create_venv()
+        self._ensured = True
+
+    def _create_venv(self) -> None:
+        self.venv = get_virtualenv(
+            *resolve_venv_backends(self.global_config, self.func),
+            download_python=resolve_download_python(self.global_config, self.func),
+            envdir=self.envdir,
+            reuse_existing=self.reuse_existing_venv(),
+            interpreter=self.func.python,
+            venv_params=self.func.venv_params,
+        )
+
+        self.venv.create()
+
+    def reuse_existing_venv(self) -> bool:
+        """
+        Determines whether to reuse an existing virtual environment.
+
+        See :func:`resolve_reuse_existing_venv` for the decision matrix.
+
+        Returns:
+            bool: True if the existing virtual environment should be reused, False otherwise.
+        """
+        return resolve_reuse_existing_venv(self.global_config, self.func)
+
+
 class SessionRunner:
     def __init__(
         self,
@@ -1091,7 +1151,7 @@ class SessionRunner:
         self.func = func
         self.global_config = global_config
         self.manifest = manifest
-        self.venv: ProcessEnv | None = None
+        self.env_runner = EnvRunner(self)
         self.posargs: list[str] = global_config.posargs[:]
         self.result: Result | None = None
         self.multi = multi
@@ -1131,8 +1191,16 @@ class SessionRunner:
         return self.func.tags
 
     @property
+    def venv(self) -> ProcessEnv | None:
+        return self.env_runner.venv
+
+    @venv.setter
+    def venv(self, value: ProcessEnv | None) -> None:
+        self.env_runner.venv = value
+
+    @property
     def envdir(self) -> str:
-        return _normalize_path(os.fspath(self.global_config.envdir), self.friendly_name)
+        return self.env_runner.envdir
 
     def get_direct_dependencies(
         self, sessions_by_id: Mapping[str, SessionRunner] | None = None
@@ -1173,27 +1241,11 @@ class SessionRunner:
             raise KeyError(msg) from exc
 
     def _create_venv(self) -> None:
-        self.venv = get_virtualenv(
-            *resolve_venv_backends(self.global_config, self.func),
-            download_python=resolve_download_python(self.global_config, self.func),
-            envdir=self.envdir,
-            reuse_existing=self.reuse_existing_venv(),
-            interpreter=self.func.python,
-            venv_params=self.func.venv_params,
-        )
-
-        self.venv.create()
+        self.env_runner.ensure()
 
     def reuse_existing_venv(self) -> bool:
-        """
-        Determines whether to reuse an existing virtual environment.
-
-        See :func:`resolve_reuse_existing_venv` for the decision matrix.
-
-        Returns:
-            bool: True if the existing virtual environment should be reused, False otherwise.
-        """
-        return resolve_reuse_existing_venv(self.global_config, self.func)
+        """See :meth:`EnvRunner.reuse_existing_venv`."""
+        return self.env_runner.reuse_existing_venv()
 
     def execute(self) -> Result:
         logger.session_info(f"Running session {self.friendly_name}")

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -1083,13 +1083,20 @@ class EnvRunner:
     become first-class objects that multiple tasks share.
     """
 
-    def __init__(self, owner: SessionRunner) -> None:
+    def __init__(self, owner: SessionRunner, name: str | None = None) -> None:
         self._owner = owner
+        self._name = name
+        self._func: Func | None = None
         self.venv: ProcessEnv | None = None
         self._ensured = False
+        self._error: BaseException | None = None
 
     @property
     def func(self) -> Func:
+        # An explicit override so that a shared environment's configuration
+        # does not depend on which task happens to run first.
+        if self._func is not None:
+            return self._func
         return self._owner.func
 
     @property
@@ -1098,17 +1105,28 @@ class EnvRunner:
 
     @property
     def friendly_name(self) -> str:
-        return self._owner.friendly_name
+        return self._name or self._owner.friendly_name
 
     @property
     def envdir(self) -> str:
         return _normalize_path(os.fspath(self.global_config.envdir), self.friendly_name)
 
     def ensure(self) -> None:
-        """Create the virtualenv if this runner hasn't already done so."""
+        """Create the virtualenv if this runner hasn't already done so.
+
+        A failure is remembered so that later tasks sharing this environment
+        fail fast instead of retrying the creation.
+        """
+        if self._error is not None:
+            raise self._error
         if self._ensured:
             return
-        self._create_venv()
+        try:
+            self._create_venv()
+        except BaseException as exc:
+            if not isinstance(exc, KeyboardInterrupt):
+                self._error = exc
+            raise
         self._ensured = True
 
     def _create_venv(self) -> None:
@@ -1136,6 +1154,12 @@ class EnvRunner:
 
 
 class SessionRunner:
+    # Set for tasks attached to an explicit environment; None for classic
+    # sessions (same-name environment/task pairs).
+    task_name: str | None = None
+    env_base_name: str | None = None
+    env_instance_name: str | None = None
+
     def __init__(
         self,
         name: str,
@@ -1145,13 +1169,14 @@ class SessionRunner:
         manifest: Manifest,
         *,
         multi: bool = False,
+        env_runner: EnvRunner | None = None,
     ) -> None:
         self.name = name
         self.signatures = signatures
         self.func = func
         self.global_config = global_config
         self.manifest = manifest
-        self.env_runner = EnvRunner(self)
+        self.env_runner = env_runner if env_runner is not None else EnvRunner(self)
         self.posargs: list[str] = global_config.posargs[:]
         self.result: Result | None = None
         self.multi = multi
@@ -1225,15 +1250,8 @@ class SessionRunner:
         """
         try:
             if sessions_by_id is None:
-                sessions_by_signature = self.manifest.all_sessions_by_signature
-                parametrized_sessions_by_name = (
-                    self.manifest.parametrized_sessions_by_name
-                )
                 for requirement in self.func.requires:
-                    if requirement in sessions_by_signature:
-                        yield sessions_by_signature[requirement]
-                    else:
-                        yield from parametrized_sessions_by_name[requirement]
+                    yield from self.manifest.resolve_requirement(requirement)
             else:
                 yield from map(sessions_by_id.__getitem__, self.func.requires)
         except KeyError as exc:

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -282,6 +282,12 @@ def filter_manifest(manifest: Manifest, global_config: NoxConfig) -> Manifest | 
         logger.error(exc.args[0])
         return 3
 
+    try:
+        manifest.check_location_collisions()
+    except ValueError as exc:
+        logger.error(exc.args[0])
+        return 3
+
     # Return the modified manifest.
     return manifest
 

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -72,7 +72,7 @@ def _load_and_exec_nox_module(global_config: NoxConfig) -> types.ModuleType:
     Loads, executes, then returns the global_config Nox module.
 
     Args:
-        global_config (Namespace): The global config.
+        global_config (NoxConfig): The global config.
 
     Raises:
         IOError: If the Nox module cannot be loaded. This
@@ -168,7 +168,7 @@ def merge_noxfile_options(
 
 def discover_manifest(
     module: types.ModuleType | int, global_config: NoxConfig
-) -> Manifest:
+) -> Manifest | int:
     """Discover all session functions in the Noxfile module.
 
     Args:
@@ -178,16 +178,21 @@ def discover_manifest(
     Returns:
         ~.Manifest: A manifest of session functions.
     """
-    # Find any function added to the session registry (meaning it was
-    # decorated with @nox.session); do not sort these, as they are being
-    # sorted by decorator call time.
-    functions = registry.get()
+    # Find everything added to the registry (@nox.session, nox.env and task
+    # decorators, aliases); do not sort these, as they are being sorted by
+    # registration time.
+    registry_data = registry.get_registry()
 
     # Get the docstring from the Noxfile
     module_docstring = module.__doc__
 
     # Return the final dictionary of session functions.
-    return Manifest(functions, global_config, module_docstring)
+    try:
+        return Manifest(registry_data, global_config, module_docstring)
+    except ValueError as exc:
+        logger.error("Error while constructing sessions.")
+        logger.error(exc.args[0])
+        return 3
 
 
 def filter_manifest(manifest: Manifest, global_config: NoxConfig) -> Manifest | int:
@@ -208,16 +213,17 @@ def filter_manifest(manifest: Manifest, global_config: NoxConfig) -> Manifest | 
         return 3
 
     # Filter by the name of any explicit sessions.
-    # This can raise KeyError if a specified session does not exist;
-    # log this if it happens. The sessions does not come from the Noxfile
-    # if keywords is not empty or tags are supplied.
+    # This can raise KeyError if a specified session does not exist, or
+    # ValueError for an ambiguous bare task name; log this if it happens.
+    # The sessions does not come from the Noxfile if keywords is not empty
+    # or tags are supplied.
     if global_config.tags is None and not global_config.keywords:
         if global_config.sessions is None:
             manifest.filter_by_default()
         else:
             try:
                 manifest.filter_by_name(global_config.sessions)
-            except KeyError as exc:
+            except (KeyError, ValueError) as exc:
                 logger.error("Error while collecting sessions.")
                 logger.error(exc.args[0])
                 return 3
@@ -326,6 +332,8 @@ def _produce_json_listing(manifest: Manifest, global_config: NoxConfig) -> None:
                     "python": session.func.python,
                     "tags": session.tags,
                     "call_spec": getattr(session.func, "call_spec", {}),
+                    "env": session.env_base_name or session.name,
+                    "task": session.task_name or session.name,
                 }
             )
     print(json.dumps(report, default=str))

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -744,10 +744,14 @@ class VirtualEnv(ProcessEnv):
         reuse_existing: bool = False,
         venv_backend: str = "virtualenv",
         venv_params: Sequence[str] = (),
+        manage_parent_dir: bool = True,
     ) -> None:
         # "pypy-" -> "pypy"
         if interpreter and interpreter.startswith("pypy-"):
             interpreter = interpreter[:4] + interpreter[5:]
+        # False for user-specified locations (e.g. .venv), where nox must not
+        # drop .gitignore/CACHEDIR.TAG into the parent directory.
+        self.manage_parent_dir = manage_parent_dir
 
         self.location_name = location
         self.location = os.path.abspath(location)
@@ -958,9 +962,10 @@ class VirtualEnv(ProcessEnv):
 
     def create(self) -> bool:
         """Create the virtualenv or venv."""
-        nox_dir = Path(self.location).parent
-        _ensure_gitignore(nox_dir)
-        _ensure_cachedir_tag(nox_dir)
+        if self.manage_parent_dir:
+            nox_dir = Path(self.location).parent
+            _ensure_gitignore(nox_dir)
+            _ensure_cachedir_tag(nox_dir)
 
         if not self._clean_location():
             logger.debug(
@@ -1030,6 +1035,7 @@ def get_virtualenv(
     reuse_existing: bool,
     interpreter: Python = None,
     venv_params: Sequence[str] = (),
+    manage_parent_dir: bool = True,
 ) -> ProcessEnv:
     # Support fallback backends
     for bk in backends:
@@ -1061,4 +1067,5 @@ def get_virtualenv(
         interpreter=interpreter,
         reuse_existing=reuse_existing,
         venv_params=venv_params,
+        manage_parent_dir=manage_parent_dir,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,9 @@ def reset_color_envvars(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def clear_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear the cache for each test."""
-    monkeypatch.setattr("nox.registry._REGISTRY", {})
+    monkeypatch.setattr("nox.environments._ENVS", {})
+    monkeypatch.setattr("nox.environments._TASKS", {})
+    monkeypatch.setattr("nox.environments._ALIASES", {})
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/resources/noxfile_env_error.py
+++ b/tests/resources/noxfile_env_error.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import nox
+
+env = nox.env("tests")
+
+
+# Tasks cannot parametrize python; building the manifest for this noxfile
+# raises ValueError.
+@env.task
+@nox.parametrize("python", ["3.12"])
+def run(unused_session):
+    pass

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -112,6 +112,15 @@ class TestOptions:
         )
         assert len(list(all_nox_sessions)) == 0
 
+    def test_session_completer_error_noxfile(self) -> None:
+        parsed_args = _options.options.namespace(
+            posargs=[],
+            noxfile=str(RESOURCES.joinpath("noxfile_env_error.py")),
+        )
+        assert not list(
+            _completers.session_completer(prefix="", parsed_args=parsed_args)
+        )
+
     def test_python_completer(self) -> None:
         parsed_args = _options.options.namespace(
             posargs=[],
@@ -124,6 +133,15 @@ class TestOptions:
         expected_pythons = {"3.6", "3.12"}
         assert expected_pythons == set(actual_pythons_from_file)
 
+    def test_python_completer_error_noxfile(self) -> None:
+        parsed_args = _options.options.namespace(
+            posargs=[],
+            noxfile=str(RESOURCES.joinpath("noxfile_env_error.py")),
+        )
+        assert not list(
+            _completers.python_completer(prefix="", parsed_args=parsed_args)
+        )
+
     def test_tag_completer(self) -> None:
         parsed_args = _options.options.namespace(
             posargs=[],
@@ -135,6 +153,13 @@ class TestOptions:
 
         expected_tags = {f"tag{n}" for n in range(1, 8)}
         assert expected_tags == set(actual_tags_from_file)
+
+    def test_tag_completer_error_noxfile(self) -> None:
+        parsed_args = _options.options.namespace(
+            posargs=[],
+            noxfile=str(RESOURCES.joinpath("noxfile_env_error.py")),
+        )
+        assert not list(_completers.tag_completer(prefix="", parsed_args=parsed_args))
 
     def test_validation_options(self) -> None:
         options = _options.NoxfileOptions(

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -31,6 +32,7 @@ from nox.manifest import Manifest
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
 
 def make_manifest(**config_kwargs: object) -> Manifest:
@@ -688,6 +690,7 @@ def test_shared_env_created_once() -> None:
 
     fake_venv = mock.MagicMock()
     fake_venv.env = {}
+    fake_venv._reused = False
     with mock.patch(
         "nox.sessions.get_virtualenv", return_value=fake_venv
     ) as get_virtualenv:
@@ -763,6 +766,659 @@ def test_requires_failure_aborts_dependent() -> None:
         nox.sessions.Status.ABORTED,
     ]
     assert "was not successful" in (results[1].reason or "")
+
+
+# Provisioning
+
+
+def test_base_sync_installs_dependencies() -> None:
+    env = nox.env("dev", dependencies=["requests", "rich"])
+    session = mock.MagicMock()
+    env.sync(session)
+    session.install.assert_called_once_with("requests", "rich")
+
+
+class TrackingEnvironment(Environment):
+    """Records sync/setup calls instead of installing."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self.sync_calls = 0
+
+    def sync(self, session: nox.Session) -> None:  # noqa: ARG002
+        self.sync_calls += 1
+
+
+def make_provision_env(
+    tmp_path: Path, dependencies: Sequence[str] = ("requests",)
+) -> TrackingEnvironment:
+    env = TrackingEnvironment("dev", dependencies=list(dependencies))
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    (tmp_path / ".nox" / "dev").mkdir(parents=True, exist_ok=True)
+    return env
+
+
+def execute_provision(tmp_path: Path, *, reused: bool, **config_kwargs: object) -> None:
+    config = nox._options.options.namespace(
+        posargs=[],
+        envdir=str(tmp_path / ".nox"),
+        noxfile=str(tmp_path / "noxfile.py"),
+        **config_kwargs,
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    fake_venv = mock.MagicMock()
+    fake_venv.env = {}
+    fake_venv._reused = reused
+    fake_venv.venv_backend = "uv"
+    with mock.patch("nox.sessions.get_virtualenv", return_value=fake_venv):
+        for session in manifest:
+            assert session.execute()
+
+
+def test_provision_writes_stamp(tmp_path: Path) -> None:
+    env = make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=False)
+    assert env.sync_calls == 1
+    stamp = json.loads(
+        (tmp_path / ".nox" / "dev" / ".nox-env.json").read_text(encoding="utf-8")
+    )
+    assert stamp["env"]["dependencies"] == ["requests"]
+
+
+def test_provision_skips_when_stamp_matches(tmp_path: Path) -> None:
+    env = make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=False)
+    assert env.sync_calls == 1
+
+    nox.registry.reset()
+    env2 = make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=True)
+    assert env2.sync_calls == 0
+
+
+def test_provision_resyncs_on_change(tmp_path: Path) -> None:
+    make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=False)
+
+    nox.registry.reset()
+    env2 = make_provision_env(tmp_path, dependencies=["requests", "rich"])
+    execute_provision(tmp_path, reused=True)
+    assert env2.sync_calls == 1
+    stamp = json.loads(
+        (tmp_path / ".nox" / "dev" / ".nox-env.json").read_text(encoding="utf-8")
+    )
+    assert stamp["env"]["dependencies"] == ["requests", "rich"]
+
+
+def test_provision_syncs_fresh_venv_even_with_stamp(tmp_path: Path) -> None:
+    make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=False)
+
+    nox.registry.reset()
+    env2 = make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=False)
+    assert env2.sync_calls == 1
+
+
+def test_provision_no_install_skips(tmp_path: Path) -> None:
+    env = make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=True, no_install=True)
+    assert env.sync_calls == 0
+
+
+def test_provision_corrupt_stamp_resyncs(tmp_path: Path) -> None:
+    env = make_provision_env(tmp_path)
+    stamp_path = tmp_path / ".nox" / "dev" / ".nox-env.json"
+    stamp_path.write_text("{corrupt", encoding="utf-8")
+    execute_provision(tmp_path, reused=True)
+    assert env.sync_calls == 1
+
+
+def test_provision_failure_cached(tmp_path: Path) -> None:
+    class FailingEnvironment(TrackingEnvironment):
+        def sync(self, session: nox.Session) -> None:
+            super().sync(session)
+            msg = "sync failed"
+            raise RuntimeError(msg)
+
+    env = FailingEnvironment("dev", dependencies=["requests"])
+
+    @env.task
+    def a(session: nox.Session) -> None:
+        pass
+
+    @env.task
+    def b(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[],
+        envdir=str(tmp_path / ".nox"),
+        noxfile=str(tmp_path / "noxfile.py"),
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    fake_venv = mock.MagicMock()
+    fake_venv.env = {}
+    fake_venv._reused = False
+    fake_venv.venv_backend = "uv"
+    with mock.patch("nox.sessions.get_virtualenv", return_value=fake_venv):
+        results = [session.execute() for session in manifest]
+
+    assert not any(results)
+    # The second task fails fast from the cached error, without re-syncing.
+    assert env.sync_calls == 1
+    with pytest.raises(RuntimeError, match="sync failed"):
+        manifest["dev:a"].env_runner.provision(mock.MagicMock())
+
+
+def test_provision_keyboard_interrupt_not_cached(tmp_path: Path) -> None:
+    make_provision_env(tmp_path)
+    config = nox._options.options.namespace(
+        posargs=[],
+        envdir=str(tmp_path / ".nox"),
+        noxfile=str(tmp_path / "noxfile.py"),
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    runner = manifest["dev:sync"].env_runner
+    with (
+        mock.patch.object(runner, "_provision", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        runner.provision(mock.MagicMock())
+    assert runner._error is None
+
+
+def test_setup_hook_unstampable(tmp_path: Path) -> None:
+    env = make_provision_env(tmp_path)
+    setup_calls = []
+
+    @env.setup
+    def _(session: nox.Session) -> None:
+        setup_calls.append(session)
+
+    assert env.stamp_data() is None
+    execute_provision(tmp_path, reused=True)
+    assert env.sync_calls == 1
+    assert len(setup_calls) == 1
+    assert not (tmp_path / ".nox" / "dev" / ".nox-env.json").exists()
+
+
+def test_setup_stamp_makes_stampable(tmp_path: Path) -> None:
+    env = make_provision_env(tmp_path)
+    env.setup_stamp = "v1"
+
+    @env.setup
+    def _(session: nox.Session) -> None:
+        pass
+
+    data = env.stamp_data()
+    assert data is not None
+    assert data["setup_stamp"] == "v1"
+
+
+def test_setup_hook_only_once() -> None:
+    env = nox.env("dev")
+
+    @env.setup
+    def _(session: nox.Session) -> None:
+        pass
+
+    with pytest.raises(ValueError, match="already has a setup function"):
+
+        @env.setup
+        def _(session: nox.Session) -> None:
+            pass
+
+
+# Locations
+
+
+def test_location_envdir(tmp_path: Path) -> None:
+    env = nox.env("dev", location=".venv")
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    assert manifest["dev:sync"].envdir == os.path.join(
+        os.path.realpath(tmp_path), ".venv"
+    )
+
+
+def test_location_matrix_requires_placeholder() -> None:
+    env = nox.env("tests", python=["3.11", "3.12"], location=".venv")
+
+    @env.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    with pytest.raises(ValueError, match="placeholder"):
+        manifest.check_location_collisions()
+
+
+def test_location_matrix_placeholder(tmp_path: Path) -> None:
+    env = nox.env("tests", python=["3.11", "3.12"], location=".venvs/{name}")
+
+    @env.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    assert manifest["tests-3.11:run"].envdir == os.path.join(
+        os.path.realpath(tmp_path), ".venvs", "tests-3.11"
+    )
+
+
+def test_location_duplicate_error() -> None:
+    env_a = nox.env("a", location=".venv")
+    env_b = nox.env("b", location=".venv")
+
+    @env_a.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    @env_b.task(name="sync")
+    def sync_b(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    with pytest.raises(ValueError, match="both resolve to the location"):
+        manifest.check_location_collisions()
+
+
+def test_location_shared_template_ok(tmp_path: Path) -> None:
+    env_a = nox.env("a", python=["3.11", "3.12"], location=".venvs/{name}")
+    env_b = nox.env("b", python=["3.11", "3.12"], location=".venvs/{name}")
+
+    @env_a.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    @env_b.task(name="run")
+    def run_b(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    assert manifest["a-3.11:run"].envdir != manifest["b-3.11:run"].envdir
+
+
+def test_location_template_collision_error(tmp_path: Path) -> None:
+    env_a = nox.env("a", python="3.12", location=".venvs/{python}")
+    env_b = nox.env("b", python="3.12", location=".venvs/{python}")
+
+    @env_a.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    @env_b.task(name="run")
+    def run_b(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    with pytest.raises(ValueError, match="both resolve to the location"):
+        manifest.check_location_collisions()
+
+
+def test_location_ownership_guard(tmp_path: Path) -> None:
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "precious.txt").write_text("data", encoding="utf-8")
+    env = nox.env("dev", location=".venv")
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    with pytest.raises(OSError, match="Refusing to use"):
+        manifest["dev:sync"].env_runner._check_location_ownership()
+    assert (tmp_path / ".venv" / "precious.txt").exists()
+
+
+def test_location_ownership_venv_ok(tmp_path: Path) -> None:
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "pyvenv.cfg").write_text(
+        "home = /usr/bin\n", encoding="utf-8"
+    )
+    env = nox.env("dev", location=".venv")
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    manifest["dev:sync"].env_runner._check_location_ownership()
+
+
+def test_located_env_create_checks_ownership(tmp_path: Path) -> None:
+    env = nox.env("dev", location=".venv")
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    fake_venv = mock.MagicMock()
+    fake_venv.env = {}
+    fake_venv._reused = False
+    with mock.patch(
+        "nox.sessions.get_virtualenv", return_value=fake_venv
+    ) as get_virtualenv:
+        manifest["dev:sync"].env_runner.ensure()
+    # Located envs never get .gitignore/CACHEDIR.TAG dropped next to them.
+    assert get_virtualenv.call_args.kwargs["manage_parent_dir"] is False
+
+
+def test_location_ownership_conda_ok(tmp_path: Path) -> None:
+    (tmp_path / ".venv" / "conda-meta").mkdir(parents=True)
+    env = nox.env("dev", location=".venv")
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    manifest["dev:sync"].env_runner._check_location_ownership()
+
+
+def test_filter_manifest_location_collision(tmp_path: Path) -> None:
+    env_a = nox.env("a", location=".venv")
+
+    @env_a.task
+    def sync_a(session: nox.Session) -> None:
+        pass
+
+    env_b = nox.env("b", location=".venv")
+
+    @env_b.task
+    def sync_b(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[], envdir=".nox", noxfile=str(tmp_path / "noxfile.py")
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    assert nox.tasks.filter_manifest(manifest, config) == 3
+
+
+# Lock file environment types
+
+
+def test_env_namespace_types() -> None:
+    assert nox.env.pylock is nox.environments.PylockEnvironment
+    assert nox.env.uv is nox.environments.UvProjectEnvironment
+
+
+def test_pylock_stamp(tmp_path: Path) -> None:
+    lockfile = tmp_path / "pylock.toml"
+    lockfile.write_text("lock-version = '1.0'\n", encoding="utf-8")
+    env = nox.env.pylock("ci", lockfile=lockfile)
+    data = env.stamp_data()
+    assert data is not None
+    assert data["kind"] == "pylock"
+    assert data["lockfile_hash"]
+
+    lockfile.write_text("lock-version = '1.1'\n", encoding="utf-8")
+    assert env.stamp_data() != data
+
+
+def test_pylock_unstampable_setup(tmp_path: Path) -> None:
+    env = nox.env.pylock("ci", lockfile=tmp_path / "pylock.toml")
+
+    @env.setup
+    def _(session: nox.Session) -> None:
+        pass
+
+    assert env.stamp_data() is None
+
+
+def test_pylock_sync_is_exact() -> None:
+    assert nox.env.pylock("ci").sync_is_exact
+    assert not nox.env.pylock("ci2", dependencies=["pip"]).sync_is_exact
+
+
+def test_pylock_sync_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(nox.virtualenv, "HAS_UV", True)
+    monkeypatch.setattr(nox.virtualenv, "UV", "/fake/uv")
+    env = nox.env.pylock("ci", lockfile="pylock.toml")
+    session = mock.MagicMock()
+    session.venv_backend = "uv"
+    session.virtualenv.is_sandboxed = True
+    env.sync(session)
+    session.run_install.assert_called_once_with(
+        "/fake/uv", "pip", "sync", "pylock.toml", external=True, silent=True
+    )
+
+
+def test_pylock_sync_requires_uv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(nox.virtualenv, "HAS_UV", False)
+    env = nox.env.pylock("ci")
+    with pytest.raises(RuntimeError, match="requires uv"):
+        env.sync(mock.MagicMock())
+
+
+def test_pylock_sync_requires_venv_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(nox.virtualenv, "HAS_UV", True)
+    env = nox.env.pylock("ci")
+    session = mock.MagicMock()
+    session.venv_backend = "conda"
+    session.virtualenv.is_sandboxed = True
+    with pytest.raises(RuntimeError, match="virtualenv-style backend"):
+        env.sync(session)
+
+
+def test_uv_env_sync_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(nox.virtualenv, "UV", "/fake/uv")
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text("version = 1\n", encoding="utf-8")
+    env = nox.env.uv(
+        "dev",
+        lockfile=lockfile,
+        groups=["dev"],
+        extras=["cli"],
+        no_default_groups=True,
+    )
+    command = env._sync_command()
+    assert command == [
+        "sync",
+        "--locked",
+        f"--project={tmp_path}",
+        "--group=dev",
+        "--extra=cli",
+        "--no-default-groups",
+    ]
+    data = env.stamp_data()
+    assert data is not None
+    assert data["kind"] == "uv"
+    assert data["command"] == command
+
+    session = mock.MagicMock()
+    session.venv_backend = "uv"
+    env.sync(session)
+    session.run_install.assert_called_once_with(
+        "/fake/uv", *command, external=True, silent=True
+    )
+
+
+def test_uv_env_sync_command_flags(tmp_path: Path) -> None:
+    env = nox.env.uv(
+        "dev",
+        lockfile=tmp_path / "uv.lock",
+        all_extras=True,
+        no_install_project=True,
+        sync_args=["--quiet"],
+    )
+    assert env._sync_command() == [
+        "sync",
+        "--locked",
+        f"--project={tmp_path}",
+        "--all-extras",
+        "--no-install-project",
+        "--quiet",
+    ]
+
+
+def test_uv_env_unstampable_setup(tmp_path: Path) -> None:
+    env = nox.env.uv("dev", lockfile=tmp_path / "uv.lock")
+
+    @env.setup
+    def _(session: nox.Session) -> None:
+        pass
+
+    assert env.stamp_data() is None
+
+
+def test_uv_env_sync_is_exact() -> None:
+    assert nox.env.uv("dev").sync_is_exact
+    assert not nox.env.uv("dev2", dependencies=["pip"]).sync_is_exact
+
+
+def test_uv_env_backend_forced() -> None:
+    assert nox.env.uv("dev").venv_backend == "uv"
+    with pytest.raises(ValueError, match="requires the 'uv' venv backend"):
+        nox.env.uv("dev2", venv_backend="virtualenv")
+
+
+def test_uv_env_missing_lockfile(tmp_path: Path) -> None:
+    env = nox.env.uv("dev", lockfile=tmp_path / "uv.lock")
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        env.stamp_data()
+
+
+# Reuse default
+
+
+def test_declarative_env_reuse_default() -> None:
+    env = nox.env("dev")
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    runner = manifest["dev:sync"]
+    assert runner.func.reuse_venv is True
+    assert runner.reuse_existing_venv()
+
+
+def test_declarative_env_reuse_opt_out() -> None:
+    env = nox.env("dev", reuse_venv=False)
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    assert not manifest["dev:sync"].reuse_existing_venv()
+
+
+def test_legacy_session_reuse_unchanged() -> None:
+    @nox.session
+    def tests(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    assert not manifest["tests"].reuse_existing_venv()
+
+
+# Shared install warning
+
+
+def test_shared_env_install_warns_once(caplog: pytest.LogCaptureFixture) -> None:
+    env = nox.env("tooling")
+
+    @env.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    @env.task
+    def typecheck(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox", no_install=False, verbose=False)
+    runner = manifest["tooling:lint"]
+    runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv, instance=True)
+    runner.venv._reused = False
+    runner.venv.venv_backend = "virtualenv"  # type: ignore[misc]
+    session = nox.sessions.Session(runner)
+    with mock.patch.object(nox.sessions.Session, "_run"):
+        session.install("requests")
+        session.install("rich")
+    warnings_ = [r for r in caplog.records if "shared environment" in r.message]
+    assert len(warnings_) == 1
+
+
+def test_own_env_install_no_warning(caplog: pytest.LogCaptureFixture) -> None:
+    env = nox.env("solo")
+
+    @env.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox", no_install=False, verbose=False)
+    runner = manifest["solo:lint"]
+    runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv, instance=True)
+    runner.venv._reused = False
+    runner.venv.venv_backend = "virtualenv"  # type: ignore[misc]
+    session = nox.sessions.Session(runner)
+    with mock.patch.object(nox.sessions.Session, "_run"):
+        session.install("requests")
+    assert not [r for r in caplog.records if "shared environment" in r.message]
+
+
+def test_provision_install_only_writes_stamp(tmp_path: Path) -> None:
+    make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=False, install_only=True)
+    assert (tmp_path / ".nox" / "dev" / ".nox-env.json").exists()
+
+    # The prepared environment is treated as up to date on the next run.
+    nox.registry.reset()
+    env2 = make_provision_env(tmp_path)
+    execute_provision(tmp_path, reused=True)
+    assert env2.sync_calls == 0
+
+
+def test_provision_install_only_setup_hook_no_stamp(tmp_path: Path) -> None:
+    env = make_provision_env(tmp_path)
+    env.setup_stamp = "v1"
+
+    @env.setup
+    def _(session: nox.Session) -> None:
+        pass
+
+    execute_provision(tmp_path, reused=False, install_only=True)
+    assert not (tmp_path / ".nox" / "dev" / ".nox-env.json").exists()
 
 
 def test_filter_manifest_ambiguous_task_returns_error_code(
@@ -923,3 +1579,138 @@ def test_discover_manifest_reports_construction_errors(
     module = mock.Mock(__doc__=None)
     assert nox.tasks.discover_manifest(module, config) == 3
     assert any("cannot parametrize" in record.message for record in caplog.records)
+
+
+def test_uv_env_sync_refuses_other_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(nox.virtualenv, "UV", "/fake/uv")
+    env = nox.env.uv("dev")
+    session = mock.MagicMock()
+    session.venv_backend = "virtualenv"
+    with pytest.raises(RuntimeError, match="must run on the 'uv' venv backend"):
+        env.sync(session)
+    session.run_install.assert_not_called()
+
+
+def test_forced_python_on_located_env_does_not_break_others(
+    tmp_path: Path,
+) -> None:
+    dev = nox.env("dev", python="3.12", location=".devenv")
+
+    @dev.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    lint = nox.env("lint", venv_backend="none")
+
+    @lint.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[],
+        envdir=".nox",
+        noxfile=str(tmp_path / "noxfile.py"),
+        sessions=["lint:run"],
+        extra_pythons=["3.13"],
+        force_pythons=["3.13"],
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    result = nox.tasks.filter_manifest(manifest, config)
+    assert result is manifest
+
+    # Selecting the located env itself does error, cleanly.
+    manifest = Manifest(nox.registry.get_registry(), config)
+    manifest.filter_by_name(["dev"])
+    with pytest.raises(ValueError, match="placeholder"):
+        manifest.check_location_collisions()
+
+
+def test_inexact_env_recreated_on_change(tmp_path: Path) -> None:
+    make_provision_env(tmp_path, dependencies=["requests", "six"])
+    execute_provision(tmp_path, reused=False)
+
+    nox.registry.reset()
+    env2 = make_provision_env(tmp_path, dependencies=["requests"])
+    config = nox._options.options.namespace(
+        posargs=[],
+        envdir=str(tmp_path / ".nox"),
+        noxfile=str(tmp_path / "noxfile.py"),
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    fake_venv = mock.MagicMock()
+    fake_venv.env = {}
+    fake_venv._reused = True
+    fake_venv.venv_backend = "uv"
+    with mock.patch(
+        "nox.sessions.get_virtualenv", return_value=fake_venv
+    ) as get_virtualenv:
+        for session in manifest:
+            assert session.execute()
+    # Stale + additive sync: the venv is recreated, not synced in place.
+    assert get_virtualenv.call_count == 2
+    assert get_virtualenv.call_args.kwargs["reuse_existing"] is False
+    assert env2.sync_calls == 1
+
+
+class ExactTrackingEnvironment(TrackingEnvironment):
+    sync_is_exact = True
+
+
+def test_exact_env_synced_in_place_on_change(tmp_path: Path) -> None:
+    env = ExactTrackingEnvironment("dev", dependencies=["requests", "six"])
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    (tmp_path / ".nox" / "dev").mkdir(parents=True, exist_ok=True)
+    execute_provision(tmp_path, reused=False)
+
+    nox.registry.reset()
+    env2 = ExactTrackingEnvironment("dev", dependencies=["requests"])
+
+    @env2.task
+    def sync2(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[],
+        envdir=str(tmp_path / ".nox"),
+        noxfile=str(tmp_path / "noxfile.py"),
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    fake_venv = mock.MagicMock()
+    fake_venv.env = {}
+    fake_venv._reused = True
+    fake_venv.venv_backend = "uv"
+    with mock.patch(
+        "nox.sessions.get_virtualenv", return_value=fake_venv
+    ) as get_virtualenv:
+        for session in manifest:
+            assert session.execute()
+    assert get_virtualenv.call_count == 1
+    assert env2.sync_calls == 1
+
+
+def test_backend_none_with_dependencies_clean_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    env = nox.env("dev", venv_backend="none", dependencies=["six"])
+
+    @env.task
+    def sync(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(
+        posargs=[],
+        envdir=str(tmp_path / ".nox"),
+        noxfile=str(tmp_path / "noxfile.py"),
+    )
+    manifest = Manifest(nox.registry.get_registry(), config)
+    result = manifest["dev:sync"].execute()
+    assert not result
+    assert any(
+        "does not have a virtualenv" in record.message for record in caplog.records
+    )

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,0 +1,925 @@
+# Copyright 2026 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+import nox
+import nox._options
+import nox.manifest
+import nox.registry
+import nox.sessions
+import nox.tasks
+from nox.environments import Environment
+from nox.manifest import Manifest
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def make_manifest(**config_kwargs: object) -> Manifest:
+    config = nox._options.options.namespace(posargs=[], **config_kwargs)
+    return Manifest(nox.registry.get_registry(), config)
+
+
+def signatures(manifest: Manifest) -> list[Sequence[str]]:
+    return [session.signatures for session, _ in manifest.list_all_sessions()]
+
+
+# Registration
+
+
+def test_env_returns_environment() -> None:
+    tooling = nox.env("tooling", python="3.12")
+    assert isinstance(tooling, Environment)
+    assert tooling.name == "tooling"
+    assert tooling.python == "3.12"
+    assert nox.registry.get_registry().envs["tooling"] is tooling
+
+
+def test_env_task_decorator_plain() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    assert nox.registry.get_registry().tasks["tooling"]["lint"] is lint
+    assert lint.task_name == "lint"
+    assert lint.env is tooling
+
+
+def test_env_task_decorator_options() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task(name="check", tags=["a"], default=False, requires=["other"])
+    def lint(session: nox.Session) -> None:
+        pass
+
+    assert nox.registry.get_registry().tasks["tooling"]["check"] is lint
+    assert lint.tags == ["a"]
+    assert lint.default is False
+    assert lint.requires == ["other"]
+
+
+def test_duplicate_env_error() -> None:
+    nox.env("tooling")
+    with pytest.raises(ValueError, match="already registered"):
+        nox.env("tooling")
+
+
+def test_duplicate_task_error() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @tooling.task(name="lint")
+        def lint2(session: nox.Session) -> None:
+            pass
+
+
+@pytest.mark.parametrize("name", ["", "a:b", "a(b"])
+def test_invalid_names(name: str) -> None:
+    with pytest.raises(ValueError, match="name"):
+        nox.env(name)
+
+
+def test_invalid_task_name() -> None:
+    tooling = nox.env("tooling")
+    with pytest.raises(ValueError, match="task name"):
+
+        @tooling.task(name="a:b")
+        def lint(session: nox.Session) -> None:
+            pass
+
+
+def test_task_shared_across_envs() -> None:
+    env_a = nox.env("a")
+    env_b = nox.env("b")
+
+    @env_b.task
+    @env_a.task
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    assert "a:check" in manifest
+    assert "b:check" in manifest
+
+
+def test_task_requires_registered_env() -> None:
+    env = Environment("ghost", register=False)
+
+    with pytest.raises(ValueError, match="not registered"):
+
+        @env.task
+        def check(session: nox.Session) -> None:
+            pass
+
+
+def test_alias_registration() -> None:
+    nox.alias("check", "tooling:lint", "tooling:typecheck")
+    assert nox.registry.get_registry().aliases["check"] == (
+        "tooling:lint",
+        "tooling:typecheck",
+    )
+
+
+def test_alias_requires_targets() -> None:
+    with pytest.raises(ValueError, match="at least one target"):
+        nox.alias("check")
+
+
+def test_alias_env_collision() -> None:
+    nox.env("tooling")
+    with pytest.raises(ValueError, match="already registered"):
+        nox.alias("tooling", "a:b")
+    nox.alias("check", "a:b")
+    with pytest.raises(ValueError, match="already registered"):
+        nox.env("check")
+
+
+def test_session_env_collision() -> None:
+    nox.env("tooling")
+    with pytest.raises(ValueError, match="share one namespace"):
+
+        @nox.session(name="tooling")
+        def tooling(session: nox.Session) -> None:
+            pass
+
+
+def test_session_alias_collision() -> None:
+    nox.alias("check", "a:b")
+    with pytest.raises(ValueError, match="share one namespace"):
+
+        @nox.session(name="check")
+        def check(session: nox.Session) -> None:
+            pass
+
+
+# Manifest construction
+
+
+def test_task_signatures_no_python() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    session = manifest["tooling:lint"]
+    assert session.signatures == ["tooling:lint"]
+    assert session.name == "tooling:lint"
+    assert session.task_name == "lint"
+    assert session.env_base_name == "tooling"
+    assert session.env_instance_name == "tooling"
+    assert session.friendly_name == "tooling:lint"
+
+
+def test_task_signatures_single_python() -> None:
+    tooling = nox.env("tooling", python="3.12")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    session = manifest["tooling:lint"]
+    assert session.signatures == ["tooling:lint", "tooling-3.12:lint"]
+    assert session.func.python == "3.12"
+
+
+def test_task_signatures_python_matrix() -> None:
+    tests = nox.env("tests", python=["3.11", "3.12"])
+
+    @tests.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    assert signatures(manifest) == [["tests-3.11:run"], ["tests-3.12:run"]]
+    session = manifest["tests-3.11:run"]
+    assert session.multi
+    assert session.env_instance_name == "tests-3.11"
+    assert session.env_base_name == "tests"
+
+
+def test_task_parametrize() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    @nox.parametrize("x", [1, 2])
+    def lint(session: nox.Session, x: int) -> None:
+        pass
+
+    manifest = make_manifest()
+    assert signatures(manifest) == [["tooling:lint(x=1)"], ["tooling:lint(x=2)"]]
+    # Both parametrizations share the environment's venv.
+    runners = [session for session, _ in manifest.list_all_sessions()]
+    assert runners[0].env_runner is runners[1].env_runner
+
+
+def test_matrix_parametrized_task() -> None:
+    env = nox.env("tests", python=["3.11", "3.12"])
+
+    @env.task
+    @nox.parametrize("x", [1, 2])
+    def run(session: nox.Session, x: int) -> None:
+        pass
+
+    manifest = make_manifest()
+    assert signatures(manifest) == [
+        ["tests-3.11:run(x=1)", "tests-3.11:run"],
+        ["tests-3.11:run(x=2)", "tests-3.11:run"],
+        ["tests-3.12:run(x=1)", "tests-3.12:run"],
+        ["tests-3.12:run(x=2)", "tests-3.12:run"],
+    ]
+    # The instance task id runs every parametrization of that instance.
+    manifest.filter_by_name(["tests-3.11:run"])
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tests-3.11:run(x=1)",
+        "tests-3.11:run(x=2)",
+    ]
+
+
+def test_env_python_list_no_venv_warns() -> None:
+    env = nox.env("tests", python=["3.11", "3.12"], venv_backend="none")
+
+    @env.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    runner = manifest["tests:run"]
+    assert runner.func.python is False
+    assert nox.manifest.WARN_PYTHONS_IGNORED in runner.func.should_warn
+
+
+def test_env_extra_pythons() -> None:
+    tests = nox.env("tests", python=["3.11"])
+
+    @tests.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    tools = nox.env("tools")
+
+    @tools.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(extra_pythons=["3.12"])
+    names = [session.friendly_name for session, _ in manifest.list_all_sessions()]
+    assert names == ["tests-3.11:run", "tests-3.12:run", "tools:lint"]
+
+
+def test_task_parametrize_python_forbidden() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    @nox.parametrize("python", ["3.11", "3.12"])
+    def lint(session: nox.Session) -> None:
+        pass
+
+    with pytest.raises(ValueError, match="cannot parametrize 'python'"):
+        make_manifest()
+
+
+def test_tasks_share_env_runner_and_envdir() -> None:
+    tooling = nox.env("tooling", python="3.12", tags=["env-tag"])
+
+    @tooling.task(tags=["task-tag"])
+    def lint(session: nox.Session) -> None:
+        pass
+
+    @tooling.task
+    def typecheck(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    lint_runner = manifest["tooling:lint"]
+    typecheck_runner = manifest["tooling:typecheck"]
+    assert lint_runner.env_runner is typecheck_runner.env_runner
+    assert lint_runner.envdir == os.path.join(".nox", "tooling")
+    assert lint_runner.tags == ["env-tag", "task-tag"]
+    assert typecheck_runner.tags == ["env-tag"]
+
+
+def test_python_matrix_envdir_per_instance() -> None:
+    tests = nox.env("tests", python=["3.11", "3.12"])
+
+    @tests.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    @tests.task
+    def cov(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    assert manifest["tests-3.11:run"].envdir == os.path.join(".nox", "tests-3-11")
+    assert (
+        manifest["tests-3.11:run"].env_runner is manifest["tests-3.11:cov"].env_runner
+    )
+    assert (
+        manifest["tests-3.11:run"].env_runner
+        is not manifest["tests-3.12:run"].env_runner
+    )
+
+
+def test_session_and_env_coexist() -> None:
+    @nox.session(venv_backend="none")
+    def lint(session: nox.Session) -> None:
+        pass
+
+    tests = nox.env("tests")
+
+    @tests.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    assert signatures(manifest) == [["lint"], ["tests:run"]]
+
+
+# Selection
+
+
+def make_selection_envs() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    @tooling.task(default=False)
+    def typecheck(session: nox.Session) -> None:
+        pass
+
+    docs = nox.env("docs")
+
+    @docs.task
+    def build(session: nox.Session) -> None:
+        pass
+
+    @docs.task(name="lint")
+    def docs_lint(session: nox.Session) -> None:
+        pass
+
+
+def selected(manifest: Manifest) -> list[str]:
+    return [
+        session.friendly_name for session, sel in manifest.list_all_sessions() if sel
+    ]
+
+
+def test_filter_by_canonical_name() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    manifest.filter_by_name(["tooling:lint"])
+    assert selected(manifest) == ["tooling:lint"]
+
+
+def test_filter_by_env_name_selects_default_tasks() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    manifest.filter_by_name(["tooling"])
+    # typecheck is default=False, so the env selector skips it.
+    assert selected(manifest) == ["tooling:lint"]
+
+
+def test_filter_by_unique_task_name() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    manifest.filter_by_name(["build"])
+    assert selected(manifest) == ["docs:build"]
+
+
+def test_filter_by_ambiguous_task_name() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    with pytest.raises(ValueError, match=r"ambiguous.*docs:lint.*tooling:lint"):
+        manifest.filter_by_name(["lint"])
+
+
+def test_filter_by_alias() -> None:
+    make_selection_envs()
+    nox.alias("check", "tooling:lint", "docs:build")
+    manifest = make_manifest()
+    manifest.filter_by_name(["check"])
+    assert selected(manifest) == ["tooling:lint", "docs:build"]
+
+
+def test_filter_by_env_instance_name() -> None:
+    tests = nox.env("tests", python=["3.11", "3.12"])
+
+    @tests.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["tests-3.11"])
+    assert selected(manifest) == ["tests-3.11:run"]
+
+
+def test_filter_by_normalized_matrix_id() -> None:
+    env = nox.env("tests", python=["3.11", "3.12"])
+
+    @env.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    # Formatting variants of the canonical id still match every instance.
+    manifest.filter_by_name(["tests:run "])
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tests-3.11:run",
+        "tests-3.12:run",
+    ]
+
+
+def test_filter_missing_name() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    with pytest.raises(KeyError, match="nonsense"):
+        manifest.filter_by_name(["nonsense"])
+
+
+def test_filter_by_keywords_env_name() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    manifest.filter_by_keywords("tooling")
+    assert len(manifest) == 2
+
+
+# Dependencies
+
+
+def test_requires_canonical_id() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    other = nox.env("other")
+
+    @other.task(requires=["tooling:lint"])
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["other:check"])
+    manifest.add_dependencies()
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tooling:lint",
+        "other:check",
+    ]
+
+
+def test_requires_alias_and_bare_task() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    @tooling.task
+    def typecheck(session: nox.Session) -> None:
+        pass
+
+    nox.alias("check", "tooling:lint", "tooling:typecheck")
+
+    other = nox.env("other")
+
+    @other.task(requires=["check"])
+    def via_alias(session: nox.Session) -> None:
+        pass
+
+    @other.task(requires=["typecheck"])
+    def via_task(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["other:via_alias", "other:via_task"])
+    manifest.add_dependencies()
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tooling:lint",
+        "tooling:typecheck",
+        "other:via_alias",
+        "other:via_task",
+    ]
+
+
+def test_requires_env_name_single_task() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    other = nox.env("other")
+
+    @other.task(requires=["tooling"])
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["other:check"])
+    manifest.add_dependencies()
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tooling:lint",
+        "other:check",
+    ]
+
+
+def test_requires_env_name_multiple_tasks_selects_defaults() -> None:
+    make_selection_envs()
+
+    other = nox.env("other")
+
+    @other.task(requires=["tooling"])
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["other:check"])
+    manifest.add_dependencies()
+    # typecheck is default=False, so only the default task is pulled in.
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tooling:lint",
+        "other:check",
+    ]
+
+
+def test_requires_matrix_task() -> None:
+    tests = nox.env("tests", python=["3.11", "3.12"])
+
+    @tests.task
+    def run(session: nox.Session) -> None:
+        pass
+
+    other = nox.env("other")
+
+    @other.task(requires=["tests:run"])
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["other:check"])
+    manifest.add_dependencies()
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tests-3.11:run",
+        "tests-3.12:run",
+        "other:check",
+    ]
+
+
+def test_bare_task_requires_prefers_real_session() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    @nox.session(name="lint")
+    def lint_session(session: nox.Session) -> None:
+        pass
+
+    other = nox.env("other")
+
+    @other.task(requires=["lint"])
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["other:check"])
+    manifest.add_dependencies()
+    # The real session named "lint" wins over the bare-task shorthand for
+    # tooling:lint.
+    assert [session.friendly_name for session in manifest._queue] == [
+        "lint",
+        "other:check",
+    ]
+
+
+def test_extra_requirements_skip_non_default_envs() -> None:
+    env = nox.env("tests", python=["3.11", "3.12"])
+
+    @env.task(default=False)
+    def run(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    extra = manifest._extra_requirements()
+    # Env and instance selectors with no default tasks are not requirable...
+    assert "tests" not in extra
+    assert "tests-3.11" not in extra
+    # ...but the unique bare task name still is.
+    assert extra["run"] == ["tests:run"]
+
+
+# Notify
+
+
+def test_notify_env_selector_with_posargs() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    manifest.filter_by_name(["docs:build"])
+    assert manifest.notify("tooling", posargs=["-x"])
+    assert manifest["tooling:lint"].posargs == ["-x"]
+
+
+def test_notify_unknown_runner_object() -> None:
+    make_selection_envs()
+    manifest = make_manifest()
+    foreign = nox.sessions.SessionRunner(
+        "ghost",
+        [],
+        nox.manifest._null_session_func,
+        manifest._config,
+        manifest,
+        multi=False,
+    )
+    with pytest.raises(ValueError, match="not found"):
+        manifest.notify(foreign)
+
+
+# Execution
+
+
+def run_manifest_sessions(manifest: Manifest) -> list[nox.sessions.Result]:
+    return [session.execute() for session in manifest]
+
+
+def test_shared_env_created_once() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    @tooling.task
+    def typecheck(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox", noxfile="noxfile.py")
+
+    fake_venv = mock.MagicMock()
+    fake_venv.env = {}
+    with mock.patch(
+        "nox.sessions.get_virtualenv", return_value=fake_venv
+    ) as get_virtualenv:
+        results = run_manifest_sessions(manifest)
+
+    assert all(results)
+    assert get_virtualenv.call_count == 1
+    assert fake_venv.create.call_count == 1
+
+
+def test_shared_env_failure_propagates() -> None:
+    tooling = nox.env("tooling", python="9.99")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    @tooling.task
+    def typecheck(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(
+        envdir=".nox", noxfile="noxfile.py", error_on_missing_interpreters=True
+    )
+
+    with mock.patch(
+        "nox.sessions.get_virtualenv",
+        side_effect=nox.virtualenv.InterpreterNotFound("9.99"),
+    ) as get_virtualenv:
+        results = run_manifest_sessions(manifest)
+
+    assert not any(results)
+    # The second task fails fast from the cached error, without retrying.
+    assert get_virtualenv.call_count == 1
+
+
+def test_shared_env_keyboard_interrupt_not_cached() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox", noxfile="noxfile.py")
+    runner = manifest["tooling:lint"].env_runner
+    with (
+        mock.patch.object(runner, "_create_venv", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        runner.ensure()
+    assert runner._error is None
+
+
+def test_requires_failure_aborts_dependent() -> None:
+    tooling = nox.env("tooling", venv_backend="none")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        session.error("boom")
+
+    other = nox.env("other", venv_backend="none")
+
+    @other.task(requires=["tooling:lint"])
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox", noxfile="noxfile.py")
+    manifest.filter_by_name(["other:check"])
+    manifest.add_dependencies()
+    results = run_manifest_sessions(manifest)
+    assert [result.status for result in results] == [
+        nox.sessions.Status.ABORTED,
+        nox.sessions.Status.ABORTED,
+    ]
+    assert "was not successful" in (results[1].reason or "")
+
+
+def test_filter_manifest_ambiguous_task_returns_error_code(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    make_selection_envs()
+    config = nox._options.options.namespace(posargs=[], sessions=["lint"])
+    manifest = Manifest(nox.registry.get_registry(), config)
+    return_value = nox.tasks.filter_manifest(manifest, config)
+    assert return_value == 3
+    assert any("ambiguous" in record.message for record in caplog.records)
+
+
+# Adversarial-review regressions
+
+
+def test_legacy_session_name_with_colon_still_works() -> None:
+    with pytest.warns(FutureWarning, match="contains characters"):
+
+        @nox.session(name="docs:build", venv_backend="none")
+        def docs_build(session: nox.Session) -> None:
+            pass
+
+    manifest = make_manifest()
+    manifest.filter_by_name(["docs:build"])
+    assert selected(manifest) == ["docs:build"]
+
+
+def test_env_selector_no_default_tasks_errors() -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task(default=False)
+    def lint(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    with pytest.raises(ValueError, match="has no default tasks"):
+        manifest.filter_by_name(["tooling"])
+
+    config = nox._options.options.namespace(posargs=[], sessions=["tooling"])
+    manifest = Manifest(nox.registry.get_registry(), config)
+    assert nox.tasks.filter_manifest(manifest, config) == 3
+
+
+def test_alias_shadowing_task_warns(caplog: pytest.LogCaptureFixture) -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    nox.alias("lint", "tooling:style")
+    make_manifest()
+    assert any(
+        "shadows the task" in record.message and "tooling:lint" in record.message
+        for record in caplog.records
+    )
+
+
+def test_empty_parametrize_does_not_poison_env() -> None:
+    tooling = nox.env("tooling", python="3.12")
+
+    @tooling.task
+    @nox.parametrize("x", [])
+    def empty(session: nox.Session, x: int) -> None:
+        pass
+
+    @tooling.task
+    def real(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest()
+    runner = manifest["tooling:real"]
+    assert runner.env_runner is manifest["tooling:empty"].env_runner
+    # The environment's venv configuration comes from the environment, not
+    # from the placeholder session created for the empty parametrize list.
+    assert runner.env_runner.func.python == "3.12"
+
+
+def test_alias_of_alias_selection() -> None:
+    make_selection_envs()
+    nox.alias("style", "tooling:lint")
+    nox.alias("all-checks", "style", "docs:build")
+    manifest = make_manifest()
+    manifest.filter_by_name(["all-checks"])
+    assert selected(manifest) == ["tooling:lint", "docs:build"]
+
+
+def test_alias_cycle_reports_missing() -> None:
+    nox.alias("a", "b")
+    nox.alias("b", "a")
+    make_selection_envs()
+    manifest = make_manifest()
+    with pytest.raises(KeyError, match="a"):
+        manifest.filter_by_name(["a"])
+
+
+def test_notify_new_identifier_forms() -> None:
+    make_selection_envs()
+    nox.alias("style", "tooling:lint")
+    manifest = make_manifest()
+    manifest.filter_by_name(["docs:build"])
+
+    assert manifest.notify("style")
+    assert manifest["tooling:lint"] in manifest._queue
+
+    assert manifest.notify("build") is False  # already selected
+
+    # Env selector: tooling's only default task is already queued.
+    assert manifest.notify("tooling") is False
+
+    assert manifest.notify("typecheck")  # bare task name, unique
+
+    with pytest.raises(ValueError, match="not found"):
+        manifest.notify("nonsense")
+
+
+def test_single_python_env_instance_selector() -> None:
+    tooling = nox.env("tooling", python="3.12")
+
+    @tooling.task
+    def lint(session: nox.Session) -> None:
+        pass
+
+    other = nox.env("other", venv_backend="none")
+
+    @other.task(requires=["tooling-3.12"])
+    def check(session: nox.Session) -> None:
+        pass
+
+    manifest = make_manifest(envdir=".nox")
+    manifest.filter_by_name(["tooling-3.12"])
+    assert selected(manifest) == ["tooling:lint"]
+    # The environment directory keeps the unsuffixed name, like classic
+    # single-python sessions.
+    assert manifest["tooling:lint"].envdir == os.path.join(".nox", "tooling")
+
+    manifest = make_manifest(envdir=".nox")
+    manifest.filter_by_name(["other:check"])
+    manifest.add_dependencies()
+    assert [session.friendly_name for session in manifest._queue] == [
+        "tooling:lint",
+        "other:check",
+    ]
+
+
+def test_discover_manifest_reports_construction_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tooling = nox.env("tooling")
+
+    @tooling.task
+    @nox.parametrize("python", ["3.11", "3.12"])
+    def lint(session: nox.Session) -> None:
+        pass
+
+    config = nox._options.options.namespace(posargs=[])
+    module = mock.Mock(__doc__=None)
+    assert nox.tasks.discover_manifest(module, config) == 3
+    assert any("cannot parametrize" in record.message for record in caplog.records)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -70,8 +70,11 @@ def test__normalize_arg() -> None:
 
 def test__normalized_session_match() -> None:
     session_mock = mock.MagicMock()
+    session_mock.name = "test"
     session_mock.signatures = ['test(foo="bar")']
     assert _normalized_session_match("test(foo='bar')", session_mock)
+    # Formatting variants of the name itself match too.
+    assert _normalized_session_match("test ", session_mock)
 
 
 def test_init() -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -31,10 +31,10 @@ def cleanup_registry() -> Generator[None, None, None]:
     after each test.
     """
     try:
-        registry._REGISTRY.clear()
+        registry.reset()
         yield
     finally:
-        registry._REGISTRY.clear()
+        registry.reset()
 
 
 def test_session_decorator() -> None:
@@ -137,8 +137,6 @@ def test_session_decorator_name(
 def test_get() -> None:
     # Establish that the get method returns a copy of the registry.
     empty = registry.get()
-    assert empty == registry._REGISTRY
-    assert empty is not registry._REGISTRY
     assert len(empty) == 0
 
     @registry.session_decorator
@@ -153,7 +151,9 @@ def test_get() -> None:
     assert empty != full
     assert len(empty) == 0
     assert len(full) == 2
-    assert full == registry._REGISTRY
-    assert full is not registry._REGISTRY
     assert full["unit_tests"] is unit_tests
     assert full["system_tests"] is system_tests
+
+    # Mutating the returned mapping must not affect the registry.
+    del full["unit_tests"]
+    assert "unit_tests" in registry.get()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -953,12 +953,8 @@ class TestSession:
 
         runner.manifest.notify.assert_called_with("other", ["--an-arg"])  # type: ignore[attr-defined]
 
-    def test_posargs_are_not_shared_between_sessions(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        registry: dict[str, nox._decorators.Func] = {}
-        monkeypatch.setattr("nox.registry._REGISTRY", registry)
-
+    def test_posargs_are_not_shared_between_sessions(self) -> None:
+        # The registry is cleared per test by the clear_cache fixture.
         @nox.session(venv_backend="none")
         def test(session: nox.Session) -> None:
             session.posargs.extend(["-x"])
@@ -970,7 +966,7 @@ class TestSession:
                 raise RuntimeError(msg)
 
         config = _options.options.namespace(posargs=[], envdir=".nox")
-        manifest = nox.manifest.Manifest(registry, config)
+        manifest = nox.manifest.Manifest(nox.registry.get(), config)
 
         assert manifest["test"].execute()
         assert manifest["lint"].execute()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -200,6 +200,7 @@ def test_discover_session_functions_decorator() -> None:
 
     # Get the manifest and establish that it looks like what we expect.
     manifest = tasks.discover_manifest(mock_module, config)
+    assert isinstance(manifest, Manifest)
     sessions = list(manifest)
     assert [s.func for s in sessions] == [foo, bar, not_a_bar]
     assert [i.friendly_name for i in sessions] == ["foo", "bar", "not-a-bar"]
@@ -575,6 +576,8 @@ def test_honor_list_json_request(capsys: pytest.CaptureFixture[builtins.str]) ->
                 description="simple",
                 func=argparse.Namespace(python=Path("123")),
                 tags=[],
+                env_base_name=None,
+                task_name=None,
             ),
             True,
         ),
@@ -593,6 +596,8 @@ def test_honor_list_json_request(capsys: pytest.CaptureFixture[builtins.str]) ->
             "python": "123",
             "tags": [],
             "call_spec": {},
+            "env": "bar",
+            "task": "bar",
         }
     ]
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -174,6 +174,20 @@ def test_ensure_cachedir_tag_creates_file(tmp_path: Path) -> None:
     )
 
 
+def test_create_manage_parent_dir_false(tmp_path: Path) -> None:
+    location = tmp_path / ".venv"
+    venv = nox.virtualenv.VirtualEnv(str(location), manage_parent_dir=False)
+
+    with mock.patch.object(
+        nox.virtualenv.VirtualEnv, "_clean_location", return_value=False
+    ):
+        assert venv.create() is False
+
+    assert venv._reused
+    assert not (tmp_path / ".gitignore").exists()
+    assert not (tmp_path / "CACHEDIR.TAG").exists()
+
+
 def test_ensure_parent_gitignore_keeps_existing_file(tmp_path: Path) -> None:
     envdir = tmp_path.joinpath(".nox")
     envdir.mkdir()


### PR DESCRIPTION
WIP! This is the whole idea, so you can see the end goal, it's designed to be mergable in 3-4 stages.

🤖 _AI text below_ :robot:

Splits the fused session concept into **environments** (a virtualenv + how to provision it) and **tasks** (what to run), so several tasks can share one venv, environments can live at a chosen path like `.venv`, and lock files get first-class, extensible support.

```python
tooling = nox.env("tooling", python="3.12", dependencies=["prek", "mypy"])

@tooling.task
def lint(session): ...          # session id: tooling:lint

dev = nox.env.uv("dev", location=".venv")   # uv sync --locked into .venv
ci = nox.env.pylock("ci")                   # PEP 751 pylock via uv pip sync

nox.alias("check", "tooling:lint", "tooling:typecheck")
```

- A session is now an `env:task` pair; `@nox.session` is sugar for a same-name pair, so existing noxfiles are unchanged (naming, envdirs, and expansion are byte-identical — verified against this repo's own noxfile).
- One identifier grammar across `-s`, `requires=`, and `session.notify()`: full ids, aliases (recursive), environment/instance selectors (default tasks), and unambiguous bare task names; ambiguity errors list the candidates.
- Declarative environments record their inputs in a stamp file and are reused by default: unchanged inputs skip installs entirely, changed lock files re-sync in place, and changed plain dependency lists recreate the env so removed packages actually disappear. `-r`/`-R`/`--reuse-venv` semantics are untouched for classic sessions.
- `location=` safety: nox refuses to delete a non-empty directory that isn't a virtualenv, never writes `.gitignore`/`CACHEDIR.TAG` outside `--envdir`, and `nox.env.uv` refuses to sync off the uv backend so `--force-venv-backend` cannot clobber a project's own `.venv`.
- Third-party lock formats subclass `nox.Environment` and override `stamp_data()`/`sync()` — no plugin registry needed.

The four commits are ordered for review: runner split (no behavior change) → env/task/alias model → provisioning/lock files/locations → docs. An adversarial review pass (backend overrides, CLI edge cases, staleness lies, name collisions) was run and its findings are folded into the relevant commits with regression tests; end-to-end flows (uv.lock → `.venv`, stamp skip/resync, ownership refusal) were exercised live in addition to the unit suite.

Design decisions that deserve reviewer eyes: declarative-object API with `@env.setup` as the dynamic escape hatch; `nox -s <env>` running default tasks; reuse-by-default for declarative envs only; provisioning as inline memoized calls on a shared EnvRunner rather than hidden graph nodes.