### PR TITLE
test: make test_download_python_failed_install pass without uv installed

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1862,7 +1862,13 @@ def test_download_python_failed_install(
     download_python: str,
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Pretend uv is available so the uv install path is exercised even on
+    # hosts without uv installed (gh-1046).
+    monkeypatch.setattr(nox.virtualenv, "HAS_UV", True)
+    monkeypatch.setattr(nox.virtualenv, "UV_VERSION", version.Version("0.10.0"))
+
     venv, _ = make_one(
         interpreter="python3.11",
         venv_backend=venv_backend,


### PR DESCRIPTION
Fixes #1046.

## Problem

`test_download_python_failed_install[always-uv]` and `[auto-uv]` fail on hosts where uv is not installed:

```
Expected 'uv_install_python' to be called once. Called 0 times.
```

The test mocks `nox.virtualenv.uv_install_python`, but `VirtualEnv._install_python()` checks uv's availability first:

```python
if self.venv_backend == "uv":
    has_uv, _, uv_ver = _uv_state()
    if has_uv and version.Version("0.4.16") <= uv_ver and uv_install_python(...):
```

Without uv on the machine, `has_uv` is `False`, the mocked `uv_install_python` is never reached, and the assertion fails.

## Fix

Monkeypatch `HAS_UV=True` and `UV_VERSION=0.10.0` in the test — the same pattern already used elsewhere in `test_virtualenv.py` (and `_uv_state()` explicitly supports monkeypatched values) — so the uv install path is exercised deterministically regardless of the host.

## Verification

Reproduced the failure locally by hiding uv from `PATH`: the two uv cases fail exactly as reported. With this change, all 6 parametrizations pass **both** with uv hidden and with uv present. Full `tests/test_virtualenv.py` passes (143 passed, 26 skipped — the skips are the pre-existing optional `pbs_installer` ones). `ruff check`/`format` clean.