### PR TITLE
fix: don't crash building the manifest when a python-matrix session has an empty parametrize

### DIFF
--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -253,7 +253,9 @@ class Manifest:
         ) in self.parametrized_sessions_by_name.items():
             parent_func = _null_session_func.copy()
             parent_func.requires = [
-                session.signatures[0] for session in parametrized_sessions
+                session.signatures[0]
+                for session in parametrized_sessions
+                if session.signatures
             ]
             parent_session = SessionRunner(
                 parent_name, [], parent_func, self._config, self, multi=False

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -409,6 +409,27 @@ def test_add_dependencies_with_empty_parametrize() -> None:
     assert [session.name for session in manifest._queue] == ["empty", "regular"]
 
 
+def test_add_dependencies_with_empty_parametrize_and_multiple_pythons() -> None:
+    manifest = Manifest({}, create_mock_config())
+
+    # A session parametrized over multiple Pythons with an empty parameter list
+    # expands to one placeholder (``multi=True``) session per interpreter, each
+    # with no signatures. ``add_dependencies`` builds a fake parent session for
+    # such parametrized names and must not assume every placeholder has a
+    # signature.
+    @nox.parametrize("param", ())
+    def empty(session: nox.Session, param: object) -> None:
+        pass
+
+    for session in manifest.make_session("empty", Func(empty, python=["3.10", "3.11"])):
+        manifest.add_session(session)
+
+    # Must not raise IndexError.
+    manifest.add_dependencies()
+
+    assert [session.name for session in manifest._queue] == ["empty", "empty"]
+
+
 def test_notify() -> None:
     manifest = Manifest({}, create_mock_config())
 


### PR DESCRIPTION
### The bug

`Manifest.add_dependencies` builds each parent session's `requires` list with `session.signatures[0]`:

```python
parent_func.requires = [
    session.signatures[0] for session in parametrized_sessions
]
```

A `@nox.session(python=[...])` whose `@nox.parametrize` list is empty produces one null-placeholder `SessionRunner` per interpreter, and those placeholders have **no signatures**. So `signatures[0]` raises `IndexError` and the whole manifest build crashes with an unhandled traceback on any command (`nox`, `nox -l`, `nox -s ...`).

Reproducer:

```python
import nox

VERSIONS = []  # e.g. computed/filtered and empty this run

@nox.session(python=["3.11", "3.12"])
@nox.parametrize("django", VERSIONS)
def tests(session, django):
    ...
```

```
$ nox -l
...
    session.signatures[0] for session in parametrized_sessions
IndexError: list index out of range
```

### The fix

Skip placeholders that have no signature, mirroring the existing guard in `Session.friendly_name` (`sessions.py`) and the empty-parameter handling already documented a few lines below in the same method:

```python
parent_func.requires = [
    session.signatures[0]
    for session in parametrized_sessions
    if session.signatures
]
```

After the fix, `nox -l` lists the placeholder no-op sessions instead of crashing.

This completes #1109, which fixed the same "empty parametrize must not crash" case for a single interpreter but left the python-matrix (`multi=True`) path uncovered — that path is what routes the placeholders through this loop.

### Verification

- New regression test `test_add_dependencies_with_empty_parametrize_and_multiple_pythons` (mirrors the existing single-interpreter test): fails with `IndexError` before the fix, passes after.
- Full suite green (`pytest tests/`), `ruff check`/`ruff format --check`/`mypy nox/manifest.py` clean.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
