### PR TITLE
fix(project): don't crash python_versions() on a major-only max_version

### DIFF
--- a/nox/project.py
+++ b/nox/project.py
@@ -156,7 +156,7 @@ def python_versions(
         raise ValueError(msg)
     min_minor_version = max(lower_bounds)
 
-    max_minor_version = int(max_version.split(".")[1])
+    max_minor_version = int(max_version.split(".")[1]) if "." in max_version else 0
 
     return [f"3.{v}" for v in range(min_minor_version, max_minor_version + 1)]
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -77,6 +77,14 @@ def test_python_range_major_only() -> None:
     assert python_versions(pyproject, max_version="3.2") == ["3.0", "3.1", "3.2"]
 
 
+def test_python_range_major_only_max_version() -> None:
+    # A major-only max_version ("3" == "3.0" per PEP 440) has an implicit minor
+    # version of 0 and must not crash, mirroring the requires-python handling.
+    pyproject = {"project": {"requires-python": ">=3"}}
+
+    assert python_versions(pyproject, max_version="3") == ["3.0"]
+
+
 def test_python_range_multiple_lower_bounds() -> None:
     # With several lower-bound specifiers the effective minimum is the largest
     # one, regardless of the order they appear in.


### PR DESCRIPTION
### What

`nox.project.python_versions()` crashes with `IndexError` when `max_version` is a major-only version like `"3"`:

```python
>>> from nox.project import python_versions
>>> python_versions({"project": {"requires-python": ">=3.9"}}, max_version="3")
IndexError: list index out of range
```

### Why

#1127 taught this helper to accept a major-only *lower* bound — `">=3"` is treated as `">=3.0"` (PEP 440), with an implicit minor of 0 that "must not crash." But the symmetric `max_version` parse a few lines down was left as an unconditional `int(max_version.split(".")[1])`, so a major-only `max_version` still index-errors out of the same public helper.

### Fix

Mirror #1127 on the `max_version` side: a major-only `max_version` gets an implicit minor of 0 (`"3"` == `"3.0"`). One line, plus a `test_python_range_major_only_max_version` case alongside the existing `test_python_range_major_only`. `test_project.py` stays green (10 passed), `ruff` clean, and no new `mypy` findings.

---

*Disclosure: this contribution is AI-authored and autonomous (Claude Code, on this account) — an AI found the gap, wrote the fix and test, and ran the verification; the human account holder reviews every change and is accountable for it. It is verified and re-runnable from the diff.*

