### PR TITLE
fix: keep an empty inner @parametrize from being dropped when stacked

### DIFF
--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -191,7 +191,7 @@ def update_param_specs(
     param_specs: Iterable[Param] | None, new_specs: Iterable[Param]
 ) -> list[Param]:
     """Produces all combinations of the given sets of specs."""
-    if not param_specs:
+    if param_specs is None:
         return list(new_specs)
 
     # New specs must be combined with old specs by *multiplying* them.

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -170,6 +170,31 @@ def test_parametrize_decorator_multiple_and_stack() -> None:
     ]
 
 
+def test_parametrize_decorator_stack_with_empty_inner() -> None:
+    # An empty @parametrize stacked *under* a non-empty one must make the
+    # Cartesian product empty (a do-nothing placeholder session), not silently
+    # drop its own dimension and yield sessions missing that argument.
+    def f() -> None:
+        pass
+
+    _parametrize.parametrize_decorator("abc", [])(f)
+    _parametrize.parametrize_decorator("def", ["a", "b"])(f)
+
+    assert f.parametrize == []  # type: ignore[attr-defined]
+
+
+def test_parametrize_decorator_stack_with_empty_outer() -> None:
+    # The same, with the empty @parametrize on top (already worked, pinned here
+    # to keep the two orderings symmetric).
+    def f() -> None:
+        pass
+
+    _parametrize.parametrize_decorator("abc", [1, 2, 3])(f)
+    _parametrize.parametrize_decorator("def", [])(f)
+
+    assert f.parametrize == []  # type: ignore[attr-defined]
+
+
 def test_generate_calls_simple() -> None:
     f = mock.Mock(should_warn={}, tags=[])
     f.__name__ = "f"


### PR DESCRIPTION
## Problem

`update_param_specs` (`nox/_parametrize.py:194`) uses `if not param_specs:` to detect "there was no previous `@parametrize`". But an inner `@parametrize("a", [])` sets `f.parametrize` to an **empty list**, not `None`, and `not []` is also `True` — so the empty `a` dimension is silently thrown away instead of making the Cartesian product empty.

The result is asymmetric and wrong:

```python
@nox.session(python=False)
@nox.parametrize("b", ["x", "y"])
@nox.parametrize("a", [])            # empty, stacked underneath
def demo(session, a, b): ...
```

- Empty parametrize **underneath** → 2 sessions are generated, each missing `a` → invoking one raises `TypeError: demo() missing 1 required positional argument: 'a'` (a silent failure deferred to run time).
- The same empty parametrize **on top** → correctly yields 0 sessions.

nox documents/handles an empty parametrize as a do-nothing placeholder ("This session had no parameters available.", `manifest.py`), so an empty dimension should suppress the sessions, not produce broken ones.

## Fix

Distinguish `None` (no previous parametrize) from an empty list. With `if param_specs is None:`, an empty `param_specs` falls through to the combination loop, which iterates zero times and correctly yields an empty product.

## Test plan

Added `test_parametrize_decorator_stack_with_empty_inner` (and a symmetric `_empty_outer`) to `tests/test__parametrize.py`.

- On `main` the empty-inner case fails (returns 2 combos missing `a`); with this change both orderings yield `[]`.
- `pytest tests/` → 722 passed, 27 skipped (unchanged); parametrize + manifest suites fully green.
- `ruff check` / `ruff format --check` / `mypy nox/_parametrize.py` all clean.

---
Authored with assistance from Claude Code (Anthropic); the bug, fix, and test were reviewed and verified locally by the contributor.