### PR TITLE
refactor: statically-typed option model as single source of truth

### DIFF
--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -306,7 +306,7 @@ def _main(*, main_ep: bool) -> None:
                     "Literal['auto', 'never', 'always']", download_python
                 )
 
-                envdir = Path(args.envdir or ".nox")
+                envdir = Path(args.envdir)
                 run_script_mode(
                     noxfile,
                     envdir,

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 __lazy_modules__ = {
     "importlib",
     "importlib.metadata",
-    "nox._options",
+    "nox._option_set",
     "nox._version",
     "nox.command",
     "nox.logger",
@@ -52,14 +52,15 @@ import nox.command
 import nox.registry
 import nox.virtualenv
 from nox import _options, tasks, workflow
-from nox._options import DefaultStr
+from nox._option_set import Source
 from nox._version import get_nox_version
 from nox.logger import logger, setup_logging
 from nox.project import load_toml
 
 if TYPE_CHECKING:
-    from argparse import Namespace
     from collections.abc import Iterator
+
+    from nox._options import NoxConfig
 
 __all__ = ["execute_workflow", "main", "nox_main"]
 
@@ -68,7 +69,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def execute_workflow(args: Namespace) -> int:
+def execute_workflow(args: NoxConfig) -> int:
     """
     Execute the appropriate tasks.
     """
@@ -266,7 +267,7 @@ def _main(*, main_ep: bool) -> None:
     if nox_script_mode != "none":
         noxfile = (
             args.noxfile
-            if main_ep or not isinstance(args.noxfile, DefaultStr)
+            if main_ep or args.provenance("noxfile") is not Source.DEFAULT
             else (get_main_filename() or args.noxfile)
         )
         toml_config = load_toml(os.path.expandvars(noxfile), missing_ok=True)

--- a/nox/_completers.py
+++ b/nox/_completers.py
@@ -1,0 +1,110 @@
+# Copyright 2019 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shell completion (argcomplete) helpers for Nox's command-line options."""
+
+from __future__ import annotations
+
+__lazy_modules__ = {"itertools", "nox.tasks"}
+
+import itertools
+from typing import TYPE_CHECKING, Any
+
+import argcomplete.completers
+
+from nox.tasks import discover_manifest, filter_manifest, load_nox_module
+
+if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Iterable
+
+    from nox._options import NoxConfig
+
+__all__ = [
+    "directory_completer",
+    "empty_completer",
+    "json_file_completer",
+    "python_completer",
+    "session_completer",
+    "tag_completer",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+directory_completer: argcomplete.completers.DirectoriesCompleter = (
+    argcomplete.completers.DirectoriesCompleter()  # type: ignore[no-untyped-call]
+)
+json_file_completer: argcomplete.completers.FilesCompleter = (
+    argcomplete.completers.FilesCompleter(("json",))  # type: ignore[no-untyped-call]
+)
+empty_completer: argcomplete.completers.ChoicesCompleter = (
+    argcomplete.completers.ChoicesCompleter(())  # type: ignore[no-untyped-call]
+)
+
+
+def _expand(parsed_args: argparse.Namespace | NoxConfig) -> NoxConfig:
+    # Imported here: nox._options needs this module to define its fields.
+    from nox._options import options  # noqa: PLC0415
+
+    return options.expand(parsed_args)
+
+
+def python_completer(
+    prefix: str,  # noqa: ARG001
+    parsed_args: argparse.Namespace | NoxConfig,
+    **kwargs: Any,
+) -> Iterable[str]:
+    config = _expand(parsed_args)
+    module = load_nox_module(config)
+    manifest = discover_manifest(module, config)
+    return filter(
+        None,
+        (
+            session.func.python  # type:ignore[misc] # str sequences flattened, other non-strs falsey and filtered out
+            for session, _ in manifest.list_all_sessions()
+        ),
+    )
+
+
+def session_completer(
+    prefix: str,  # noqa: ARG001
+    parsed_args: argparse.Namespace | NoxConfig,
+    **kwargs: Any,
+) -> Iterable[str]:
+    config = _expand(parsed_args)
+    config.list_sessions = True
+    module = load_nox_module(config)
+    manifest = discover_manifest(module, config)
+    filtered_manifest = filter_manifest(manifest, config)
+    if isinstance(filtered_manifest, int):
+        return []
+    return (
+        session.friendly_name for session, _ in filtered_manifest.list_all_sessions()
+    )
+
+
+def tag_completer(
+    prefix: str,  # noqa: ARG001
+    parsed_args: argparse.Namespace | NoxConfig,
+    **kwargs: Any,
+) -> Iterable[str]:
+    config = _expand(parsed_args)
+    module = load_nox_module(config)
+    manifest = discover_manifest(module, config)
+    return itertools.chain.from_iterable(
+        filter(None, (session.tags for session, _ in manifest.list_all_sessions()))
+    )

--- a/nox/_merge.py
+++ b/nox/_merge.py
@@ -1,0 +1,120 @@
+# Copyright 2019 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Post-parse option policy.
+
+:func:`finalize` resolves alias flags and cross-field options right after
+parsing; :func:`merge_noxfile_options` merges values set in the Noxfile into
+the config. The generic machinery lives in ``nox._option_set``; the option
+model in ``nox._options``.
+"""
+
+from __future__ import annotations
+
+__lazy_modules__ = {"nox._option_set"}
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+from nox._option_set import ArgumentError, Source, apply_noxfile_values
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from nox._options import NoxConfig, NoxfileOptions
+
+__all__ = ["finalize", "merge_noxfile_options"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def _strip_posargs(posargs: Sequence[str]) -> list[str]:
+    """Remove the leading "--" from the posargs array (if any) and assert that
+    the remaining arguments came after a "--"."""
+    if not posargs:
+        return []
+
+    dash_index = posargs.index("--") if "--" in posargs else len(posargs)
+    if dash_index != 0:
+        unexpected_posargs = posargs[:dash_index]
+        raise ArgumentError(
+            None, f"Unknown argument(s) '{' '.join(unexpected_posargs)}'."
+        )
+
+    return list(posargs[dash_index + 1 :])
+
+
+def finalize(config: NoxConfig) -> None:
+    """Resolve aliases and cross-field options after parsing."""
+    config.posargs = _strip_posargs(config.posargs)
+
+    if config.force_pythons:
+        source = config.provenance("force_pythons")
+        config.set_value("pythons", config.force_pythons, source)
+        config.set_value("extra_pythons", config.force_pythons, source)
+
+    if config.R:
+        # -R wins even over an explicit --reuse-venv (long-standing behavior).
+        config.set_value("reuse_venv", "yes", Source.COMMAND_LINE)
+        config.set_value("reuse_existing_virtualenvs", True, Source.COMMAND_LINE)  # noqa: FBT003
+        config.set_value("no_install", True, Source.COMMAND_LINE)  # noqa: FBT003
+
+    # -r/-N are an alias for --reuse-venv=yes|no; an explicit --reuse-venv wins.
+    if (
+        config.reuse_existing_virtualenvs is not None
+        and config.provenance("reuse_venv") is not Source.COMMAND_LINE
+    ):
+        config.set_value(
+            "reuse_venv",
+            "yes" if config.reuse_existing_virtualenvs else "no",
+            Source.COMMAND_LINE,
+        )
+
+    if config.no_venv:
+        if config.force_venv_backend not in {None, "none"}:
+            msg = "You can not use `--no-venv` with a non-none `--force-venv-backend`"
+            raise ValueError(msg)
+        config.set_value("force_venv_backend", "none", Source.COMMAND_LINE)
+
+    if config.forcecolor and config.nocolor:
+        raise ArgumentError(None, "Can not specify both --no-color and --force-color.")
+    config.color = config.forcecolor or (not config.nocolor and sys.stdout.isatty())
+
+
+def merge_noxfile_options(config: NoxConfig, noxfile_config: NoxfileOptions) -> None:
+    """Apply ``nox.options`` (as set by the noxfile) to the parsed config.
+
+    A value explicitly given on the command line (or via an environment
+    variable) always wins over the noxfile.
+    """
+    # sessions/keywords/tags are only taken from the noxfile if none of the
+    # three was given on the command line.
+    trio = ("sessions", "keywords", "tags")
+    cli_selected = any(config.provenance(name) is not Source.DEFAULT for name in trio)
+    apply_noxfile_values(config, noxfile_config, skip=trio if cli_selected else ())
+
+    # The legacy reuse_existing_virtualenvs alias, when enabled in the
+    # noxfile, wins over a noxfile-set reuse_venv (but not the command line).
+    if (
+        noxfile_config.provenance("reuse_existing_virtualenvs") is not Source.DEFAULT
+        and noxfile_config.reuse_existing_virtualenvs
+        and config.provenance("reuse_venv") is not Source.COMMAND_LINE
+    ):
+        config.set_value("reuse_venv", "yes", Source.NOXFILE)
+
+    # The noxfile may have set a PathLike envdir.
+    config.envdir = os.fspath(config.envdir)

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -16,9 +16,8 @@
 
 Options are declared once as fields on attrs classes (see ``nox._options``),
 carrying CLI metadata in an :class:`Opt` record. Everything else is derived
-from the model: the argparse parser, environment-variable handling, the
-noxfile/CLI merge, and serialization back to an argument list (:func:`to_argv`)
-for spawning child ``nox`` processes.
+from the model: the argparse parser, environment-variable handling, and the
+noxfile/CLI merge.
 """
 
 from __future__ import annotations
@@ -41,14 +40,12 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ArgumentError",
-    "Forward",
     "NoxOptions",  # noqa: F822 (provided lazily by __getattr__)
     "Opt",
     "Options",
     "OptionsBase",
     "Source",
     "opt",
-    "to_argv",
 ]
 
 
@@ -80,20 +77,6 @@ class Source(enum.IntEnum):
     COMMAND_LINE = 3
 
 
-class Forward(enum.Enum):
-    """How :func:`to_argv` treats an option when rebuilding an argument list.
-
-    NEVER: not forwarded (presentation-only options, or aliases whose state
-    lives in another field). IF_CHANGED: emitted when the value differs from
-    the field default. ALWAYS: emitted unconditionally (flag pairs and options
-    whose defaults are environment-dependent, so children stay deterministic).
-    """
-
-    NEVER = enum.auto()
-    IF_CHANGED = enum.auto()
-    ALWAYS = enum.auto()
-
-
 @attrs.frozen(kw_only=True)
 class Opt:
     """CLI metadata attached to a model field via ``attrs.field(metadata=...)``.
@@ -110,10 +93,6 @@ class Opt:
         hidden: Present on the config object but not exposed on the CLI.
         positional: A positional argument (only ``posargs``).
         completer: argcomplete completer.
-        forward: See :class:`Forward`.
-        serialize: Custom argv emitter; receives the value, returns the argv
-            chunk or None to skip. Overrides the generic emission; runs after
-            the ``forward`` policy has been applied.
         argparse_kwargs: Extra/overriding kwargs for ``add_argument``.
     """
 
@@ -125,8 +104,6 @@ class Opt:
     hidden: bool = False
     positional: bool = False
     completer: Callable[..., Iterable[str]] | None = None
-    forward: Forward = Forward.IF_CHANGED
-    serialize: Callable[[Any], list[str] | None] | None = None
     argparse_kwargs: dict[str, Any] = attrs.field(factory=dict)
 
 
@@ -191,52 +168,6 @@ def _analyze_type(tp: Any) -> tuple[str, tuple[Any, ...] | None]:
     if origin in {list, tuple} or tp in {list, tuple}:
         return ("list", None)
     return ("value", None)
-
-
-def to_argv(config: OptionsBase) -> list[str]:
-    """Serialize a config back into the CLI arguments that reproduce it.
-
-    The output, parsed and finalized again, restores every forwardable value.
-    Options marked ``Forward.NEVER`` are skipped; new options are forwarded by
-    default. Positional arguments (posargs) are emitted last, after ``--``.
-    """
-    argv: list[str] = []
-    tail: list[str] = []
-    defaults = type(config)()
-    for field in attrs.fields(type(config)):
-        option = _get_opt(field)
-        if option is None or option.forward is Forward.NEVER:
-            continue
-        value = getattr(config, field.name)
-        if option.positional:
-            if value:
-                tail = ["--", *(str(v) for v in value)]
-            continue
-        if option.forward is Forward.IF_CHANGED and value == getattr(
-            defaults, field.name
-        ):
-            continue
-        choices = option.argparse_kwargs.get("choices")
-        if choices is not None and value not in choices:
-            # Values the CLI grammar can't express (e.g. the noxfile-only
-            # "uv|virtualenv" fallback syntax); the child re-derives them.
-            continue
-        if option.serialize is not None:
-            argv += option.serialize(value) or []
-            continue
-        if option.negative_flags:
-            argv.append(option.flags[-1] if value else option.negative_flags[-1])
-            continue
-        flag = option.flags[-1]
-        if isinstance(value, bool):
-            if value:
-                argv.append(flag)
-        elif isinstance(value, (list, tuple)):
-            if value:
-                argv += [flag, *(str(v) for v in value)]
-        elif value is not None:
-            argv += [flag, str(value)]
-    return argv + tail
 
 
 def apply_noxfile_values(

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -141,7 +141,11 @@ def _get_opt(field: attrs.Attribute[Any]) -> Opt | None:
 
 @attrs.define(kw_only=True)
 class OptionsBase:
-    """Base for option models; tracks the provenance of each field's value."""
+    """Base for option models; tracks the provenance of each field's value.
+
+    ``attrs.evolve`` builds the copy through ``__init__``, so the copy's
+    provenance resets to ``Source.DEFAULT`` for every field.
+    """
 
     _provenance: dict[str, Source] = attrs.field(
         init=False, factory=dict, repr=False, eq=False
@@ -358,7 +362,11 @@ class Options(Generic[ConfigT]):
             if option is None:
                 continue
             if field.name in sparse:
-                config.set_value(field.name, sparse[field.name], Source.COMMAND_LINE)
+                value = sparse[field.name]
+                # argparse always fills positionals in; empty means not given.
+                if option.positional and not value:
+                    continue
+                config.set_value(field.name, value, Source.COMMAND_LINE)
             elif option.env_var and (env_value := os.environ.get(option.env_var)):
                 kind, _ = _analyze_type(field.type)
                 value = env_value.split(",") if kind == "list" else env_value
@@ -369,7 +377,11 @@ class Options(Generic[ConfigT]):
         parser = self.parser()
         argcomplete.autocomplete(parser)
         namespace = parser.parse_args(args)
-        config = self.expand(namespace)
+        try:
+            config = self.expand(namespace)
+        except ValueError as err:
+            # Bad environment-variable values fail their field validator.
+            parser.error(str(err.args[0]) if err.args else str(err))
         try:
             if self.finalize is not None:
                 self.finalize(config)

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -112,7 +112,8 @@ class Opt:
         completer: argcomplete completer.
         forward: See :class:`Forward`.
         serialize: Custom argv emitter; receives the value, returns the argv
-            chunk or None to skip. Overrides the generic emission.
+            chunk or None to skip. Overrides the generic emission; runs after
+            the ``forward`` policy has been applied.
         argparse_kwargs: Extra/overriding kwargs for ``add_argument``.
     """
 
@@ -147,6 +148,9 @@ class OptionsBase:
     )
 
     def provenance(self, name: str) -> Source:
+        if name not in attrs.fields_dict(type(self)):
+            msg = f"{name} is not an option."
+            raise KeyError(msg)
         return self._provenance.get(name, Source.DEFAULT)
 
     def set_value(self, name: str, value: Any, source: Source) -> None:
@@ -162,13 +166,6 @@ def record_noxfile_set(
     if not field.name.startswith("_"):
         instance._provenance[field.name] = Source.NOXFILE
     return value
-
-
-def _field_default(field: attrs.Attribute[Any]) -> Any:
-    default = field.default
-    if isinstance(default, attrs.Factory):  # type: ignore[arg-type]
-        return default.factory()  # type: ignore[union-attr]
-    return default
 
 
 def _analyze_type(tp: Any) -> tuple[str, tuple[Any, ...] | None]:
@@ -201,6 +198,7 @@ def to_argv(config: OptionsBase) -> list[str]:
     """
     argv: list[str] = []
     tail: list[str] = []
+    defaults = type(config)()
     for field in attrs.fields(type(config)):
         option = _get_opt(field)
         if option is None or option.forward is Forward.NEVER:
@@ -210,13 +208,20 @@ def to_argv(config: OptionsBase) -> list[str]:
             if value:
                 tail = ["--", *(str(v) for v in value)]
             continue
+        if option.forward is Forward.IF_CHANGED and value == getattr(
+            defaults, field.name
+        ):
+            continue
+        choices = option.argparse_kwargs.get("choices")
+        if choices is not None and value not in choices:
+            # Values the CLI grammar can't express (e.g. the noxfile-only
+            # "uv|virtualenv" fallback syntax); the child re-derives them.
+            continue
         if option.serialize is not None:
             argv += option.serialize(value) or []
             continue
         if option.negative_flags:
             argv.append(option.flags[-1] if value else option.negative_flags[-1])
-            continue
-        if option.forward is Forward.IF_CHANGED and value == _field_default(field):
             continue
         flag = option.flags[-1]
         if isinstance(value, bool):
@@ -250,32 +255,25 @@ class Options(Generic[ConfigT]):
 
     Args:
         config_class: The attrs class holding every option (the CLI surface).
-        noxfile_class: Its base class holding the noxfile-settable subset.
         groups: Mapping of group key to (title, description) for ``--help``.
         description: The parser description.
         finalize: Called with the fresh config after parsing, before returning;
             resolves aliases and cross-field options. ``ArgumentError`` raised
             here is reported via ``parser.error``.
-        merge: Called by :meth:`merge_namespaces` with (config, noxfile
-            options) to apply noxfile settings and post-merge defaults.
     """
 
     def __init__(
         self,
         config_class: type[ConfigT],
-        noxfile_class: type[OptionsBase],
         *,
         groups: dict[str, tuple[str, str]],
         description: str,
         finalize: Callable[[Any], None] | None = None,
-        merge: Callable[[Any, Any], None] | None = None,
     ) -> None:
         self.config_class = config_class
-        self.noxfile_class = noxfile_class
         self.groups = groups
         self.description = description
         self.finalize = finalize
-        self.merge = merge
         attrs.resolve_types(config_class)
 
     def _argparse_kwargs(
@@ -393,12 +391,3 @@ class Options(Generic[ConfigT]):
                 raise KeyError(msg)
             config.set_value(key, value, Source.COMMAND_LINE)
         return config
-
-    def noxfile_namespace(self) -> Any:
-        """Return a fresh instance of the noxfile-settable options."""
-        return self.noxfile_class()
-
-    def merge_namespaces(self, config: ConfigT, noxfile_config: Any) -> None:
-        """Merge the noxfile options into the parsed config."""
-        if self.merge is not None:
-            self.merge(config, noxfile_config)

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ArgumentError",
-    "NoxOptions",  # noqa: F822 (provided lazily by __getattr__)
     "Opt",
     "Options",
     "OptionsBase",
@@ -51,16 +50,6 @@ __all__ = [
 
 def __dir__() -> list[str]:
     return __all__
-
-
-def __getattr__(name: str) -> Any:
-    # Compatibility alias; NoxOptions was defined here before the model moved.
-    if name == "NoxOptions":
-        from nox._options import NoxfileOptions  # noqa: PLC0415
-
-        return NoxfileOptions
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)
 
 
 METADATA_KEY = "nox_opt"

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -12,34 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""High-level options interface. This allows defining options just once that
-can be specified from the command line and the Noxfile, easily used in tests,
-and surfaced in documentation."""
+"""Machinery for statically-defined option models.
+
+Options are declared once as fields on attrs classes (see ``nox._options``),
+carrying CLI metadata in an :class:`Opt` record. Everything else is derived
+from the model: the argparse parser, environment-variable handling, the
+noxfile/CLI merge, and serialization back to an argument list (:func:`to_argv`)
+for spawning child ``nox`` processes.
+"""
 
 from __future__ import annotations
 
-__lazy_modules__ = {"argcomplete", "argparse", "functools"}
+__lazy_modules__ = {"argcomplete", "argparse", "types"}
 
 import argparse
-import functools
+import enum
 import os
+import types
+import typing
 from argparse import ArgumentError, ArgumentParser, Namespace
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 import argcomplete
 import attrs
-import attrs.validators as av
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable, Iterable
 
 __all__ = [
     "ArgumentError",
-    "NoxOptions",
-    "Option",
-    "OptionGroup",
-    "OptionSet",
-    "make_flag_pair",
+    "Forward",
+    "NoxOptions",  # noqa: F822 (provided lazily by __getattr__)
+    "Opt",
+    "Options",
+    "OptionsBase",
+    "Source",
+    "opt",
+    "to_argv",
 ]
 
 
@@ -47,354 +56,349 @@ def __dir__() -> list[str]:
     return __all__
 
 
-av_opt_str = av.optional(av.instance_of(str))
-av_opt_path = av.optional(av.or_(av.instance_of(str), av.instance_of(os.PathLike)))  # type: ignore[type-abstract]
-av_opt_list_str = av.optional(
-    av.deep_iterable(
-        member_validator=av.instance_of(str),
-        iterable_validator=av.not_(av.instance_of(str)),
-    )
-)
-av_bool = av.instance_of(bool)
+def __getattr__(name: str) -> Any:
+    # Compatibility alias; NoxOptions was defined here before the model moved.
+    if name == "NoxOptions":
+        from nox._options import NoxfileOptions  # noqa: PLC0415
+
+        return NoxfileOptions
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
 
 
-@attrs.define(slots=True, kw_only=True)
-class NoxOptions:
-    default_venv_backend: None | str = attrs.field(validator=av_opt_str)
-    download_python: None | Literal["auto", "never", "always"] = attrs.field(
-        default=None, validator=av.optional(av.in_(["auto", "never", "always"]))
-    )
-    envdir: None | str | os.PathLike[str] = attrs.field(validator=av_opt_path)
-    error_on_external_run: bool = attrs.field(validator=av_bool)
-    error_on_missing_interpreters: bool = attrs.field(validator=av_bool)
-    force_venv_backend: None | str = attrs.field(validator=av_opt_str)
-    keywords: None | str = attrs.field(validator=av_opt_str)
-    pythons: None | Sequence[str] = attrs.field(validator=av_opt_list_str)
-    report: None | str = attrs.field(validator=av_opt_str)
-    reuse_existing_virtualenvs: bool = attrs.field(validator=av_bool)
-    reuse_venv: None | Literal["no", "yes", "never", "always"] = attrs.field(
-        validator=av.optional(av.in_(["no", "yes", "never", "always"]))
-    )
-    sessions: None | Sequence[str] = attrs.field(validator=av_opt_list_str)
-    stop_on_first_error: bool = attrs.field(validator=av_bool)
-    tags: None | Sequence[str] = attrs.field(validator=av_opt_list_str)
-    verbose: bool = attrs.field(validator=av_bool)
+METADATA_KEY = "nox_opt"
+
+ConfigT = TypeVar("ConfigT", bound="OptionsBase")
 
 
-class OptionGroup:
-    """A single group for command-line options.
+class Source(enum.IntEnum):
+    """Where a value came from; higher-ranked sources win during merging."""
 
-    Args:
-        name (str): The name used to refer to the group.
-        args: Passed through to``ArgumentParser.add_argument_group``.
-        kwargs: Passed through to``ArgumentParser.add_argument_group``.
+    DEFAULT = 0
+    NOXFILE = 1
+    ENVIRONMENT = 2
+    COMMAND_LINE = 3
+
+
+class Forward(enum.Enum):
+    """How :func:`to_argv` treats an option when rebuilding an argument list.
+
+    NEVER: not forwarded (presentation-only options, or aliases whose state
+    lives in another field). IF_CHANGED: emitted when the value differs from
+    the field default. ALWAYS: emitted unconditionally (flag pairs and options
+    whose defaults are environment-dependent, so children stay deterministic).
     """
 
-    __slots__ = ("args", "kwargs", "name")
-
-    def __init__(self, name: str, *args: Any, **kwargs: Any) -> None:
-        self.name = name
-        self.args = args
-        self.kwargs = kwargs
+    NEVER = enum.auto()
+    IF_CHANGED = enum.auto()
+    ALWAYS = enum.auto()
 
 
-class Option:
-    """A single option that can be specified via command-line or configuration
-    file.
+@attrs.frozen(kw_only=True)
+class Opt:
+    """CLI metadata attached to a model field via ``attrs.field(metadata=...)``.
 
     Args:
-        name (str): The name used to refer to the option in the final namespace
-            object.
-        flags (Sequence[str]): The list of flags used by argparse. Effectively
-            the ``*args`` for ``ArgumentParser.add_argument``.
-        group (OptionGroup): The argument group this option belongs to.
-        help (str): The help string pass to argparse.
-        noxfile (bool): Whether or not this option can be set in the
-            configuration file.
-        merge_func (Callable[[Namespace, NoxOptions], Any]): A function that
-            can define custom behavior when merging the command-line options
-            with the configuration file options. The first argument is the
-            command-line options, the second is the configuration file options.
-            It should return the new value for the option.
-        finalizer_func (Callable[Any, Namespace], Any): A function that can
-            define custom finalization behavior. This is called after all
-            arguments are parsed. It's called with the options parsed value
-            and the set of command-line options and should return the new
-            value.
-        default (Union[Any, Callable[[], Any]]): The default value. It may
-            also be a function in which case it will be invoked after argument
-            parsing if nothing was specified.
-        hidden (bool): Means this option will be present in the namespace, but
-            will not show up on the argument list.
-        kwargs: Passed through to``ArgumentParser.add_argument``.
+        flags: The argparse flags (e.g. ``-s``, ``--sessions``). The last flag
+            is the canonical one used when serializing back to argv.
+        group: Key into the option set's group table. Required unless hidden.
+        help: The argparse help string.
+        negative_flags: If non-empty, this is a flag pair; these flags
+            ``store_false`` into the same field.
+        env_var: Environment variable providing the value when the flag is not
+            passed (comma-split for list-typed fields).
+        hidden: Present on the config object but not exposed on the CLI.
+        positional: A positional argument (only ``posargs``).
+        completer: argcomplete completer.
+        forward: See :class:`Forward`.
+        serialize: Custom argv emitter; receives the value, returns the argv
+            chunk or None to skip. Overrides the generic emission.
+        argparse_kwargs: Extra/overriding kwargs for ``add_argument``.
+    """
+
+    flags: tuple[str, ...] = ()
+    group: str | None = None
+    help: str | None = None
+    negative_flags: tuple[str, ...] = ()
+    env_var: str | None = None
+    hidden: bool = False
+    positional: bool = False
+    completer: Callable[..., Iterable[str]] | None = None
+    forward: Forward = Forward.IF_CHANGED
+    serialize: Callable[[Any], list[str] | None] | None = None
+    argparse_kwargs: dict[str, Any] = attrs.field(factory=dict)
+
+
+def opt(*flags: str, **kwargs: Any) -> dict[str, Opt]:
+    """Build the metadata dict for an option field."""
+    return {METADATA_KEY: Opt(flags=flags, **kwargs)}
+
+
+def _get_opt(field: attrs.Attribute[Any]) -> Opt | None:
+    return field.metadata.get(METADATA_KEY)
+
+
+@attrs.define(kw_only=True)
+class OptionsBase:
+    """Base for option models; tracks the provenance of each field's value."""
+
+    _provenance: dict[str, Source] = attrs.field(
+        init=False, factory=dict, repr=False, eq=False
+    )
+
+    def provenance(self, name: str) -> Source:
+        return self._provenance.get(name, Source.DEFAULT)
+
+    def set_value(self, name: str, value: Any, source: Source) -> None:
+        """Set a field and record where the value came from."""
+        setattr(self, name, value)
+        self._provenance[name] = source
+
+
+def record_noxfile_set(
+    instance: OptionsBase, field: attrs.Attribute[Any], value: Any
+) -> Any:
+    """on_setattr hook: record plain assignments (``nox.options.x = ...``)."""
+    if not field.name.startswith("_"):
+        instance._provenance[field.name] = Source.NOXFILE
+    return value
+
+
+def _field_default(field: attrs.Attribute[Any]) -> Any:
+    default = field.default
+    if isinstance(default, attrs.Factory):  # type: ignore[arg-type]
+        return default.factory()  # type: ignore[union-attr]
+    return default
+
+
+def _analyze_type(tp: Any) -> tuple[str, tuple[Any, ...] | None]:
+    """Classify a field type for argparse.
+
+    Returns a kind (``"flag"``, ``"list"``, or ``"value"``) and Literal
+    choices, if any.
+    """
+    origin = typing.get_origin(tp)
+    if origin in {typing.Union, types.UnionType}:
+        non_none = [a for a in typing.get_args(tp) if a is not type(None)]
+        if len(non_none) == 1:
+            return _analyze_type(non_none[0])
+        return ("value", None)
+    if origin is Literal:
+        return ("value", typing.get_args(tp))
+    if tp is bool:
+        return ("flag", None)
+    if origin in {list, tuple} or tp in {list, tuple}:
+        return ("list", None)
+    return ("value", None)
+
+
+def to_argv(config: OptionsBase) -> list[str]:
+    """Serialize a config back into the CLI arguments that reproduce it.
+
+    The output, parsed and finalized again, restores every forwardable value.
+    Options marked ``Forward.NEVER`` are skipped; new options are forwarded by
+    default. Positional arguments (posargs) are emitted last, after ``--``.
+    """
+    argv: list[str] = []
+    tail: list[str] = []
+    for field in attrs.fields(type(config)):
+        option = _get_opt(field)
+        if option is None or option.forward is Forward.NEVER:
+            continue
+        value = getattr(config, field.name)
+        if option.positional:
+            if value:
+                tail = ["--", *(str(v) for v in value)]
+            continue
+        if option.serialize is not None:
+            argv += option.serialize(value) or []
+            continue
+        if option.negative_flags:
+            argv.append(option.flags[-1] if value else option.negative_flags[-1])
+            continue
+        if option.forward is Forward.IF_CHANGED and value == _field_default(field):
+            continue
+        flag = option.flags[-1]
+        if isinstance(value, bool):
+            if value:
+                argv.append(flag)
+        elif isinstance(value, (list, tuple)):
+            if value:
+                argv += [flag, *(str(v) for v in value)]
+        elif value is not None:
+            argv += [flag, str(value)]
+    return argv + tail
+
+
+def apply_noxfile_values(
+    config: OptionsBase, noxfile_config: OptionsBase, *, skip: Iterable[str] = ()
+) -> None:
+    """Copy fields set in the noxfile into the config where nothing outranks them."""
+    skip = set(skip)
+    for field in attrs.fields(type(noxfile_config)):
+        name = field.name
+        if _get_opt(field) is None or name in skip:
+            continue
+        if noxfile_config.provenance(name) is Source.DEFAULT:
+            continue
+        if config.provenance(name) is Source.DEFAULT:
+            config.set_value(name, getattr(noxfile_config, name), Source.NOXFILE)
+
+
+class Options(Generic[ConfigT]):
+    """The full option set: builds the parser and config objects from the model.
+
+    Args:
+        config_class: The attrs class holding every option (the CLI surface).
+        noxfile_class: Its base class holding the noxfile-settable subset.
+        groups: Mapping of group key to (title, description) for ``--help``.
+        description: The parser description.
+        finalize: Called with the fresh config after parsing, before returning;
+            resolves aliases and cross-field options. ``ArgumentError`` raised
+            here is reported via ``parser.error``.
+        merge: Called by :meth:`merge_namespaces` with (config, noxfile
+            options) to apply noxfile settings and post-merge defaults.
     """
 
     def __init__(
         self,
-        name: str,
-        *flags: str,
-        group: OptionGroup | None,
-        help: str | None = None,
-        noxfile: bool = False,
-        merge_func: Callable[[Namespace, NoxOptions], Any] | None = None,
-        finalizer_func: Callable[[Any, Namespace], Any] | None = None,
-        default: (
-            bool | str | None | list[str] | Callable[[], bool | str | None | list[str]]
-        ) = None,
-        hidden: bool = False,
-        completer: Callable[..., Iterable[str]] | None = None,
-        **kwargs: Any,
+        config_class: type[ConfigT],
+        noxfile_class: type[OptionsBase],
+        *,
+        groups: dict[str, tuple[str, str]],
+        description: str,
+        finalize: Callable[[Any], None] | None = None,
+        merge: Callable[[Any, Any], None] | None = None,
     ) -> None:
-        self.name = name
-        self.flags = flags
-        self.group = group
-        self.help = help
-        self.noxfile = noxfile
-        self.merge_func = merge_func
-        self.finalizer_func = finalizer_func
-        self.hidden = hidden
-        self.completer = completer
-        self.kwargs = kwargs
-        self._default = default
+        self.config_class = config_class
+        self.noxfile_class = noxfile_class
+        self.groups = groups
+        self.description = description
+        self.finalize = finalize
+        self.merge = merge
+        attrs.resolve_types(config_class)
 
-    @property
-    def default(self) -> bool | str | None | list[str]:
-        if callable(self._default):
-            return self._default()
-        return self._default
-
-
-def flag_pair_merge_func(
-    enable_name: str,
-    enable_default: bool | Callable[[], bool],  # noqa: FBT001
-    disable_name: str,
-    command_args: Namespace,
-    noxfile_args: NoxOptions,
-) -> bool:
-    """Merge function for flag pairs. If the flag is set in the Noxfile or
-    the command line params, return ``True`` *unless* the disable flag has been
-    specified on the command-line.
-
-    For example, assuming you have a flag pair created using::
-
-        make_flag_pair(
-            "thing_a",
-            "--thing-a",
-            "--no-thing-a"
-        )
-
-    Then if the Noxfile says::
-
-        nox.options.thing_a = True
-
-    But the command line says::
-
-        nox --no-thing-a
-
-    Then the result will be ``False``.
-
-    However, without the "--no-thing-a" flag set then this returns ``True`` if
-    *either*::
-
-        nox.options.thing_a = True
-
-    or::
-
-        nox --thing-a
-
-    are specified.
-    """
-    noxfile_value = getattr(noxfile_args, enable_name)
-    command_value = getattr(command_args, enable_name)
-    disable_value = getattr(command_args, disable_name)
-    default_value = enable_default() if callable(enable_default) else enable_default
-    if default_value and disable_value is None and noxfile_value != default_value:
-        # Makes sure make_flag_pair with default=true can be overridden via noxfile
-        disable_value = True
-
-    return (command_value or noxfile_value) and not disable_value
-
-
-def make_flag_pair(
-    name: str,
-    enable_flags: tuple[str, str] | tuple[str],
-    disable_flags: tuple[str, str] | tuple[str],
-    *,
-    default: bool | Callable[[], bool] = False,
-    **kwargs: Any,
-) -> tuple[Option, Option]:
-    """Returns two options - one to enable a behavior and another to disable it.
-
-    The positive option is considered to be available to the Noxfile, as
-    there isn't much point in doing flag pairs without it.
-    """
-    disable_name = f"no_{name}"
-
-    kwargs["action"] = "store_true"
-    enable_option = Option(
-        name,
-        *enable_flags,
-        noxfile=True,
-        merge_func=functools.partial(flag_pair_merge_func, name, default, disable_name),
-        default=default,
-        **kwargs,
-    )
-
-    kwargs["help"] = f"Disables {enable_flags[-1]} if it is enabled in the Noxfile."
-    disable_option = Option(disable_name, *disable_flags, **kwargs)
-
-    return enable_option, disable_option
-
-
-class OptionSet:
-    """A set of options.
-
-    A high-level wrapper over ``argparse.ArgumentParser``. It allows for
-    introspection of options as well as quality-of-life features such as
-    finalization, callable defaults, and strongly typed namespaces for tests.
-    """
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.parser_args = args
-        self.parser_kwargs = kwargs
-        self.options: dict[str, Option] = {}
-        self.groups: dict[str, OptionGroup] = {}
-
-    def add_options(self, *args: Option) -> None:
-        """Adds a sequence of Options to the OptionSet.
-
-        Args:
-            args (Sequence[Options])
-        """
-        for option in args:
-            self.options[option.name] = option
-
-    def add_groups(self, *args: OptionGroup) -> None:
-        """Adds a sequence of OptionGroups to the OptionSet.
-
-        Args:
-            args (Sequence[OptionGroup])
-        """
-        for option_group in args:
-            self.groups[option_group.name] = option_group
+    def _argparse_kwargs(
+        self, field: attrs.Attribute[Any], option: Opt
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        kind, choices = _analyze_type(field.type)
+        if kind == "flag":
+            kwargs["action"] = "store_true"
+        elif kind == "list":
+            kwargs["nargs"] = "*"
+        if choices:
+            kwargs["choices"] = list(choices)
+        kwargs.update(option.argparse_kwargs)
+        return kwargs
 
     def parser(self) -> ArgumentParser:
-        """Returns an ``ArgumentParser`` for this option set.
+        """Build the ``ArgumentParser`` for the model.
 
-        Generally, you won't use this directly. Instead, use
-        :func:`parse_args`.
+        Parsing is sparse: only flags actually passed appear in the resulting
+        namespace (via ``argparse.SUPPRESS``), so provenance is exact.
         """
-        parser_kwargs = {"allow_abbrev": False, **self.parser_kwargs}
-        parser = argparse.ArgumentParser(*self.parser_args, **parser_kwargs)
-
+        parser = argparse.ArgumentParser(
+            description=self.description, add_help=False, allow_abbrev=False
+        )
         groups = {
-            name: parser.add_argument_group(*option_group.args, **option_group.kwargs)
-            for name, option_group in self.groups.items()
+            name: parser.add_argument_group(title, description)
+            for name, (title, description) in self.groups.items()
         }
-
-        for option in self.options.values():
-            if option.hidden:
+        for field in attrs.fields(self.config_class):
+            option = _get_opt(field)
+            if option is None or option.hidden:
                 continue
-
-            # Every option must have a group (except for hidden options)
             if option.group is None:
-                msg = f"Option {option.name} must either have a group or be hidden."
+                msg = f"Option {field.name} must either have a group or be hidden."
                 raise ValueError(msg)
-
-            argument = groups[option.group.name].add_argument(
-                *option.flags, help=option.help, default=option.default, **option.kwargs
+            group = groups[option.group]
+            if option.positional:
+                group.add_argument(
+                    field.name,
+                    help=option.help,
+                    default=[],
+                    **option.argparse_kwargs,
+                )
+                continue
+            argument = group.add_argument(
+                *option.flags,
+                dest=field.name,
+                help=option.help,
+                default=argparse.SUPPRESS,
+                **self._argparse_kwargs(field, option),
             )
             if option.completer:
                 argument.completer = option.completer  # type: ignore[attr-defined]
-
+            if option.negative_flags:
+                group.add_argument(
+                    *option.negative_flags,
+                    dest=field.name,
+                    action="store_false",
+                    default=argparse.SUPPRESS,
+                    help=f"Disables {option.flags[-1]} if it is enabled in the Noxfile.",
+                )
         return parser
 
     def print_help(self) -> None:
-        return self.parser().print_help()
+        self.parser().print_help()
 
-    def _finalize_args(self, args: Namespace) -> None:
-        """Does any necessary post-processing on arguments."""
-        for option in self.options.values():
-            # Handle hidden items.
-            if option.hidden and not hasattr(args, option.name):
-                setattr(args, option.name, option.default)
+    def expand(self, namespace: Namespace | ConfigT) -> ConfigT:
+        """Build a full config from a sparse argparse namespace.
 
-            value = getattr(args, option.name)
+        Values present in the namespace were passed on the command line;
+        everything else falls back to the environment variable (if declared)
+        and then the field default. A config passed in (e.g. from
+        :meth:`namespace` in tests) is returned unchanged.
+        """
+        if isinstance(namespace, self.config_class):
+            return namespace
+        sparse = vars(namespace)
+        config = self.config_class()
+        for field in attrs.fields(self.config_class):
+            option = _get_opt(field)
+            if option is None:
+                continue
+            if field.name in sparse:
+                config.set_value(field.name, sparse[field.name], Source.COMMAND_LINE)
+            elif option.env_var and (env_value := os.environ.get(option.env_var)):
+                kind, _ = _analyze_type(field.type)
+                value = env_value.split(",") if kind == "list" else env_value
+                config.set_value(field.name, value, Source.ENVIRONMENT)
+        return config
 
-            # argparse only checks choices for values given on the command
-            # line; re-check here so bad environment-variable defaults produce
-            # a clean error instead of misbehaving later.
-            choices = option.kwargs.get("choices")
-            if choices is not None and value is not None and value not in choices:
-                msg = f"{option.name!r} must be in {choices!r} (got {value!r})"
-                raise ArgumentError(None, msg)
-
-            # Handle options that have finalizer functions.
-            if option.finalizer_func:
-                setattr(args, option.name, option.finalizer_func(value, args))
-
-    def parse_args(self, args: Sequence[str] | None = None) -> Namespace:
+    def parse_args(self, args: list[str] | None = None) -> ConfigT:
         parser = self.parser()
         argcomplete.autocomplete(parser)
-        parsed_args = parser.parse_args(args)
-
+        namespace = parser.parse_args(args)
+        config = self.expand(namespace)
         try:
-            self._finalize_args(parsed_args)
+            if self.finalize is not None:
+                self.finalize(config)
         except ArgumentError as err:
             parser.error(str(err))
-        return parsed_args
+        return config
 
-    def namespace(self, **kwargs: Any) -> argparse.Namespace:
-        """Return a namespace that contains all of the options in this set.
+    def namespace(self, **kwargs: Any) -> ConfigT:
+        """Return a config with every option at its default.
 
-        kwargs can be used to set values and does so in a checked way - you
-        can not set an option that does not exist in the set. This is useful
-        for testing.
+        kwargs set values in a checked way - you can not set an option that
+        does not exist. This is useful for testing.
         """
-        args = {option.name: option.default for option in self.options.values()}
-
-        # Don't use update - validate that the keys actually exist so that
-        # we don't accidentally set non-existent options.
-        # don't bother with coverage here, this is effectively only ever
-        # used in tests.
+        fields = attrs.fields_dict(self.config_class)
+        config = self.config_class()
         for key, value in kwargs.items():
-            if key not in args:
+            if key not in fields or _get_opt(fields[key]) is None:
                 msg = f"{key} is not an option."
                 raise KeyError(msg)
-            args[key] = value
+            config.set_value(key, value, Source.COMMAND_LINE)
+        return config
 
-        return argparse.Namespace(**args)
+    def noxfile_namespace(self) -> Any:
+        """Return a fresh instance of the noxfile-settable options."""
+        return self.noxfile_class()
 
-    def noxfile_namespace(self) -> NoxOptions:
-        """Returns a namespace of options that can be set in the configuration
-        file."""
-        values = {}
-        for option in self.options.values():
-            if not option.noxfile:
-                continue
-            value = option.default
-            choices = option.kwargs.get("choices")
-            if choices is not None and value not in choices:
-                # A bad environment-variable default; this runs at import
-                # time, so leave it unset and let parse_args report it.
-                value = None
-            values[option.name] = value
-        return NoxOptions(**values)  # type: ignore[arg-type]
-
-    def merge_namespaces(
-        self, command_args: Namespace, noxfile_args: NoxOptions
-    ) -> None:
-        """Merges the command-line options with the Noxfile options."""
-        command_args_copy = Namespace(**vars(command_args))
-        for name, option in self.options.items():
-            if option.merge_func:
-                setattr(
-                    command_args,
-                    name,
-                    option.merge_func(command_args_copy, noxfile_args),
-                )
-            elif option.noxfile:
-                value = getattr(command_args_copy, name, None) or getattr(
-                    noxfile_args, name, None
-                )
-                setattr(command_args, name, value)
+    def merge_namespaces(self, config: ConfigT, noxfile_config: Any) -> None:
+        """Merge the noxfile options into the parsed config."""
+        if self.merge is not None:
+            self.merge(config, noxfile_config)

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -52,6 +52,7 @@ __all__ = [
     "NoxConfig",
     "NoxfileOptions",
     "ReuseVenvType",
+    "merge_noxfile_options",
     "noxfile_options",
     "options",
 ]
@@ -63,9 +64,11 @@ def __dir__() -> list[str]:
 
 ReuseVenvType = Literal["no", "yes", "never", "always"]
 
+av_str: Validator = av.instance_of(str)
 av_opt_str: Validator = av.optional(av.instance_of(str))
-av_opt_path: Validator = av.optional(
-    av.or_(av.instance_of(str), av.instance_of(os.PathLike))  # type: ignore[type-abstract]
+av_path: Validator = av.or_(
+    av.instance_of(str),
+    av.instance_of(os.PathLike),  # type: ignore[type-abstract]
 )
 av_opt_list_str: Validator = av.optional(
     av.deep_iterable(
@@ -188,9 +191,9 @@ class NoxfileOptions(_option_set.OptionsBase):
     See :doc:`usage` for more details on these settings and their effect.
     """
 
-    default_venv_backend: str | None = attrs.field(
-        default=None,
-        validator=av_opt_str,
+    default_venv_backend: str = attrs.field(
+        default="virtualenv",
+        validator=av_str,
         metadata=opt(
             "-db",
             "--default-venv-backend",
@@ -217,9 +220,9 @@ class NoxfileOptions(_option_set.OptionsBase):
             ),
         ),
     )
-    envdir: str | os.PathLike[str] | None = attrs.field(
-        default=None,
-        validator=av_opt_path,
+    envdir: str | os.PathLike[str] = attrs.field(
+        default=".nox",
+        validator=av_path,
         metadata=opt(
             "--envdir",
             group="environment",
@@ -316,9 +319,9 @@ class NoxfileOptions(_option_set.OptionsBase):
             help="This is an alias for '--reuse-venv=yes|no'.",
         ),
     )
-    reuse_venv: ReuseVenvType | None = attrs.field(
-        default=None,
-        validator=av.optional(av.in_(["no", "yes", "never", "always"])),
+    reuse_venv: ReuseVenvType = attrs.field(
+        default="no",
+        validator=av.in_(["no", "yes", "never", "always"]),
         metadata=opt(
             "--reuse-venv",
             group="environment",
@@ -650,7 +653,7 @@ def _finalize(config: NoxConfig) -> None:
     config.color = config.forcecolor or (not config.nocolor and sys.stdout.isatty())
 
 
-def _merge_noxfile_options(config: NoxConfig, noxfile_config: NoxfileOptions) -> None:
+def merge_noxfile_options(config: NoxConfig, noxfile_config: NoxfileOptions) -> None:
     """Apply ``nox.options`` (as set by the noxfile) to the parsed config.
 
     A value explicitly given on the command line (or via an environment
@@ -673,12 +676,8 @@ def _merge_noxfile_options(config: NoxConfig, noxfile_config: NoxfileOptions) ->
     ):
         config.set_value("reuse_venv", "yes", Source.NOXFILE)
 
-    # Defaults that only apply once the noxfile has had its say.
-    config.envdir = os.fspath(config.envdir or ".nox")
-    if config.reuse_venv is None:
-        config.reuse_venv = "no"
-    if config.default_venv_backend is None:
-        config.default_venv_backend = "virtualenv"
+    # The noxfile may have set a PathLike envdir.
+    config.envdir = os.fspath(config.envdir)
 
 
 options = _option_set.Options(

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -16,32 +16,21 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = {
-    "argcomplete",
-    "argparse",
-    "itertools",
-    "nox._option_set",
-    "nox.tasks",
-    "nox.virtualenv",
-}
+__lazy_modules__ = {"argparse", "nox._option_set", "nox.virtualenv"}
 
 import argparse
-import itertools
 import os
-import sys
 from typing import TYPE_CHECKING, Any, Literal
 
-import argcomplete
 import attrs
 import attrs.validators as av
 
-from nox import _option_set
-from nox._option_set import Forward, Source, opt
-from nox.tasks import discover_manifest, filter_manifest, load_nox_module
+from nox import _completers, _merge, _option_set
+from nox._option_set import Forward, opt
 from nox.virtualenv import ALL_VENVS
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable
 
     # Opaque validator type; keeps mypy's attrs plugin from inferring field
     # types from the validator instead of the annotation.
@@ -52,7 +41,6 @@ __all__ = [
     "NoxConfig",
     "NoxfileOptions",
     "ReuseVenvType",
-    "merge_noxfile_options",
     "noxfile_options",
     "options",
 ]
@@ -130,53 +118,6 @@ def _serialize_color(value: Any) -> list[str]:
     return ["--forcecolor"] if value else ["--nocolor"]
 
 
-def _python_completer(
-    prefix: str,  # noqa: ARG001
-    parsed_args: argparse.Namespace | NoxConfig,
-    **kwargs: Any,
-) -> Iterable[str]:
-    config = options.expand(parsed_args)
-    module = load_nox_module(config)
-    manifest = discover_manifest(module, config)
-    return filter(
-        None,
-        (
-            session.func.python  # type:ignore[misc] # str sequences flattened, other non-strs falsey and filtered out
-            for session, _ in manifest.list_all_sessions()
-        ),
-    )
-
-
-def _session_completer(
-    prefix: str,  # noqa: ARG001
-    parsed_args: argparse.Namespace | NoxConfig,
-    **kwargs: Any,
-) -> Iterable[str]:
-    config = options.expand(parsed_args)
-    config.list_sessions = True
-    module = load_nox_module(config)
-    manifest = discover_manifest(module, config)
-    filtered_manifest = filter_manifest(manifest, config)
-    if isinstance(filtered_manifest, int):
-        return []
-    return (
-        session.friendly_name for session, _ in filtered_manifest.list_all_sessions()
-    )
-
-
-def _tag_completer(
-    prefix: str,  # noqa: ARG001
-    parsed_args: argparse.Namespace | NoxConfig,
-    **kwargs: Any,
-) -> Iterable[str]:
-    config = options.expand(parsed_args)
-    module = load_nox_module(config)
-    manifest = discover_manifest(module, config)
-    return itertools.chain.from_iterable(
-        filter(None, (session.tags for session, _ in manifest.list_all_sessions()))
-    )
-
-
 @attrs.define(
     kw_only=True,
     on_setattr=[attrs.setters.validate, _option_set.record_noxfile_set],
@@ -226,7 +167,7 @@ class NoxfileOptions(_option_set.OptionsBase):
         metadata=opt(
             "--envdir",
             group="environment",
-            completer=argcomplete.completers.DirectoriesCompleter(),  # type: ignore[no-untyped-call]
+            completer=_completers.directory_completer,
             help="Directory where Nox will store virtualenvs, this is ``.nox`` by default.",
         ),
     )
@@ -277,7 +218,7 @@ class NoxfileOptions(_option_set.OptionsBase):
             "-k",
             "--keywords",
             group="sessions",
-            completer=argcomplete.completers.ChoicesCompleter(()),  # type: ignore[no-untyped-call]
+            completer=_completers.empty_completer,
             help="Only run sessions that match the given expression.",
         ),
     )
@@ -290,7 +231,7 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--python",
             group="python",
             env_var="NOXPYTHON",
-            completer=_python_completer,
+            completer=_completers.python_completer,
             help=(
                 "Only run sessions that use the given python interpreter versions."
                 " Environment variable: NOXPYTHON"
@@ -303,7 +244,7 @@ class NoxfileOptions(_option_set.OptionsBase):
         metadata=opt(
             "--report",
             group="reporting",
-            completer=argcomplete.completers.FilesCompleter(("json",)),  # type: ignore[no-untyped-call]
+            completer=_completers.json_file_completer,
             help="Output a report of all sessions to the given filename.",
         ),
     )
@@ -341,7 +282,7 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--session",
             group="sessions",
             env_var="NOXSESSION",
-            completer=_session_completer,
+            completer=_completers.session_completer,
             help=(
                 "Which sessions to run. By default, all sessions will run."
                 " Environment variable: NOXSESSION"
@@ -367,7 +308,7 @@ class NoxfileOptions(_option_set.OptionsBase):
             "-t",
             "--tags",
             group="sessions",
-            completer=_tag_completer,
+            completer=_completers.tag_completer,
             help="Only run sessions with the given tags.",
         ),
     )
@@ -477,7 +418,7 @@ class NoxConfig(NoxfileOptions):
             "--extra-python",
             group="python",
             env_var="NOXEXTRAPYTHON",
-            completer=_python_completer,
+            completer=_completers.python_completer,
             help=(
                 "Additionally, run sessions using the given python interpreter versions."
                 " Environment variable: NOXEXTRAPYTHON"
@@ -492,7 +433,7 @@ class NoxConfig(NoxfileOptions):
             "--force-python",
             group="python",
             env_var="NOXFORCEPYTHON",
-            completer=_python_completer,
+            completer=_completers.python_completer,
             help=(
                 "Run sessions with the given interpreters instead of those listed in the"
                 " Noxfile. This is a shorthand for ``--python=X.Y --extra-python=X.Y``."
@@ -598,93 +539,11 @@ class NoxConfig(NoxfileOptions):
     )
 
 
-def _strip_posargs(posargs: Sequence[str]) -> list[str]:
-    """Remove the leading "--" from the posargs array (if any) and assert that
-    the remaining arguments came after a "--"."""
-    if not posargs:
-        return []
-
-    dash_index = posargs.index("--") if "--" in posargs else len(posargs)
-    if dash_index != 0:
-        unexpected_posargs = posargs[:dash_index]
-        raise _option_set.ArgumentError(
-            None, f"Unknown argument(s) '{' '.join(unexpected_posargs)}'."
-        )
-
-    return list(posargs[dash_index + 1 :])
-
-
-def _finalize(config: NoxConfig) -> None:
-    """Resolve aliases and cross-field options after parsing."""
-    config.posargs = _strip_posargs(config.posargs)
-
-    if config.force_pythons:
-        source = config.provenance("force_pythons")
-        config.set_value("pythons", config.force_pythons, source)
-        config.set_value("extra_pythons", config.force_pythons, source)
-
-    if config.R:
-        # -R wins even over an explicit --reuse-venv (long-standing behavior).
-        config.set_value("reuse_venv", "yes", Source.COMMAND_LINE)
-        config.set_value("reuse_existing_virtualenvs", True, Source.COMMAND_LINE)  # noqa: FBT003
-        config.set_value("no_install", True, Source.COMMAND_LINE)  # noqa: FBT003
-
-    # -r/-N are an alias for --reuse-venv=yes|no; an explicit --reuse-venv wins.
-    if (
-        config.reuse_existing_virtualenvs is not None
-        and config.provenance("reuse_venv") is not Source.COMMAND_LINE
-    ):
-        config.set_value(
-            "reuse_venv",
-            "yes" if config.reuse_existing_virtualenvs else "no",
-            Source.COMMAND_LINE,
-        )
-
-    if config.no_venv:
-        if config.force_venv_backend not in {None, "none"}:
-            msg = "You can not use `--no-venv` with a non-none `--force-venv-backend`"
-            raise ValueError(msg)
-        config.set_value("force_venv_backend", "none", Source.COMMAND_LINE)
-
-    if config.forcecolor and config.nocolor:
-        raise _option_set.ArgumentError(
-            None, "Can not specify both --no-color and --force-color."
-        )
-    config.color = config.forcecolor or (not config.nocolor and sys.stdout.isatty())
-
-
-def merge_noxfile_options(config: NoxConfig, noxfile_config: NoxfileOptions) -> None:
-    """Apply ``nox.options`` (as set by the noxfile) to the parsed config.
-
-    A value explicitly given on the command line (or via an environment
-    variable) always wins over the noxfile.
-    """
-    # sessions/keywords/tags are only taken from the noxfile if none of the
-    # three was given on the command line.
-    trio = ("sessions", "keywords", "tags")
-    cli_selected = any(config.provenance(name) is not Source.DEFAULT for name in trio)
-    _option_set.apply_noxfile_values(
-        config, noxfile_config, skip=trio if cli_selected else ()
-    )
-
-    # The legacy reuse_existing_virtualenvs alias, when enabled in the
-    # noxfile, wins over a noxfile-set reuse_venv (but not the command line).
-    if (
-        noxfile_config.provenance("reuse_existing_virtualenvs") is not Source.DEFAULT
-        and noxfile_config.reuse_existing_virtualenvs
-        and config.provenance("reuse_venv") is not Source.COMMAND_LINE
-    ):
-        config.set_value("reuse_venv", "yes", Source.NOXFILE)
-
-    # The noxfile may have set a PathLike envdir.
-    config.envdir = os.fspath(config.envdir)
-
-
 options = _option_set.Options(
     NoxConfig,
     groups=GROUPS,
     description="Nox is a Python automation toolkit.",
-    finalize=_finalize,
+    finalize=_merge.finalize,
 )
 
 noxfile_options: NoxfileOptions = NoxfileOptions()

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -123,18 +123,6 @@ def _forcecolor_default() -> bool:
     }
 
 
-def _backend_serializer(flag: str) -> Any:
-    """CLI ``choices`` rejects the noxfile-only ``"uv|virtualenv"`` fallback
-    syntax, so such values are skipped; the child re-derives them."""
-
-    def _serialize(value: Any) -> list[str] | None:
-        if value and "|" not in value:
-            return [flag, str(value)]
-        return None
-
-    return _serialize
-
-
 def _serialize_color(value: Any) -> list[str]:
     return ["--forcecolor"] if value else ["--nocolor"]
 
@@ -208,7 +196,6 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--default-venv-backend",
             group="environment",
             env_var="NOX_DEFAULT_VENV_BACKEND",
-            serialize=_backend_serializer("--default-venv-backend"),
             argparse_kwargs={"choices": list(ALL_VENVS)},
             help=(
                 "Virtual environment backend to use by default for Nox sessions, this is"
@@ -272,7 +259,6 @@ class NoxfileOptions(_option_set.OptionsBase):
             "-fb",
             "--force-venv-backend",
             group="environment",
-            serialize=_backend_serializer("--force-venv-backend"),
             argparse_kwargs={"choices": list(ALL_VENVS)},
             help=(
                 "Virtual environment backend to force-use for all Nox sessions in this run,"
@@ -598,7 +584,8 @@ class NoxConfig(NoxfileOptions):
     )
     color: bool = attrs.field(
         default=False,
-        metadata=opt(hidden=True, serialize=_serialize_color),
+        # ALWAYS: the default depends on the parent's tty, so pin it for children.
+        metadata=opt(hidden=True, forward=Forward.ALWAYS, serialize=_serialize_color),
     )
     # The original working directory that Nox was invoked from, since it could
     # be different from the Noxfile's directory.
@@ -634,6 +621,7 @@ def _finalize(config: NoxConfig) -> None:
         config.set_value("extra_pythons", config.force_pythons, source)
 
     if config.R:
+        # -R wins even over an explicit --reuse-venv (long-standing behavior).
         config.set_value("reuse_venv", "yes", Source.COMMAND_LINE)
         config.set_value("reuse_existing_virtualenvs", True, Source.COMMAND_LINE)  # noqa: FBT003
         config.set_value("no_install", True, Source.COMMAND_LINE)  # noqa: FBT003
@@ -695,12 +683,10 @@ def _merge_noxfile_options(config: NoxConfig, noxfile_config: NoxfileOptions) ->
 
 options = _option_set.Options(
     NoxConfig,
-    NoxfileOptions,
     groups=GROUPS,
     description="Nox is a Python automation toolkit.",
     finalize=_finalize,
-    merge=_merge_noxfile_options,
 )
 
-noxfile_options: NoxfileOptions = options.noxfile_namespace()
+noxfile_options: NoxfileOptions = NoxfileOptions()
 """The ``nox.options`` object noxfiles mutate to configure Nox."""

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -26,7 +26,7 @@ import attrs
 import attrs.validators as av
 
 from nox import _completers, _merge, _option_set
-from nox._option_set import Forward, opt
+from nox._option_set import opt
 from nox.virtualenv import ALL_VENVS
 
 if TYPE_CHECKING:
@@ -114,10 +114,6 @@ def _forcecolor_default() -> bool:
     }
 
 
-def _serialize_color(value: Any) -> list[str]:
-    return ["--forcecolor"] if value else ["--nocolor"]
-
-
 @attrs.define(
     kw_only=True,
     on_setattr=[attrs.setters.validate, _option_set.record_noxfile_set],
@@ -178,7 +174,6 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--error-on-external-run",
             negative_flags=("--no-error-on-external-run",),
             group="execution",
-            forward=Forward.ALWAYS,
             help=(
                 "Error if run() is used to execute a program that isn't installed in a"
                 " session's virtualenv."
@@ -192,7 +187,6 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--error-on-missing-interpreters",
             negative_flags=("--no-error-on-missing-interpreters",),
             group="execution",
-            forward=Forward.ALWAYS,
             help="Error instead of skipping sessions if an interpreter can not be located.",
         ),
     )
@@ -256,7 +250,6 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--reuse-existing-virtualenvs",
             negative_flags=("-N", "--no-reuse-existing-virtualenvs"),
             group="environment",
-            forward=Forward.NEVER,  # An alias; the state lives in reuse_venv.
             help="This is an alias for '--reuse-venv=yes|no'.",
         ),
     )
@@ -297,7 +290,6 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--stop-on-first-error",
             negative_flags=("--no-stop-on-first-error",),
             group="execution",
-            forward=Forward.ALWAYS,
             help="Stop after the first error.",
         ),
     )
@@ -320,7 +312,6 @@ class NoxfileOptions(_option_set.OptionsBase):
             "--verbose",
             negative_flags=("--no-verbose",),
             group="reporting",
-            forward=Forward.ALWAYS,
             help="Logs the output of all commands run including commands marked silent.",
         ),
     )
@@ -341,7 +332,6 @@ class NoxConfig(NoxfileOptions):
             "-h",
             "--help",
             group="general",
-            forward=Forward.NEVER,
             help="Show this help message and exit.",
         ),
     )
@@ -350,17 +340,16 @@ class NoxConfig(NoxfileOptions):
         metadata=opt(
             "--version",
             group="general",
-            forward=Forward.NEVER,
             help="Show the Nox version and exit.",
         ),
     )
     script_mode: Literal["none", "fresh", "reuse"] = attrs.field(
         default="reuse",
-        metadata=opt("--script-mode", group="general", forward=Forward.NEVER),
+        metadata=opt("--script-mode", group="general"),
     )
     script_venv_backend: str | None = attrs.field(
         default=None,
-        metadata=opt("--script-venv-backend", group="general", forward=Forward.NEVER),
+        metadata=opt("--script-venv-backend", group="general"),
     )
     noxfile: str = attrs.field(
         default="noxfile.py",
@@ -368,7 +357,6 @@ class NoxConfig(NoxfileOptions):
             "-f",
             "--noxfile",
             group="general",
-            forward=Forward.ALWAYS,
             help="Location of the Python file containing Nox sessions.",
         ),
     )
@@ -388,7 +376,6 @@ class NoxConfig(NoxfileOptions):
             "--list-sessions",
             "--list",
             group="sessions",
-            forward=Forward.NEVER,
             help="List all available sessions and exit.",
         ),
     )
@@ -397,7 +384,6 @@ class NoxConfig(NoxfileOptions):
         metadata=opt(
             "--usage",
             group="sessions",
-            forward=Forward.NEVER,
             argparse_kwargs={"nargs": 1},
             help="Print the full docstring of a given session and exit. Raises if there is no docstring.",
         ),
@@ -407,7 +393,6 @@ class NoxConfig(NoxfileOptions):
         metadata=opt(
             "--json",
             group="sessions",
-            forward=Forward.NEVER,
             help="JSON output formatting. Requires list-sessions currently.",
         ),
     )
@@ -447,7 +432,6 @@ class NoxConfig(NoxfileOptions):
         metadata=opt(
             "--no-venv",
             group="environment",
-            forward=Forward.NEVER,  # An alias; the state lives in force_venv_backend.
             help=(
                 "Runs the selected sessions directly on the current interpreter, without"
                 " creating a venv. This is an alias for '--force-venv-backend none'."
@@ -459,7 +443,6 @@ class NoxConfig(NoxfileOptions):
         metadata=opt(
             "-R",
             group="environment",
-            forward=Forward.NEVER,  # An alias for reuse_venv + no_install.
             help=(
                 "Reuse existing virtualenvs and skip package re-installation."
                 " This is an alias for '--reuse-existing-virtualenvs --no-install'."
@@ -512,7 +495,6 @@ class NoxConfig(NoxfileOptions):
             "--nocolor",
             "--no-color",
             group="reporting",
-            forward=Forward.NEVER,  # The state lives in color.
             help="Disable all color output. Environment variable: NO_COLOR",
         ),
     )
@@ -522,20 +504,15 @@ class NoxConfig(NoxfileOptions):
             "--forcecolor",
             "--force-color",
             group="reporting",
-            forward=Forward.NEVER,  # The state lives in color.
             help="Force color output, even if stdout is not an interactive terminal.",
         ),
     )
-    color: bool = attrs.field(
-        default=False,
-        # ALWAYS: the default depends on the parent's tty, so pin it for children.
-        metadata=opt(hidden=True, forward=Forward.ALWAYS, serialize=_serialize_color),
-    )
+    color: bool = attrs.field(default=False, metadata=opt(hidden=True))
     # The original working directory that Nox was invoked from, since it could
     # be different from the Noxfile's directory.
     invoked_from: str = attrs.field(
         default=attrs.Factory(os.getcwd),
-        metadata=opt(hidden=True, forward=Forward.NEVER),
+        metadata=opt(hidden=True),
     )
 
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -12,293 +12,141 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""All of Nox's configuration options."""
+"""All of Nox's configuration options, defined once as typed attrs classes."""
 
 from __future__ import annotations
 
-__lazy_modules__ = {"itertools", "nox.tasks"}
+__lazy_modules__ = {
+    "argcomplete",
+    "argparse",
+    "itertools",
+    "nox._option_set",
+    "nox.tasks",
+    "nox.virtualenv",
+}
 
 import argparse
-import functools
 import itertools
 import os
 import sys
 from typing import TYPE_CHECKING, Any, Literal
 
 import argcomplete
+import attrs
+import attrs.validators as av
 
 from nox import _option_set
+from nox._option_set import Forward, Source, opt
 from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 from nox.virtualenv import ALL_VENVS
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
-    from nox._option_set import NoxOptions
+    # Opaque validator type; keeps mypy's attrs plugin from inferring field
+    # types from the validator instead of the annotation.
+    Validator = Callable[[Any, "attrs.Attribute[Any]", Any], Any]
 
 
-__all__ = ["ReuseVenvType", "noxfile_options", "options"]
+__all__ = [
+    "NoxConfig",
+    "NoxfileOptions",
+    "ReuseVenvType",
+    "noxfile_options",
+    "options",
+]
 
 
 def __dir__() -> list[str]:
     return __all__
 
 
-# User-specified arguments will be a regular string
-class DefaultStr(str):
-    __slots__ = ()
-
-
 ReuseVenvType = Literal["no", "yes", "never", "always"]
 
-options = _option_set.OptionSet(
-    description="Nox is a Python automation toolkit.", add_help=False
+av_opt_str: Validator = av.optional(av.instance_of(str))
+av_opt_path: Validator = av.optional(
+    av.or_(av.instance_of(str), av.instance_of(os.PathLike))  # type: ignore[type-abstract]
 )
+av_opt_list_str: Validator = av.optional(
+    av.deep_iterable(
+        member_validator=av.instance_of(str),
+        iterable_validator=av.not_(av.instance_of(str)),
+    )
+)
+av_opt_bool: Validator = av.optional(av.instance_of(bool))
+av_bool: Validator = av.instance_of(bool)
 
-options.add_groups(
-    _option_set.OptionGroup(
-        "general",
+GROUPS: dict[str, tuple[str, str]] = {
+    "general": (
         "General options",
         "These are general arguments used when invoking Nox.",
     ),
-    _option_set.OptionGroup(
-        "sessions",
+    "sessions": (
         "Sessions options",
         "These arguments are used to control which Nox session(s) to execute.",
     ),
-    _option_set.OptionGroup(
-        "python",
+    "python": (
         "Python options",
         "These arguments are used to control which Python version(s) to use.",
     ),
-    _option_set.OptionGroup(
-        "environment",
+    "environment": (
         "Environment options",
         "These arguments are used to control Nox's creation and usage of virtual"
         " environments.",
     ),
-    _option_set.OptionGroup(
-        "execution",
+    "execution": (
         "Execution options",
         "These arguments are used to control execution of sessions.",
     ),
-    _option_set.OptionGroup(
-        "reporting",
+    "reporting": (
         "Reporting options",
         "These arguments are used to control Nox's reporting during execution.",
     ),
-)
+}
 
 
-def _sessions_merge_func(
-    key: str, command_args: argparse.Namespace, noxfile_args: NoxOptions
-) -> list[str]:
-    """Only return the Noxfile value for sessions/keywords if neither sessions,
-    keywords or tags are specified on the command-line.
-
-    Args:
-        key (str): This function is used for both the "sessions" and "keywords"
-            options, this allows using ``funtools.partial`` to pass the
-            same function for both options.
-        command_args (_option_set.Namespace): The options specified on the
-            command-line.
-        noxfile_Args (NoxOptions): The options specified in the
-            Noxfile."""
-    # A bare flag parses to an empty value, which is still an explicit choice
-    # that must win over the Noxfile, so compare against None here.
-    if (
-        command_args.sessions is None
-        and command_args.keywords is None
-        and command_args.tags is None
-    ):
-        return getattr(noxfile_args, key)  # type: ignore[no-any-return]
-    return getattr(command_args, key)  # type: ignore[no-any-return]
+def _error_on_missing_interpreters_default() -> bool:
+    return "CI" in os.environ
 
 
-def _default_venv_backend_merge_func(
-    command_args: argparse.Namespace, noxfile_args: NoxOptions
-) -> str:
-    """Merge default_venv_backend from command args and Noxfile. Default is "virtualenv".
-
-    Args:
-        command_args (_option_set.Namespace): The options specified on the
-            command-line.
-        noxfile_Args (NoxOptions): The options specified in the
-            Noxfile.
-    """
-    return (
-        command_args.default_venv_backend
-        or noxfile_args.default_venv_backend
-        or "virtualenv"
-    )
+def _nocolor_default() -> bool:
+    return "NO_COLOR" in os.environ
 
 
-def _force_venv_backend_merge_func(
-    command_args: argparse.Namespace, noxfile_args: NoxOptions
-) -> str:
-    """Merge force_venv_backend from command args and Noxfile. Default is None.
-
-    Args:
-        command_args (_option_set.Namespace): The options specified on the
-            command-line.
-        noxfile_Args (NoxOptions): The options specified in the
-            Noxfile.
-    """
-    if command_args.no_venv:
-        if (
-            command_args.force_venv_backend is not None
-            and command_args.force_venv_backend != "none"
-        ):
-            msg = "You can not use `--no-venv` with a non-none `--force-venv-backend`"
-            raise ValueError(msg)
-        return "none"
-    return command_args.force_venv_backend or noxfile_args.force_venv_backend  # type: ignore[return-value]
+def _forcecolor_default() -> bool:
+    return os.environ.get("FORCE_COLOR", "").lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    }
 
 
-def _envdir_merge_func(
-    command_args: argparse.Namespace, noxfile_args: NoxOptions
-) -> str:
-    """Ensure that there is always some envdir.
+def _backend_serializer(flag: str) -> Any:
+    """CLI ``choices`` rejects the noxfile-only ``"uv|virtualenv"`` fallback
+    syntax, so such values are skipped; the child re-derives them."""
 
-    Args:
-        command_args (_option_set.Namespace): The options specified on the
-            command-line.
-        noxfile_Args (NoxOptions): The options specified in the
-            Noxfile.
-    """
-    return os.fspath(command_args.envdir or noxfile_args.envdir or ".nox")
+    def _serialize(value: Any) -> list[str] | None:
+        if value and "|" not in value:
+            return [flag, str(value)]
+        return None
+
+    return _serialize
 
 
-def _reuse_venv_merge_func(
-    command_args: argparse.Namespace, noxfile_args: NoxOptions
-) -> ReuseVenvType:
-    """Merge reuse_venv from command args and Noxfile while maintaining
-    backwards compatibility with reuse_existing_virtualenvs. Default is "no".
-
-    The -r/-N/-R aliases are already folded into the command-line reuse_venv
-    by :func:`_reuse_venv_finalizer`, so any command-line value wins over the
-    Noxfile.
-
-    Args:
-        command_args (_option_set.Namespace): The options specified on the
-            command-line.
-        noxfile_Args (NoxOptions): The options specified in the
-            Noxfile.
-    """
-    if command_args.reuse_venv is not None:
-        return command_args.reuse_venv  # type: ignore[no-any-return]
-    # back-compat scenario with reuse_existing_virtualenvs in the Noxfile
-    if noxfile_args.reuse_existing_virtualenvs:
-        return "yes"
-    return noxfile_args.reuse_venv or "no"
-
-
-def default_env_var_list_factory(env_var: str) -> Callable[[], list[str] | None]:
-    """Looks at the env var to set the default value for a list of env vars.
-
-    Args:
-        env_var (str): The name of the environment variable to look up.
-
-    Returns:
-        A callback that retrieves a list from a comma-delimited environment variable.
-    """
-
-    def _default_list() -> list[str] | None:
-        env_value = os.environ.get(env_var)
-        return env_value.split(",") if env_value else None
-
-    return _default_list
-
-
-def _color_finalizer(_value: bool, args: argparse.Namespace) -> bool:  # noqa: FBT001
-    """Figures out the correct value for "color" based on the two color flags.
-
-    Args:
-        value (bool): The current value of the "color" option.
-        args (_option_set.Namespace): The values for all options.
-
-    Returns:
-        The new value for the "color" option.
-    """
-    if args.forcecolor and args.nocolor:
-        raise _option_set.ArgumentError(
-            None, "Can not specify both --no-color and --force-color."
-        )
-
-    if args.forcecolor:
-        return True
-
-    if args.nocolor or "NO_COLOR" in os.environ:
-        return False
-
-    return sys.stdout.isatty()
-
-
-def _force_pythons_finalizer(
-    value: Sequence[str], args: argparse.Namespace
-) -> Sequence[str]:
-    """Propagate ``--force-python`` to ``--python`` and ``--extra-python``."""
-    if value:
-        args.pythons = args.extra_pythons = value
-    return value
-
-
-def _R_finalizer(value: bool, args: argparse.Namespace) -> bool:  # noqa: FBT001
-    """Propagate -R to --reuse-existing-virtualenvs and --no-install."""
-    if value:
-        args.reuse_existing_virtualenvs = args.no_install = value
-    return value
-
-
-def _reuse_venv_finalizer(
-    value: ReuseVenvType | None, args: argparse.Namespace
-) -> ReuseVenvType | None:
-    """Fold the -r/-N/-R aliases into --reuse-venv. An explicit --reuse-venv
-    wins over -r and -N given alongside it, but -R always forces reuse."""
-    if args.R:
-        return "yes"
-    if value is not None:
-        return value
-    if args.no_reuse_existing_virtualenvs:
-        return "no"
-    if args.reuse_existing_virtualenvs:
-        return "yes"
-    return None
-
-
-def _posargs_finalizer(
-    value: Sequence[Any], _args: argparse.Namespace
-) -> Sequence[Any] | list[Any]:
-    """Removes the leading "--"s in the posargs array (if any) and asserts that
-    remaining arguments came after a "--".
-    """
-    posargs = value
-    if not posargs:
-        return []
-
-    if "--" not in posargs:
-        unexpected_posargs = posargs
-        raise _option_set.ArgumentError(
-            None, f"Unknown argument(s) '{' '.join(unexpected_posargs)}'."
-        )
-
-    dash_index = posargs.index("--")
-    if dash_index != 0:
-        unexpected_posargs = posargs[0:dash_index]
-        raise _option_set.ArgumentError(
-            None, f"Unknown argument(s) '{' '.join(unexpected_posargs)}'."
-        )
-
-    return posargs[dash_index + 1 :]
+def _serialize_color(value: Any) -> list[str]:
+    return ["--forcecolor"] if value else ["--nocolor"]
 
 
 def _python_completer(
     prefix: str,  # noqa: ARG001
-    parsed_args: argparse.Namespace,
+    parsed_args: argparse.Namespace | NoxConfig,
     **kwargs: Any,
 ) -> Iterable[str]:
-    module = load_nox_module(parsed_args)
-    manifest = discover_manifest(module, parsed_args)
+    config = options.expand(parsed_args)
+    module = load_nox_module(config)
+    manifest = discover_manifest(module, config)
     return filter(
         None,
         (
@@ -310,13 +158,14 @@ def _python_completer(
 
 def _session_completer(
     prefix: str,  # noqa: ARG001
-    parsed_args: argparse.Namespace,
+    parsed_args: argparse.Namespace | NoxConfig,
     **kwargs: Any,
 ) -> Iterable[str]:
-    parsed_args.list_sessions = True
-    module = load_nox_module(parsed_args)
-    manifest = discover_manifest(module, parsed_args)
-    filtered_manifest = filter_manifest(manifest, parsed_args)
+    config = options.expand(parsed_args)
+    config.list_sessions = True
+    module = load_nox_module(config)
+    manifest = discover_manifest(module, config)
+    filtered_manifest = filter_manifest(manifest, config)
     if isinstance(filtered_manifest, int):
         return []
     return (
@@ -326,384 +175,532 @@ def _session_completer(
 
 def _tag_completer(
     prefix: str,  # noqa: ARG001
-    parsed_args: argparse.Namespace,
+    parsed_args: argparse.Namespace | NoxConfig,
     **kwargs: Any,
 ) -> Iterable[str]:
-    module = load_nox_module(parsed_args)
-    manifest = discover_manifest(module, parsed_args)
+    config = options.expand(parsed_args)
+    module = load_nox_module(config)
+    manifest = discover_manifest(module, config)
     return itertools.chain.from_iterable(
         filter(None, (session.tags for session, _ in manifest.list_all_sessions()))
     )
 
 
-options.add_options(
-    _option_set.Option(
-        "help",
-        "-h",
-        "--help",
-        group=options.groups["general"],
-        action="store_true",
-        help="Show this help message and exit.",
-    ),
-    _option_set.Option(
-        "version",
-        "--version",
-        group=options.groups["general"],
-        action="store_true",
-        help="Show the Nox version and exit.",
-    ),
-    _option_set.Option(
-        "script_mode",
-        "--script-mode",
-        group=options.groups["general"],
-        choices=["none", "fresh", "reuse"],
+@attrs.define(
+    kw_only=True,
+    on_setattr=[attrs.setters.validate, _option_set.record_noxfile_set],
+)
+class NoxfileOptions(_option_set.OptionsBase):
+    """Options that are configurable in the Noxfile.
+
+    By setting properties on ``nox.options`` you can specify command line
+    arguments in your Noxfile. If an argument is specified in both the Noxfile
+    and on the command line, the command line arguments take precedence.
+
+    See :doc:`usage` for more details on these settings and their effect.
+    """
+
+    default_venv_backend: str | None = attrs.field(
+        default=None,
+        validator=av_opt_str,
+        metadata=opt(
+            "-db",
+            "--default-venv-backend",
+            group="environment",
+            env_var="NOX_DEFAULT_VENV_BACKEND",
+            serialize=_backend_serializer("--default-venv-backend"),
+            argparse_kwargs={"choices": list(ALL_VENVS)},
+            help=(
+                "Virtual environment backend to use by default for Nox sessions, this is"
+                f" ``'virtualenv'`` by default but any of ``{list(ALL_VENVS)!r}`` are accepted."
+            ),
+        ),
+    )
+    download_python: Literal["auto", "never", "always"] | None = attrs.field(
+        default=None,
+        validator=av.optional(av.in_(["auto", "never", "always"])),
+        metadata=opt(
+            "--download-python",
+            group="python",
+            env_var="NOX_DOWNLOAD_PYTHON",
+            help=(
+                "When should nox download python standalone builds to run the sessions,"
+                " defaults to 'auto' which will download when the version requested can't"
+                " be found in the running environment. Environment variable: NOX_DOWNLOAD_PYTHON"
+            ),
+        ),
+    )
+    envdir: str | os.PathLike[str] | None = attrs.field(
+        default=None,
+        validator=av_opt_path,
+        metadata=opt(
+            "--envdir",
+            group="environment",
+            completer=argcomplete.completers.DirectoriesCompleter(),  # type: ignore[no-untyped-call]
+            help="Directory where Nox will store virtualenvs, this is ``.nox`` by default.",
+        ),
+    )
+    error_on_external_run: bool = attrs.field(
+        default=False,
+        validator=av_bool,
+        metadata=opt(
+            "--error-on-external-run",
+            negative_flags=("--no-error-on-external-run",),
+            group="execution",
+            forward=Forward.ALWAYS,
+            help=(
+                "Error if run() is used to execute a program that isn't installed in a"
+                " session's virtualenv."
+            ),
+        ),
+    )
+    error_on_missing_interpreters: bool = attrs.field(
+        default=attrs.Factory(_error_on_missing_interpreters_default),
+        validator=av_bool,
+        metadata=opt(
+            "--error-on-missing-interpreters",
+            negative_flags=("--no-error-on-missing-interpreters",),
+            group="execution",
+            forward=Forward.ALWAYS,
+            help="Error instead of skipping sessions if an interpreter can not be located.",
+        ),
+    )
+    force_venv_backend: str | None = attrs.field(
+        default=None,
+        validator=av_opt_str,
+        metadata=opt(
+            "-fb",
+            "--force-venv-backend",
+            group="environment",
+            serialize=_backend_serializer("--force-venv-backend"),
+            argparse_kwargs={"choices": list(ALL_VENVS)},
+            help=(
+                "Virtual environment backend to force-use for all Nox sessions in this run,"
+                " overriding any other venv backend declared in the Noxfile and ignoring"
+                f" the default backend. Any of ``{list(ALL_VENVS)!r}`` are accepted."
+            ),
+        ),
+    )
+    keywords: str | None = attrs.field(
+        default=None,
+        validator=av_opt_str,
+        metadata=opt(
+            "-k",
+            "--keywords",
+            group="sessions",
+            completer=argcomplete.completers.ChoicesCompleter(()),  # type: ignore[no-untyped-call]
+            help="Only run sessions that match the given expression.",
+        ),
+    )
+    pythons: list[str] | None = attrs.field(
+        default=None,
+        validator=av_opt_list_str,
+        metadata=opt(
+            "-p",
+            "--pythons",
+            "--python",
+            group="python",
+            env_var="NOXPYTHON",
+            completer=_python_completer,
+            help=(
+                "Only run sessions that use the given python interpreter versions."
+                " Environment variable: NOXPYTHON"
+            ),
+        ),
+    )
+    report: str | None = attrs.field(
+        default=None,
+        validator=av_opt_str,
+        metadata=opt(
+            "--report",
+            group="reporting",
+            completer=argcomplete.completers.FilesCompleter(("json",)),  # type: ignore[no-untyped-call]
+            help="Output a report of all sessions to the given filename.",
+        ),
+    )
+    reuse_existing_virtualenvs: bool | None = attrs.field(
+        default=None,
+        validator=av_opt_bool,
+        metadata=opt(
+            "-r",
+            "--reuse-existing-virtualenvs",
+            negative_flags=("-N", "--no-reuse-existing-virtualenvs"),
+            group="environment",
+            forward=Forward.NEVER,  # An alias; the state lives in reuse_venv.
+            help="This is an alias for '--reuse-venv=yes|no'.",
+        ),
+    )
+    reuse_venv: ReuseVenvType | None = attrs.field(
+        default=None,
+        validator=av.optional(av.in_(["no", "yes", "never", "always"])),
+        metadata=opt(
+            "--reuse-venv",
+            group="environment",
+            help=(
+                "Controls existing virtualenvs recreation. This is ``'no'`` by"
+                " default, but any of ``('yes', 'no', 'always', 'never')`` are accepted."
+            ),
+        ),
+    )
+    sessions: list[str] | None = attrs.field(
+        default=None,
+        validator=av_opt_list_str,
+        metadata=opt(
+            "-s",
+            "-e",
+            "--sessions",
+            "--session",
+            group="sessions",
+            env_var="NOXSESSION",
+            completer=_session_completer,
+            help=(
+                "Which sessions to run. By default, all sessions will run."
+                " Environment variable: NOXSESSION"
+            ),
+        ),
+    )
+    stop_on_first_error: bool = attrs.field(
+        default=False,
+        validator=av_bool,
+        metadata=opt(
+            "-x",
+            "--stop-on-first-error",
+            negative_flags=("--no-stop-on-first-error",),
+            group="execution",
+            forward=Forward.ALWAYS,
+            help="Stop after the first error.",
+        ),
+    )
+    tags: list[str] | None = attrs.field(
+        default=None,
+        validator=av_opt_list_str,
+        metadata=opt(
+            "-t",
+            "--tags",
+            group="sessions",
+            completer=_tag_completer,
+            help="Only run sessions with the given tags.",
+        ),
+    )
+    verbose: bool = attrs.field(
+        default=False,
+        validator=av_bool,
+        metadata=opt(
+            "-v",
+            "--verbose",
+            negative_flags=("--no-verbose",),
+            group="reporting",
+            forward=Forward.ALWAYS,
+            help="Logs the output of all commands run including commands marked silent.",
+        ),
+    )
+
+
+@attrs.define(kw_only=True, on_setattr=attrs.setters.validate)
+class NoxConfig(NoxfileOptions):
+    """The full configuration: every CLI option, including the noxfile-settable
+    ones inherited from :class:`NoxfileOptions`.
+
+    An instance of this class is the ``global_config`` threaded through the
+    workflow tasks and sessions.
+    """
+
+    help: bool = attrs.field(
+        default=False,
+        metadata=opt(
+            "-h",
+            "--help",
+            group="general",
+            forward=Forward.NEVER,
+            help="Show this help message and exit.",
+        ),
+    )
+    version: bool = attrs.field(
+        default=False,
+        metadata=opt(
+            "--version",
+            group="general",
+            forward=Forward.NEVER,
+            help="Show the Nox version and exit.",
+        ),
+    )
+    script_mode: Literal["none", "fresh", "reuse"] = attrs.field(
         default="reuse",
-    ),
-    _option_set.Option(
-        "script_venv_backend",
-        "--script-venv-backend",
-        group=options.groups["general"],
-    ),
-    _option_set.Option(
-        "list_sessions",
-        "-l",
-        "--list-sessions",
-        "--list",
-        group=options.groups["sessions"],
-        action="store_true",
-        help="List all available sessions and exit.",
-    ),
-    _option_set.Option(
-        "usage",
-        "--usage",
-        group=options.groups["sessions"],
-        nargs=1,
-        help="Print the full docstring of a given session and exit. Raises if there is no docstring.",
-    ),
-    _option_set.Option(
-        "json",
-        "--json",
-        group=options.groups["sessions"],
-        action="store_true",
-        help="JSON output formatting. Requires list-sessions currently.",
-    ),
-    _option_set.Option(
-        "sessions",
-        "-s",
-        "-e",
-        "--sessions",
-        "--session",
-        group=options.groups["sessions"],
-        noxfile=True,
-        merge_func=functools.partial(_sessions_merge_func, "sessions"),
-        nargs="*",
-        default=default_env_var_list_factory("NOXSESSION"),
-        help=(
-            "Which sessions to run. By default, all sessions will run."
-            " Environment variable: NOXSESSION"
+        metadata=opt("--script-mode", group="general", forward=Forward.NEVER),
+    )
+    script_venv_backend: str | None = attrs.field(
+        default=None,
+        metadata=opt("--script-venv-backend", group="general", forward=Forward.NEVER),
+    )
+    noxfile: str = attrs.field(
+        default="noxfile.py",
+        metadata=opt(
+            "-f",
+            "--noxfile",
+            group="general",
+            forward=Forward.ALWAYS,
+            help="Location of the Python file containing Nox sessions.",
         ),
-        completer=_session_completer,
-    ),
-    _option_set.Option(
-        "pythons",
-        "-p",
-        "--pythons",
-        "--python",
-        group=options.groups["python"],
-        noxfile=True,
-        nargs="*",
-        default=default_env_var_list_factory("NOXPYTHON"),
-        help=(
-            "Only run sessions that use the given python interpreter versions."
-            " Environment variable: NOXPYTHON"
+    )
+    posargs: list[str] = attrs.field(
+        factory=list,
+        metadata=opt(
+            group="general",
+            positional=True,
+            argparse_kwargs={"nargs": argparse.REMAINDER},
+            help="Arguments following ``--`` that are passed through to the session(s).",
         ),
-        completer=_python_completer,
-    ),
-    _option_set.Option(
-        "keywords",
-        "-k",
-        "--keywords",
-        group=options.groups["sessions"],
-        noxfile=True,
-        merge_func=functools.partial(_sessions_merge_func, "keywords"),
-        help="Only run sessions that match the given expression.",
-        completer=argcomplete.completers.ChoicesCompleter(()),  # type: ignore[no-untyped-call]
-    ),
-    _option_set.Option(
-        "tags",
-        "-t",
-        "--tags",
-        group=options.groups["sessions"],
-        noxfile=True,
-        merge_func=functools.partial(_sessions_merge_func, "tags"),
-        nargs="*",
-        help="Only run sessions with the given tags.",
-        completer=_tag_completer,
-    ),
-    _option_set.Option(
-        "posargs",
-        "posargs",
-        group=options.groups["general"],
-        nargs=argparse.REMAINDER,
-        help="Arguments following ``--`` that are passed through to the session(s).",
-        finalizer_func=_posargs_finalizer,
-    ),
-    *_option_set.make_flag_pair(
-        "verbose",
-        ("-v", "--verbose"),
-        ("--no-verbose",),
-        group=options.groups["reporting"],
-        help="Logs the output of all commands run including commands marked silent.",
-    ),
-    _option_set.Option(
-        "add_timestamp",
-        "-ts",
-        "--add-timestamp",
-        group=options.groups["reporting"],
-        action="store_true",
-        help="Adds a timestamp to logged output.",
-    ),
-    _option_set.Option(
-        "default_venv_backend",
-        "-db",
-        "--default-venv-backend",
-        group=options.groups["environment"],
-        noxfile=True,
-        default=lambda: os.environ.get("NOX_DEFAULT_VENV_BACKEND"),
-        merge_func=_default_venv_backend_merge_func,
-        help=(
-            "Virtual environment backend to use by default for Nox sessions, this is"
-            f" ``'virtualenv'`` by default but any of ``{list(ALL_VENVS)!r}`` are accepted."
-        ),
-        choices=list(ALL_VENVS),
-    ),
-    _option_set.Option(
-        "force_venv_backend",
-        "-fb",
-        "--force-venv-backend",
-        group=options.groups["environment"],
-        noxfile=True,
-        merge_func=_force_venv_backend_merge_func,
-        help=(
-            "Virtual environment backend to force-use for all Nox sessions in this run,"
-            " overriding any other venv backend declared in the Noxfile and ignoring"
-            f" the default backend. Any of ``{list(ALL_VENVS)!r}`` are accepted."
-        ),
-        choices=list(ALL_VENVS),
-    ),
-    _option_set.Option(
-        "no_venv",
-        "--no-venv",
-        group=options.groups["environment"],
+    )
+    list_sessions: bool = attrs.field(
         default=False,
-        action="store_true",
-        help=(
-            "Runs the selected sessions directly on the current interpreter, without"
-            " creating a venv. This is an alias for '--force-venv-backend none'."
+        metadata=opt(
+            "-l",
+            "--list-sessions",
+            "--list",
+            group="sessions",
+            forward=Forward.NEVER,
+            help="List all available sessions and exit.",
         ),
-    ),
-    _option_set.Option(
-        "reuse_venv",
-        "--reuse-venv",
-        group=options.groups["environment"],
-        noxfile=True,
-        merge_func=_reuse_venv_merge_func,
-        finalizer_func=_reuse_venv_finalizer,
-        help=(
-            "Controls existing virtualenvs recreation. This is ``'no'`` by"
-            " default, but any of ``('yes', 'no', 'always', 'never')`` are accepted."
+    )
+    usage: list[str] | None = attrs.field(
+        default=None,
+        metadata=opt(
+            "--usage",
+            group="sessions",
+            forward=Forward.NEVER,
+            argparse_kwargs={"nargs": 1},
+            help="Print the full docstring of a given session and exit. Raises if there is no docstring.",
         ),
-        choices=["yes", "no", "always", "never"],
-    ),
-    *_option_set.make_flag_pair(
-        "reuse_existing_virtualenvs",
-        ("-r", "--reuse-existing-virtualenvs"),
-        (
-            "-N",
-            "--no-reuse-existing-virtualenvs",
-        ),
-        group=options.groups["environment"],
-        help="This is an alias for '--reuse-venv=yes|no'.",
-    ),
-    _option_set.Option(
-        "R",
-        "-R",
+    )
+    json: bool = attrs.field(
         default=False,
-        group=options.groups["environment"],
-        action="store_true",
-        help=(
-            "Reuse existing virtualenvs and skip package re-installation."
-            " This is an alias for '--reuse-existing-virtualenvs --no-install'."
+        metadata=opt(
+            "--json",
+            group="sessions",
+            forward=Forward.NEVER,
+            help="JSON output formatting. Requires list-sessions currently.",
         ),
-        finalizer_func=_R_finalizer,
-    ),
-    _option_set.Option(
-        "noxfile",
-        "-f",
-        "--noxfile",
-        group=options.groups["general"],
-        default=DefaultStr("noxfile.py"),
-        help="Location of the Python file containing Nox sessions.",
-    ),
-    _option_set.Option(
-        "envdir",
-        "--envdir",
-        noxfile=True,
-        merge_func=_envdir_merge_func,
-        group=options.groups["environment"],
-        help="Directory where Nox will store virtualenvs, this is ``.nox`` by default.",
-        completer=argcomplete.completers.DirectoriesCompleter(),  # type: ignore[no-untyped-call]
-    ),
-    _option_set.Option(
-        "download_python",
-        "--download-python",
-        noxfile=True,
-        group=options.groups["python"],
-        default=lambda: os.getenv("NOX_DOWNLOAD_PYTHON"),
-        help=(
-            "When should nox download python standalone builds to run the sessions,"
-            " defaults to 'auto' which will download when the version requested can't"
-            " be found in the running environment. Environment variable: NOX_DOWNLOAD_PYTHON"
+    )
+    extra_pythons: list[str] | None = attrs.field(
+        default=None,
+        metadata=opt(
+            "--extra-pythons",
+            "--extra-python",
+            group="python",
+            env_var="NOXEXTRAPYTHON",
+            completer=_python_completer,
+            help=(
+                "Additionally, run sessions using the given python interpreter versions."
+                " Environment variable: NOXEXTRAPYTHON"
+            ),
         ),
-        choices=["auto", "never", "always"],
-    ),
-    _option_set.Option(
-        "extra_pythons",
-        "--extra-pythons",
-        "--extra-python",
-        group=options.groups["python"],
-        nargs="*",
-        default=default_env_var_list_factory("NOXEXTRAPYTHON"),
-        help=(
-            "Additionally, run sessions using the given python interpreter versions."
-            " Environment variable: NOXEXTRAPYTHON"
+    )
+    force_pythons: list[str] | None = attrs.field(
+        default=None,
+        metadata=opt(
+            "-P",
+            "--force-pythons",
+            "--force-python",
+            group="python",
+            env_var="NOXFORCEPYTHON",
+            completer=_python_completer,
+            help=(
+                "Run sessions with the given interpreters instead of those listed in the"
+                " Noxfile. This is a shorthand for ``--python=X.Y --extra-python=X.Y``."
+                " It will also work on sessions that don't have any interpreter parametrized."
+                " Environment variable: NOXFORCEPYTHON"
+            ),
         ),
-        completer=_python_completer,
-    ),
-    _option_set.Option(
-        "force_pythons",
-        "-P",
-        "--force-pythons",
-        "--force-python",
-        group=options.groups["python"],
-        nargs="*",
-        default=default_env_var_list_factory("NOXFORCEPYTHON"),
-        help=(
-            "Run sessions with the given interpreters instead of those listed in the"
-            " Noxfile. This is a shorthand for ``--python=X.Y --extra-python=X.Y``."
-            " It will also work on sessions that don't have any interpreter parametrized."
-            " Environment variable: NOXFORCEPYTHON"
-        ),
-        finalizer_func=_force_pythons_finalizer,
-        completer=_python_completer,
-    ),
-    *_option_set.make_flag_pair(
-        "stop_on_first_error",
-        ("-x", "--stop-on-first-error"),
-        ("--no-stop-on-first-error",),
-        group=options.groups["execution"],
-        help="Stop after the first error.",
-    ),
-    *_option_set.make_flag_pair(
-        "error_on_missing_interpreters",
-        ("--error-on-missing-interpreters",),
-        ("--no-error-on-missing-interpreters",),
-        group=options.groups["execution"],
-        help="Error instead of skipping sessions if an interpreter can not be located.",
-        default=lambda: "CI" in os.environ,
-    ),
-    *_option_set.make_flag_pair(
-        "error_on_external_run",
-        ("--error-on-external-run",),
-        ("--no-error-on-external-run",),
-        group=options.groups["execution"],
-        help=(
-            "Error if run() is used to execute a program that isn't installed in a"
-            " session's virtualenv."
-        ),
-    ),
-    _option_set.Option(
-        "install_only",
-        "--install-only",
-        group=options.groups["execution"],
-        action="store_true",
-        help="Skip session.run invocations in the Noxfile.",
-    ),
-    _option_set.Option(
-        "no_install",
-        "--no-install",
+    )
+    no_venv: bool = attrs.field(
         default=False,
-        group=options.groups["execution"],
-        action="store_true",
-        help=(
-            "Skip invocations of session methods for installing packages"
-            " (session.install, session.conda_install, session.run_install)"
-            " when a virtualenv is being reused."
+        metadata=opt(
+            "--no-venv",
+            group="environment",
+            forward=Forward.NEVER,  # An alias; the state lives in force_venv_backend.
+            help=(
+                "Runs the selected sessions directly on the current interpreter, without"
+                " creating a venv. This is an alias for '--force-venv-backend none'."
+            ),
         ),
-    ),
-    _option_set.Option(
-        "report",
-        "--report",
-        group=options.groups["reporting"],
-        noxfile=True,
-        help="Output a report of all sessions to the given filename.",
-        completer=argcomplete.completers.FilesCompleter(("json",)),  # type: ignore[no-untyped-call]
-    ),
-    _option_set.Option(
-        "non_interactive",
-        "--non-interactive",
-        group=options.groups["execution"],
-        action="store_true",
-        help=(
-            "Force session.interactive to always be False, even in interactive"
-            " sessions."
+    )
+    R: bool = attrs.field(
+        default=False,
+        metadata=opt(
+            "-R",
+            group="environment",
+            forward=Forward.NEVER,  # An alias for reuse_venv + no_install.
+            help=(
+                "Reuse existing virtualenvs and skip package re-installation."
+                " This is an alias for '--reuse-existing-virtualenvs --no-install'."
+            ),
         ),
-    ),
-    _option_set.Option(
-        "nocolor",
-        "--nocolor",
-        "--no-color",
-        group=options.groups["reporting"],
-        default=lambda: "NO_COLOR" in os.environ,
-        action="store_true",
-        help="Disable all color output. Environment variable: NO_COLOR",
-    ),
-    _option_set.Option(
-        "forcecolor",
-        "--forcecolor",
-        "--force-color",
-        group=options.groups["reporting"],
-        default=lambda: (
-            os.environ.get("FORCE_COLOR", "").lower()
-            not in {"", "0", "false", "no", "off"}
+    )
+    install_only: bool = attrs.field(
+        default=False,
+        metadata=opt(
+            "--install-only",
+            group="execution",
+            help="Skip session.run invocations in the Noxfile.",
         ),
-        action="store_true",
-        help="Force color output, even if stdout is not an interactive terminal.",
-    ),
-    _option_set.Option(
-        "color",
-        "--color",
-        group=options.groups["reporting"],
-        hidden=True,
-        finalizer_func=_color_finalizer,
-    ),
-    # Stores the original working directory that Nox was invoked from,
-    # since it could be different from the Noxfile's directory.
-    _option_set.Option(
-        "invoked_from",
-        group=None,
-        hidden=True,
-        default=os.getcwd,
-    ),
+    )
+    no_install: bool = attrs.field(
+        default=False,
+        metadata=opt(
+            "--no-install",
+            group="execution",
+            help=(
+                "Skip invocations of session methods for installing packages"
+                " (session.install, session.conda_install, session.run_install)"
+                " when a virtualenv is being reused."
+            ),
+        ),
+    )
+    non_interactive: bool = attrs.field(
+        default=False,
+        metadata=opt(
+            "--non-interactive",
+            group="execution",
+            help=(
+                "Force session.interactive to always be False, even in interactive"
+                " sessions."
+            ),
+        ),
+    )
+    add_timestamp: bool = attrs.field(
+        default=False,
+        metadata=opt(
+            "-ts",
+            "--add-timestamp",
+            group="reporting",
+            help="Adds a timestamp to logged output.",
+        ),
+    )
+    nocolor: bool = attrs.field(
+        default=attrs.Factory(_nocolor_default),
+        metadata=opt(
+            "--nocolor",
+            "--no-color",
+            group="reporting",
+            forward=Forward.NEVER,  # The state lives in color.
+            help="Disable all color output. Environment variable: NO_COLOR",
+        ),
+    )
+    forcecolor: bool = attrs.field(
+        default=attrs.Factory(_forcecolor_default),
+        metadata=opt(
+            "--forcecolor",
+            "--force-color",
+            group="reporting",
+            forward=Forward.NEVER,  # The state lives in color.
+            help="Force color output, even if stdout is not an interactive terminal.",
+        ),
+    )
+    color: bool = attrs.field(
+        default=False,
+        metadata=opt(hidden=True, serialize=_serialize_color),
+    )
+    # The original working directory that Nox was invoked from, since it could
+    # be different from the Noxfile's directory.
+    invoked_from: str = attrs.field(
+        default=attrs.Factory(os.getcwd),
+        metadata=opt(hidden=True, forward=Forward.NEVER),
+    )
+
+
+def _strip_posargs(posargs: Sequence[str]) -> list[str]:
+    """Remove the leading "--" from the posargs array (if any) and assert that
+    the remaining arguments came after a "--"."""
+    if not posargs:
+        return []
+
+    dash_index = posargs.index("--") if "--" in posargs else len(posargs)
+    if dash_index != 0:
+        unexpected_posargs = posargs[:dash_index]
+        raise _option_set.ArgumentError(
+            None, f"Unknown argument(s) '{' '.join(unexpected_posargs)}'."
+        )
+
+    return list(posargs[dash_index + 1 :])
+
+
+def _finalize(config: NoxConfig) -> None:
+    """Resolve aliases and cross-field options after parsing."""
+    config.posargs = _strip_posargs(config.posargs)
+
+    if config.force_pythons:
+        source = config.provenance("force_pythons")
+        config.set_value("pythons", config.force_pythons, source)
+        config.set_value("extra_pythons", config.force_pythons, source)
+
+    if config.R:
+        config.set_value("reuse_venv", "yes", Source.COMMAND_LINE)
+        config.set_value("reuse_existing_virtualenvs", True, Source.COMMAND_LINE)  # noqa: FBT003
+        config.set_value("no_install", True, Source.COMMAND_LINE)  # noqa: FBT003
+
+    # -r/-N are an alias for --reuse-venv=yes|no; an explicit --reuse-venv wins.
+    if (
+        config.reuse_existing_virtualenvs is not None
+        and config.provenance("reuse_venv") is not Source.COMMAND_LINE
+    ):
+        config.set_value(
+            "reuse_venv",
+            "yes" if config.reuse_existing_virtualenvs else "no",
+            Source.COMMAND_LINE,
+        )
+
+    if config.no_venv:
+        if config.force_venv_backend not in {None, "none"}:
+            msg = "You can not use `--no-venv` with a non-none `--force-venv-backend`"
+            raise ValueError(msg)
+        config.set_value("force_venv_backend", "none", Source.COMMAND_LINE)
+
+    if config.forcecolor and config.nocolor:
+        raise _option_set.ArgumentError(
+            None, "Can not specify both --no-color and --force-color."
+        )
+    config.color = config.forcecolor or (not config.nocolor and sys.stdout.isatty())
+
+
+def _merge_noxfile_options(config: NoxConfig, noxfile_config: NoxfileOptions) -> None:
+    """Apply ``nox.options`` (as set by the noxfile) to the parsed config.
+
+    A value explicitly given on the command line (or via an environment
+    variable) always wins over the noxfile.
+    """
+    # sessions/keywords/tags are only taken from the noxfile if none of the
+    # three was given on the command line.
+    trio = ("sessions", "keywords", "tags")
+    cli_selected = any(config.provenance(name) is not Source.DEFAULT for name in trio)
+    _option_set.apply_noxfile_values(
+        config, noxfile_config, skip=trio if cli_selected else ()
+    )
+
+    # The legacy reuse_existing_virtualenvs alias, when enabled in the
+    # noxfile, wins over a noxfile-set reuse_venv (but not the command line).
+    if (
+        noxfile_config.provenance("reuse_existing_virtualenvs") is not Source.DEFAULT
+        and noxfile_config.reuse_existing_virtualenvs
+        and config.provenance("reuse_venv") is not Source.COMMAND_LINE
+    ):
+        config.set_value("reuse_venv", "yes", Source.NOXFILE)
+
+    # Defaults that only apply once the noxfile has had its say.
+    config.envdir = os.fspath(config.envdir or ".nox")
+    if config.reuse_venv is None:
+        config.reuse_venv = "no"
+    if config.default_venv_backend is None:
+        config.default_venv_backend = "virtualenv"
+
+
+options = _option_set.Options(
+    NoxConfig,
+    NoxfileOptions,
+    groups=GROUPS,
+    description="Nox is a Python automation toolkit.",
+    finalize=_finalize,
+    merge=_merge_noxfile_options,
 )
 
-
-"""Options that are configurable in the Noxfile.
-
-By setting properties on ``nox.options`` you can specify command line
-arguments in your Noxfile. If an argument is specified in both the Noxfile
-and on the command line, the command line arguments take precedence.
-
-See :doc:`usage` for more details on these settings and their effect.
-"""
-noxfile_options = options.noxfile_namespace()
+noxfile_options: NoxfileOptions = options.noxfile_namespace()
+"""The ``nox.options`` object noxfiles mutate to configure Nox."""

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -28,8 +28,9 @@ from nox._resolver import CycleError, lazy_stable_topo_sort
 from nox.sessions import Session, SessionRunner
 
 if TYPE_CHECKING:
-    import argparse
     from collections.abc import Iterable, Iterator, Sequence
+
+    from nox._options import NoxConfig
 
 __all__ = ["WARN_PYTHONS_IGNORED", "Manifest", "keyword_match"]
 
@@ -67,13 +68,13 @@ class Manifest:
     def __init__(
         self,
         session_functions: Mapping[str, Func],
-        global_config: argparse.Namespace,
+        global_config: NoxConfig,
         module_docstring: str | None = None,
     ) -> None:
         self._all_sessions: list[SessionRunner] = []
         self._queue: list[SessionRunner] = []
         self._consumed: list[SessionRunner] = []
-        self._config: argparse.Namespace = global_config
+        self._config: NoxConfig = global_config
         self.module_docstring: str | None = module_docstring
 
         # Create the sessions based on the provided session functions.
@@ -374,7 +375,8 @@ class Manifest:
         for call in calls:
             long_names = []
             if not multi or (
-                self._config.force_pythons and call.python in self._config.extra_pythons
+                self._config.force_pythons
+                and call.python in (self._config.extra_pythons or ())
             ):
                 long_names.append(f"{name}{call.session_signature}")
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -278,9 +278,7 @@ class Session:
     @property
     def cache_dir(self) -> pathlib.Path:
         """Create and return a 'shared cache' directory to be used across sessions."""
-        path = pathlib.Path(self._runner.global_config.envdir or ".nox").joinpath(
-            ".cache"
-        )
+        path = pathlib.Path(self._runner.global_config.envdir).joinpath(".cache")
         path.mkdir(parents=True, exist_ok=True)
         return path
 
@@ -1003,7 +1001,6 @@ def resolve_venv_backends(global_config: NoxConfig, func: Func) -> list[str]:
         global_config.force_venv_backend
         or func.venv_backend
         or global_config.default_venv_backend
-        or "virtualenv"
     )
     return backends.split("|")
 
@@ -1111,9 +1108,7 @@ class SessionRunner:
 
     @property
     def envdir(self) -> str:
-        return _normalize_path(
-            os.fspath(self.global_config.envdir or ".nox"), self.friendly_name
-        )
+        return _normalize_path(os.fspath(self.global_config.envdir), self.friendly_name)
 
     def get_direct_dependencies(
         self, sessions_by_id: Mapping[str, SessionRunner] | None = None

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -59,7 +59,6 @@ from nox.virtualenv import (
 )
 
 if typing.TYPE_CHECKING:
-    import argparse
     from collections.abc import (
         Callable,
         Generator,
@@ -77,6 +76,7 @@ if typing.TYPE_CHECKING:
     )
 
     from nox._decorators import Func
+    from nox._options import NoxConfig
     from nox.command import ExternalType
     from nox.manifest import Manifest
 
@@ -278,7 +278,9 @@ class Session:
     @property
     def cache_dir(self) -> pathlib.Path:
         """Create and return a 'shared cache' directory to be used across sessions."""
-        path = pathlib.Path(self._runner.global_config.envdir).joinpath(".cache")
+        path = pathlib.Path(self._runner.global_config.envdir or ".nox").joinpath(
+            ".cache"
+        )
         path.mkdir(parents=True, exist_ok=True)
         return path
 
@@ -333,7 +335,7 @@ class Session:
         to the Noxfile's directory before running any sessions. This gives
         you the original working directory that Nox was invoked form.
         """
-        return self._runner.global_config.invoked_from  # type: ignore[no-any-return]
+        return self._runner.global_config.invoked_from
 
     def chdir(self, dir: str | os.PathLike[str]) -> _WorkingDirContext:
         """Change the current working directory.
@@ -995,13 +997,70 @@ class Session:
         raise _SessionSkip(*args)
 
 
+def resolve_venv_backends(global_config: NoxConfig, func: Func) -> list[str]:
+    """The venv backends to try for a session: forced, session-declared, or default."""
+    backends = (
+        global_config.force_venv_backend
+        or func.venv_backend
+        or global_config.default_venv_backend
+        or "virtualenv"
+    )
+    return backends.split("|")
+
+
+def resolve_download_python(
+    global_config: NoxConfig, func: Func
+) -> Literal["auto", "never", "always"]:
+    """Whether to download missing interpreters for a session."""
+    return global_config.download_python or func.download_python or "auto"
+
+
+def resolve_reuse_existing_venv(global_config: NoxConfig, func: Func) -> bool:
+    """Determines whether to reuse an existing virtual environment.
+
+    The decision matrix is as follows:
+
+    +--------------------------+-----------------+-------------+
+    | global_config.reuse_venv | func.reuse_venv | Reuse venv? |
+    +==========================+=================+=============+
+    | "always"                 | N/A             | Yes         |
+    +--------------------------+-----------------+-------------+
+    | "never"                  | N/A             | No          |
+    +--------------------------+-----------------+-------------+
+    | "yes"                    | True|None       | Yes         |
+    +--------------------------+-----------------+-------------+
+    | "yes"                    | False           | No          |
+    +--------------------------+-----------------+-------------+
+    | "no"                     | True            | Yes         |
+    +--------------------------+-----------------+-------------+
+    | "no"                     | False|None      | No          |
+    +--------------------------+-----------------+-------------+
+
+    Summary
+    ~~~~~~~
+    - "always" forces reuse regardless of `func.reuse_venv`.
+    - "never" forces recreation regardless of `func.reuse_venv`.
+    - "yes" and "no" respect `func.reuse_venv` being ``False`` or ``True`` respectively.
+    """
+    return any(
+        (
+            # "always" forces reuse regardless of func.reuse_venv
+            global_config.reuse_venv == "always",
+            # Respect func.reuse_venv when it's explicitly True, unless global_config is "never"
+            func.reuse_venv is True and global_config.reuse_venv != "never",
+            # Delegate to reuse ("yes") when func.reuse_venv is not explicitly False
+            func.reuse_venv is not False and global_config.reuse_venv == "yes",
+        )
+    )
+
+
 class SessionRunner:
     def __init__(
         self,
         name: str,
         signatures: Sequence[str],
         func: Func,
-        global_config: argparse.Namespace,
+        global_config: NoxConfig,
         manifest: Manifest,
         *,
         multi: bool = False,
@@ -1052,7 +1111,9 @@ class SessionRunner:
 
     @property
     def envdir(self) -> str:
-        return _normalize_path(self.global_config.envdir, self.friendly_name)
+        return _normalize_path(
+            os.fspath(self.global_config.envdir or ".nox"), self.friendly_name
+        )
 
     def get_direct_dependencies(
         self, sessions_by_id: Mapping[str, SessionRunner] | None = None
@@ -1093,24 +1154,11 @@ class SessionRunner:
             raise KeyError(msg) from exc
 
     def _create_venv(self) -> None:
-        reuse_existing = self.reuse_existing_venv()
-
-        backends = (
-            self.global_config.force_venv_backend
-            or self.func.venv_backend
-            or self.global_config.default_venv_backend
-            or "virtualenv"
-        ).split("|")
-
-        download_python = (
-            self.global_config.download_python or self.func.download_python or "auto"
-        )
-
         self.venv = get_virtualenv(
-            *backends,
-            download_python=download_python,
+            *resolve_venv_backends(self.global_config, self.func),
+            download_python=resolve_download_python(self.global_config, self.func),
             envdir=self.envdir,
-            reuse_existing=reuse_existing,
+            reuse_existing=self.reuse_existing_venv(),
             interpreter=self.func.python,
             venv_params=self.func.venv_params,
         )
@@ -1121,52 +1169,12 @@ class SessionRunner:
         """
         Determines whether to reuse an existing virtual environment.
 
-        The decision matrix is as follows:
-
-        +--------------------------+-----------------+-------------+
-        | global_config.reuse_venv | func.reuse_venv | Reuse venv? |
-        +==========================+=================+=============+
-        | "always"                 | N/A             | Yes         |
-        +--------------------------+-----------------+-------------+
-        | "never"                  | N/A             | No          |
-        +--------------------------+-----------------+-------------+
-        | "yes"                    | True|None       | Yes         |
-        +--------------------------+-----------------+-------------+
-        | "yes"                    | False           | No          |
-        +--------------------------+-----------------+-------------+
-        | "no"                     | True            | Yes         |
-        +--------------------------+-----------------+-------------+
-        | "no"                     | False|None      | No          |
-        +--------------------------+-----------------+-------------+
-
-        Summary
-        ~~~~~~~
-        - "always" forces reuse regardless of `func.reuse_venv`.
-        - "never" forces recreation regardless of `func.reuse_venv`.
-        - "yes" and "no" respect `func.reuse_venv` being ``False`` or ``True`` respectively.
+        See :func:`resolve_reuse_existing_venv` for the decision matrix.
 
         Returns:
             bool: True if the existing virtual environment should be reused, False otherwise.
         """
-        if self.global_config.reuse_venv not in {"always", "never", "no", "yes", None}:
-            msg = (
-                "nox.options.reuse_venv must be set to 'always', 'never', 'no', or 'yes',"
-                f" got {self.global_config.reuse_venv!r}!"
-            )
-            raise AttributeError(msg)
-
-        return any(
-            (
-                # "always" forces reuse regardless of func.reuse_venv
-                self.global_config.reuse_venv == "always",
-                # Respect func.reuse_venv when it's explicitly True, unless global_config is "never"
-                self.func.reuse_venv is True
-                and self.global_config.reuse_venv != "never",
-                # Delegate to reuse ("yes") when func.reuse_venv is not explicitly False
-                self.func.reuse_venv is not False
-                and self.global_config.reuse_venv == "yes",
-            )
-        )
+        return resolve_reuse_existing_venv(self.global_config, self.func)
 
     def execute(self) -> Result:
         logger.session_info(f"Running session {self.friendly_name}")

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -162,7 +162,7 @@ def merge_noxfile_options(
         module (module): The Noxfile module.
         global_config (~nox.main.GlobalConfig): The global configuration.
     """
-    _options.options.merge_namespaces(global_config, nox.options)
+    _options._merge_noxfile_options(global_config, nox.options)
     return module
 
 

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -162,7 +162,7 @@ def merge_noxfile_options(
         module (module): The Noxfile module.
         global_config (~nox.main.GlobalConfig): The global configuration.
     """
-    _options._merge_noxfile_options(global_config, nox.options)
+    _options.merge_noxfile_options(global_config, nox.options)
     return module
 
 

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -47,7 +47,8 @@ from nox.sessions import Result, Status, _duration_str
 
 if TYPE_CHECKING:
     import types
-    from argparse import Namespace
+
+    from nox._options import NoxConfig
 
 __all__ = [
     "create_report",
@@ -66,7 +67,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
+def _load_and_exec_nox_module(global_config: NoxConfig) -> types.ModuleType:
     """
     Loads, executes, then returns the global_config Nox module.
 
@@ -98,7 +99,7 @@ def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
     return module
 
 
-def load_nox_module(global_config: Namespace) -> types.ModuleType | int:
+def load_nox_module(global_config: NoxConfig) -> types.ModuleType | int:
     """Load the user's Noxfile and return the module object for it.
 
     .. note::
@@ -121,9 +122,8 @@ def load_nox_module(global_config: Namespace) -> types.ModuleType | int:
     # Save the absolute path to the Noxfile.
     # This will inoculate it if Nox changes paths because of an implicit
     # or explicit chdir (like the one below).
-    # Keeps the class of the original string
-    global_config.noxfile = global_config.noxfile.__class__(
-        os.path.join(noxfile_parent_dir, os.path.basename(global_config_noxfile))
+    global_config.noxfile = os.path.join(
+        noxfile_parent_dir, os.path.basename(global_config_noxfile)
     )
 
     try:
@@ -153,7 +153,7 @@ def load_nox_module(global_config: Namespace) -> types.ModuleType | int:
 
 
 def merge_noxfile_options(
-    module: types.ModuleType, global_config: Namespace
+    module: types.ModuleType, global_config: NoxConfig
 ) -> types.ModuleType:
     """Merges any modifications made to ``nox.options`` by the Noxfile module
     into global_config.
@@ -167,7 +167,7 @@ def merge_noxfile_options(
 
 
 def discover_manifest(
-    module: types.ModuleType | int, global_config: Namespace
+    module: types.ModuleType | int, global_config: NoxConfig
 ) -> Manifest:
     """Discover all session functions in the Noxfile module.
 
@@ -190,7 +190,7 @@ def discover_manifest(
     return Manifest(functions, global_config, module_docstring)
 
 
-def filter_manifest(manifest: Manifest, global_config: Namespace) -> Manifest | int:
+def filter_manifest(manifest: Manifest, global_config: NoxConfig) -> Manifest | int:
     """Filter the manifest according to the provided configuration.
 
     Args:
@@ -272,7 +272,7 @@ def filter_manifest(manifest: Manifest, global_config: Namespace) -> Manifest | 
     return manifest
 
 
-def _produce_listing(manifest: Manifest, global_config: Namespace) -> None:
+def _produce_listing(manifest: Manifest, global_config: NoxConfig) -> None:
     # If the user just asked for a list of sessions, print that
     # and any docstring specified in noxfile.py and be done. This
     # can also be called if Noxfile sessions is an empty list.
@@ -306,7 +306,7 @@ def _produce_listing(manifest: Manifest, global_config: Namespace) -> None:
     )
 
 
-def _produce_json_listing(manifest: Manifest, global_config: Namespace) -> None:  # noqa: ARG001
+def _produce_json_listing(manifest: Manifest, global_config: NoxConfig) -> None:  # noqa: ARG001
     report = []
     for session, selected in manifest.list_all_sessions():
         if selected:
@@ -323,7 +323,7 @@ def _produce_json_listing(manifest: Manifest, global_config: Namespace) -> None:
     print(json.dumps(report, default=str))
 
 
-def honor_list_request(manifest: Manifest, global_config: Namespace) -> Manifest | int:
+def honor_list_request(manifest: Manifest, global_config: NoxConfig) -> Manifest | int:
     """If --list was passed, simply list the manifest and exit cleanly.
 
     Args:
@@ -350,7 +350,7 @@ def honor_list_request(manifest: Manifest, global_config: Namespace) -> Manifest
     return 0
 
 
-def honor_usage_request(manifest: Manifest, global_config: Namespace) -> Manifest | int:
+def honor_usage_request(manifest: Manifest, global_config: NoxConfig) -> Manifest | int:
     """If --usage was passed, print the full docstring of the session and exit.
     Raise an error if the session does not exist or has no docstring to print.
 
@@ -388,7 +388,7 @@ def honor_usage_request(manifest: Manifest, global_config: Namespace) -> Manifes
     return 0
 
 
-def run_manifest(manifest: Manifest, global_config: Namespace) -> list[Result]:
+def run_manifest(manifest: Manifest, global_config: NoxConfig) -> list[Result]:
     """Run the full manifest of sessions.
 
     Args:
@@ -434,7 +434,7 @@ Sequence_Results_T = TypeVar("Sequence_Results_T", bound=Sequence[Result])
 
 def print_summary(
     results: Sequence_Results_T,
-    global_config: Namespace,  # noqa: ARG001
+    global_config: NoxConfig,  # noqa: ARG001
 ) -> Sequence_Results_T:
     """Print a summary of the results.
 
@@ -469,7 +469,7 @@ def print_summary(
 
 
 def create_report(
-    results: Sequence_Results_T, global_config: Namespace
+    results: Sequence_Results_T, global_config: NoxConfig
 ) -> Sequence_Results_T:
     """Write a report to the location designated in the config, if any.
 
@@ -500,7 +500,7 @@ def create_report(
     return results
 
 
-def final_reduce(results: list[Result], global_config: Namespace) -> int:  # noqa: ARG001
+def final_reduce(results: list[Result], global_config: NoxConfig) -> int:  # noqa: ARG001
     """Reduce the results to a final exit code.
 
     Args:

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, TypeVar
 from colorlog.escape_codes import parse_colors
 
 import nox
-from nox import _options, registry
+from nox import _merge, registry
 from nox._resolver import CycleError
 from nox._version import InvalidVersionSpecifier, VersionCheckFailed, check_nox_version
 from nox.logger import logger
@@ -162,7 +162,7 @@ def merge_noxfile_options(
         module (module): The Noxfile module.
         global_config (~nox.main.GlobalConfig): The global configuration.
     """
-    _options.merge_noxfile_options(global_config, nox.options)
+    _merge.merge_noxfile_options(global_config, nox.options)
     return module
 
 

--- a/nox/workflow.py
+++ b/nox/workflow.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    import argparse
     from collections.abc import Callable, Iterable
+
+    from nox._options import NoxConfig
 
 __all__ = ["execute"]
 
@@ -27,9 +28,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def execute(
-    workflow: Iterable[Callable[..., Any]], global_config: argparse.Namespace
-) -> int:
+def execute(workflow: Iterable[Callable[..., Any]], global_config: NoxConfig) -> int:
     """Execute each function in the workflow.
 
     Each function in the workflow receives the result of the previous one

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -20,7 +20,7 @@ import attrs
 import pytest
 
 from nox import _completers, _merge, _option_set, _options
-from nox._option_set import Forward, Options, OptionsBase, Source, opt, to_argv
+from nox._option_set import Options, OptionsBase, Source, opt
 
 RESOURCES = Path(__file__).parent.joinpath("resources")
 
@@ -166,105 +166,6 @@ class TestOptions:
             options.reuse_venv = None
         with pytest.raises(TypeError):
             options.default_venv_backend = None
-
-
-def _forwardable_fields() -> list[str]:
-    return [
-        field.name
-        for field in attrs.fields(_options.NoxConfig)
-        if (o := _option_set._get_opt(field)) is not None
-        and o.forward is not Forward.NEVER
-    ]
-
-
-class TestToArgv:
-    @pytest.mark.parametrize(
-        "args",
-        [
-            [],
-            ["-r"],
-            ["-R"],
-            ["--verbose", "--reuse-venv", "never", "--envdir", "elsewhere"],
-            ["--no-verbose", "--error-on-missing-interpreters"],
-            ["--forcecolor", "-s", "a", "b", "-p", "3.12", "3.13"],
-            ["--nocolor", "--install-only", "--non-interactive", "-ts"],
-            ["--default-venv-backend", "uv", "--download-python", "never"],
-            ["--force-python", "3.13", "--stop-on-first-error"],
-            ["-s", "test", "--", "-k", "foo", "--flag"],
-        ],
-    )
-    def test_round_trip(self, args: list[str]) -> None:
-        """Parsing to_argv's output must restore every forwardable value."""
-        config = _options.options.parse_args(args)
-        rebuilt = _options.options.parse_args(to_argv(config))
-
-        for name in _forwardable_fields():
-            assert getattr(rebuilt, name) == getattr(config, name), name
-
-    def test_never_forwarded(self) -> None:
-        config = _options.options.parse_args(
-            ["--list-sessions", "--json", "--no-venv", "-R"]
-        )
-        argv = to_argv(config)
-
-        for flag in ("--list-sessions", "--json", "--no-venv", "-R"):
-            assert flag not in argv
-        # The alias state is forwarded through the canonical options instead.
-        assert "--no-install" in argv
-        assert argv[argv.index("--reuse-venv") :][:2] == ["--reuse-venv", "yes"]
-
-    def test_flag_pairs_always_emitted(self) -> None:
-        """Environment-dependent pair defaults must be pinned for children."""
-        argv = to_argv(_options.options.parse_args([]))
-
-        assert (
-            "--error-on-missing-interpreters" in argv
-            or "--no-error-on-missing-interpreters" in argv
-        )
-        assert "--verbose" in argv or "--no-verbose" in argv
-
-    def test_noxfile_only_backend_skipped(self) -> None:
-        """The "a|b" fallback syntax is not valid on the CLI, so it is not
-        forwarded; children re-derive it from the noxfile."""
-        config = _options.options.namespace(default_venv_backend="uv|virtualenv")
-        argv = to_argv(config)
-
-        assert "--default-venv-backend" not in argv
-
-    def test_posargs_last(self) -> None:
-        config = _options.options.parse_args(["-v", "--", "posarg"])
-        argv = to_argv(config)
-
-        assert argv[-2:] == ["--", "posarg"]
-
-    def test_always_forward_falsey_values(self) -> None:
-        """ALWAYS-forwarded options with nothing to say emit no arguments."""
-
-        @attrs.define(kw_only=True)
-        class AlwaysConfig(OptionsBase):
-            flag: bool = attrs.field(
-                default=False,
-                metadata=opt("--flag", group="g", forward=Forward.ALWAYS),
-            )
-            items: list[str] = attrs.field(
-                factory=list,
-                metadata=opt("--items", group="g", forward=Forward.ALWAYS),
-            )
-            name: str | None = attrs.field(
-                default=None,
-                metadata=opt("--name", group="g", forward=Forward.ALWAYS),
-            )
-
-        assert to_argv(AlwaysConfig()) == []
-
-    def test_evolve_selects_session(self) -> None:
-        """The pattern used to spawn a child nox for a single session."""
-        config = _options.options.parse_args(["-s", "a", "b", "-k", "expr"])
-        child = attrs.evolve(config, sessions=["b"], keywords=None, tags=None)
-        argv = to_argv(child)
-
-        assert argv[argv.index("--session") :][:2] == ["--session", "b"]
-        assert "--keywords" not in argv
 
 
 class TestMerge:

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -128,9 +128,9 @@ class TestOptions:
 
     def test_validation_options(self) -> None:
         options = _option_set.NoxOptions(
-            default_venv_backend=None,
+            default_venv_backend="virtualenv",
             download_python="auto",
-            envdir=None,
+            envdir=".nox",
             error_on_external_run=False,
             error_on_missing_interpreters=False,
             force_venv_backend=None,
@@ -138,7 +138,7 @@ class TestOptions:
             pythons=None,
             report=None,
             reuse_existing_virtualenvs=False,
-            reuse_venv=None,
+            reuse_venv="no",
             sessions=None,
             stop_on_first_error=False,
             tags=None,
@@ -151,6 +151,11 @@ class TestOptions:
 
         options.envdir = "envdir"
         options.envdir = Path("envdir")
+        # These used to accept None to mean "unset"; now they hold real values.
+        with pytest.raises(ValueError):  # noqa: PT011
+            options.reuse_venv = None
+        with pytest.raises(TypeError):
+            options.default_venv_backend = None
 
 
 def _forwardable_fields() -> list[str]:
@@ -237,7 +242,7 @@ class TestMerge:
         self, args: list[str], noxfile_config: _options.NoxfileOptions
     ) -> _options.NoxConfig:
         config = _options.options.parse_args(args)
-        _options._merge_noxfile_options(config, noxfile_config)
+        _options.merge_noxfile_options(config, noxfile_config)
         return config
 
     def test_noxfile_beats_default(self) -> None:
@@ -305,3 +310,55 @@ class TestMerge:
         assert config.envdir == ".nox"
         assert config.reuse_venv == "no"
         assert config.default_venv_backend == "virtualenv"
+
+
+class TestEnvVars:
+    def test_invalid_value_is_a_clean_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A bad env-var value must produce a parser error, not a traceback."""
+        monkeypatch.setenv("NOX_DOWNLOAD_PYTHON", "bogus")
+
+        with pytest.raises(SystemExit):
+            _options.options.parse_args([])
+
+        assert "'download_python' must be in" in capsys.readouterr().err
+
+
+class TestReuseAliasPrecedence:
+    """An explicit --reuse-venv on the command line now wins over the -r/-N
+    aliases given alongside it (the aliases used to win). -R still wins."""
+
+    def test_r_with_explicit_reuse_venv(self) -> None:
+        config = _options.options.parse_args(["-r", "--reuse-venv", "never"])
+
+        assert config.reuse_venv == "never"
+
+    def test_no_reuse_with_explicit_reuse_venv(self) -> None:
+        config = _options.options.parse_args(["-N", "--reuse-venv", "always"])
+
+        assert config.reuse_venv == "always"
+
+    def test_R_beats_no_reuse(self) -> None:
+        config = _options.options.parse_args(["-N", "-R"])
+
+        assert config.reuse_venv == "yes"
+
+
+class TestProvenance:
+    def test_posargs_default(self) -> None:
+        config = _options.options.parse_args([])
+
+        assert config.provenance("posargs") is Source.DEFAULT
+
+    def test_posargs_given(self) -> None:
+        config = _options.options.parse_args(["--", "x"])
+
+        assert config.provenance("posargs") is Source.COMMAND_LINE
+
+    def test_evolve_resets_provenance(self) -> None:
+        config = _options.options.parse_args(["-s", "a"])
+        child = attrs.evolve(config)
+
+        assert config.provenance("sessions") is Source.COMMAND_LINE
+        assert child.provenance("sessions") is Source.DEFAULT

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import attrs
 import pytest
 
-from nox import _option_set, _options
+from nox import _completers, _merge, _option_set, _options
 from nox._option_set import Forward, Options, OptionsBase, Source, opt, to_argv
 
 RESOURCES = Path(__file__).parent.joinpath("resources")
@@ -86,7 +86,7 @@ class TestOptions:
             posargs=[],
             noxfile=str(RESOURCES.joinpath("noxfile_multiple_sessions.py")),
         )
-        actual_sessions_from_file = _options._session_completer(
+        actual_sessions_from_file = _completers.session_completer(
             prefix="", parsed_args=parsed_args
         )
 
@@ -97,7 +97,7 @@ class TestOptions:
         parsed_args = _options.options.namespace(
             sessions=("baz",), keywords=None, posargs=[]
         )
-        all_nox_sessions = _options._session_completer(
+        all_nox_sessions = _completers.session_completer(
             prefix="", parsed_args=parsed_args
         )
         assert len(list(all_nox_sessions)) == 0
@@ -107,7 +107,7 @@ class TestOptions:
             posargs=[],
             noxfile=str(RESOURCES.joinpath("noxfile_pythons.py")),
         )
-        actual_pythons_from_file = _options._python_completer(
+        actual_pythons_from_file = _completers.python_completer(
             prefix="", parsed_args=parsed_args
         )
 
@@ -119,7 +119,7 @@ class TestOptions:
             posargs=[],
             noxfile=str(RESOURCES.joinpath("noxfile_tags.py")),
         )
-        actual_tags_from_file = _options._tag_completer(
+        actual_tags_from_file = _completers.tag_completer(
             prefix="", parsed_args=parsed_args
         )
 
@@ -242,7 +242,7 @@ class TestMerge:
         self, args: list[str], noxfile_config: _options.NoxfileOptions
     ) -> _options.NoxConfig:
         config = _options.options.parse_args(args)
-        _options.merge_noxfile_options(config, noxfile_config)
+        _merge.merge_noxfile_options(config, noxfile_config)
         return config
 
     def test_noxfile_beats_default(self) -> None:

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -59,6 +59,16 @@ class TestOptions:
         with pytest.raises(KeyError):
             make_small_options().namespace(non_existent_option="meep")
 
+    def test_provenance_non_existent_option(self) -> None:
+        with pytest.raises(KeyError, match="non_existent_option is not an option"):
+            SmallConfig().provenance("non_existent_option")
+
+    def test_parse_args_without_finalize(self) -> None:
+        config = make_small_options().parse_args(["--option-a", "moop"])
+
+        assert config.option_a == "moop"
+        assert config.provenance("option_a") is Source.COMMAND_LINE
+
     def test_parser_hidden_option(self) -> None:
         options = make_small_options()
 
@@ -227,6 +237,26 @@ class TestToArgv:
 
         assert argv[-2:] == ["--", "posarg"]
 
+    def test_always_forward_falsey_values(self) -> None:
+        """ALWAYS-forwarded options with nothing to say emit no arguments."""
+
+        @attrs.define(kw_only=True)
+        class AlwaysConfig(OptionsBase):
+            flag: bool = attrs.field(
+                default=False,
+                metadata=opt("--flag", group="g", forward=Forward.ALWAYS),
+            )
+            items: list[str] = attrs.field(
+                factory=list,
+                metadata=opt("--items", group="g", forward=Forward.ALWAYS),
+            )
+            name: str | None = attrs.field(
+                default=None,
+                metadata=opt("--name", group="g", forward=Forward.ALWAYS),
+            )
+
+        assert to_argv(AlwaysConfig()) == []
+
     def test_evolve_selects_session(self) -> None:
         """The pattern used to spawn a child nox for a single session."""
         config = _options.options.parse_args(["-s", "a", "b", "-k", "expr"])
@@ -355,6 +385,17 @@ class TestProvenance:
         config = _options.options.parse_args(["--", "x"])
 
         assert config.provenance("posargs") is Source.COMMAND_LINE
+
+    def test_private_assignment_not_recorded(self) -> None:
+        """Assigning internal state does not register as a noxfile-set option."""
+        noxfile_config = _options.NoxfileOptions()
+        noxfile_config.sessions = ["a"]
+        assert noxfile_config.provenance("sessions") is Source.NOXFILE
+
+        noxfile_config._provenance = {}
+
+        assert noxfile_config.provenance("sessions") is Source.DEFAULT
+        assert noxfile_config.provenance("_provenance") is Source.DEFAULT
 
     def test_evolve_resets_provenance(self) -> None:
         config = _options.options.parse_args(["-s", "a"])

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -36,7 +36,6 @@ class SmallConfig(OptionsBase):
 def make_small_options() -> Options[SmallConfig]:
     return Options(
         SmallConfig,
-        SmallConfig,
         groups={"group_a": ("Group A", "The A group.")},
         description="test options",
     )
@@ -74,7 +73,7 @@ class TestOptions:
         class GrouplessConfig(OptionsBase):
             no_group: str = attrs.field(default="meep", metadata=opt("--no-group"))
 
-        options = Options(GrouplessConfig, GrouplessConfig, groups={}, description="")
+        options = Options(GrouplessConfig, groups={}, description="")
 
         with pytest.raises(
             ValueError,
@@ -158,7 +157,7 @@ def _forwardable_fields() -> list[str]:
     return [
         field.name
         for field in attrs.fields(_options.NoxConfig)
-        if (o := field.metadata.get(_option_set.METADATA_KEY)) is not None
+        if (o := _option_set._get_opt(field)) is not None
         and o.forward is not Forward.NEVER
     ]
 
@@ -238,18 +237,18 @@ class TestMerge:
         self, args: list[str], noxfile_config: _options.NoxfileOptions
     ) -> _options.NoxConfig:
         config = _options.options.parse_args(args)
-        _options.options.merge_namespaces(config, noxfile_config)
+        _options._merge_noxfile_options(config, noxfile_config)
         return config
 
     def test_noxfile_beats_default(self) -> None:
-        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config = _options.NoxfileOptions()
         noxfile_config.sessions = ["lint"]
         config = self.parse_and_merge([], noxfile_config)
 
         assert config.sessions == ["lint"]
 
     def test_cli_beats_noxfile(self) -> None:
-        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config = _options.NoxfileOptions()
         noxfile_config.sessions = ["lint"]
         config = self.parse_and_merge(["-s", "test"], noxfile_config)
 
@@ -258,7 +257,7 @@ class TestMerge:
     def test_cli_reuse_venv_beats_noxfile_alias(self) -> None:
         """An explicit CLI --reuse-venv wins over the noxfile's legacy
         reuse_existing_virtualenvs alias (this used to be reversed)."""
-        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config = _options.NoxfileOptions()
         noxfile_config.reuse_existing_virtualenvs = True
         config = self.parse_and_merge(["--reuse-venv", "never"], noxfile_config)
 
@@ -267,14 +266,14 @@ class TestMerge:
     def test_bare_sessions_flag_beats_noxfile(self) -> None:
         """An explicit but empty -s means "no sessions", not "use the
         noxfile's list" (this used to fall through to the noxfile)."""
-        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config = _options.NoxfileOptions()
         noxfile_config.sessions = ["lint"]
         config = self.parse_and_merge(["-s"], noxfile_config)
 
         assert config.sessions == []
 
     def test_cli_keywords_suppress_noxfile_sessions(self) -> None:
-        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config = _options.NoxfileOptions()
         noxfile_config.sessions = ["lint"]
         config = self.parse_and_merge(["-k", "test"], noxfile_config)
 
@@ -285,7 +284,7 @@ class TestMerge:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("NOXSESSION", "a,b")
-        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config = _options.NoxfileOptions()
         noxfile_config.sessions = ["lint"]
         config = self.parse_and_merge([], noxfile_config)
 
@@ -294,14 +293,14 @@ class TestMerge:
 
     def test_noxfile_beats_ci_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CI", "1")
-        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config = _options.NoxfileOptions()
         noxfile_config.error_on_missing_interpreters = False
         config = self.parse_and_merge([], noxfile_config)
 
         assert config.error_on_missing_interpreters is False
 
     def test_merged_defaults(self) -> None:
-        config = self.parse_and_merge([], _options.options.noxfile_namespace())
+        config = self.parse_and_merge([], _options.NoxfileOptions())
 
         assert config.envdir == ".nox"
         assert config.reuse_venv == "no"

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import attrs
 import pytest
 
-from nox import _completers, _merge, _option_set, _options
+from nox import _completers, _merge, _options
 from nox._option_set import Options, OptionsBase, Source, opt
 
 RESOURCES = Path(__file__).parent.joinpath("resources")
@@ -137,7 +137,7 @@ class TestOptions:
         assert expected_tags == set(actual_tags_from_file)
 
     def test_validation_options(self) -> None:
-        options = _option_set.NoxOptions(
+        options = _options.NoxfileOptions(
             default_venv_backend="virtualenv",
             download_python="auto",
             envdir=".nox",
@@ -155,17 +155,17 @@ class TestOptions:
             verbose=False,
         )
         options.sessions = ["testytest"]
-        options.sessions = ("testytest",)
+        options.sessions = ("testytest",)  # type: ignore[assignment]
         with pytest.raises(ValueError):  # noqa: PT011
-            options.sessions = "testytest"
+            options.sessions = "testytest"  # type: ignore[assignment]
 
         options.envdir = "envdir"
         options.envdir = Path("envdir")
         # These used to accept None to mean "unset"; now they hold real values.
         with pytest.raises(ValueError):  # noqa: PT011
-            options.reuse_venv = None
+            options.reuse_venv = None  # type: ignore[assignment]
         with pytest.raises(TypeError):
-            options.default_venv_backend = None
+            options.default_venv_backend = None  # type: ignore[assignment]
 
 
 class TestMerge:

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -15,82 +15,72 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+import attrs
 import pytest
 
 from nox import _option_set, _options
-
-if TYPE_CHECKING:
-    import argparse
-
-# The vast majority of _option_set is tested by test_main, but the test helper
-# :func:`OptionSet.namespace` needs a bit of help to get to full coverage.
-
+from nox._option_set import Forward, Options, OptionsBase, Source, opt, to_argv
 
 RESOURCES = Path(__file__).parent.joinpath("resources")
 
 
-class TestOptionSet:
+@attrs.define(kw_only=True)
+class SmallConfig(OptionsBase):
+    option_a: str = attrs.field(
+        default="meep", metadata=opt("--option-a", group="group_a")
+    )
+    hidden_option: str = attrs.field(default="meep", metadata=opt(hidden=True))
+
+
+def make_small_options() -> Options[SmallConfig]:
+    return Options(
+        SmallConfig,
+        SmallConfig,
+        groups={"group_a": ("Group A", "The A group.")},
+        description="test options",
+    )
+
+
+class TestOptions:
     def test_namespace(self) -> None:
-        optionset = _option_set.OptionSet()
-        optionset.add_groups(_option_set.OptionGroup("group_a"))
-        optionset.add_options(
-            _option_set.Option(
-                "option_a", group=optionset.groups["group_a"], default="meep"
-            )
-        )
+        namespace = make_small_options().namespace()
 
-        namespace = optionset.namespace()
-
-        assert hasattr(namespace, "option_a")
-        assert not hasattr(namespace, "non_existent_option")
         assert namespace.option_a == "meep"
+        assert not hasattr(namespace, "non_existent_option")
 
     def test_namespace_values(self) -> None:
-        optionset = _option_set.OptionSet()
-        optionset.add_groups(_option_set.OptionGroup("group_a"))
-        optionset.add_options(
-            _option_set.Option(
-                "option_a", group=optionset.groups["group_a"], default="meep"
-            )
-        )
-
-        namespace = optionset.namespace(option_a="moop")
+        namespace = make_small_options().namespace(option_a="moop")
 
         assert namespace.option_a == "moop"
+        assert namespace.provenance("option_a") is Source.COMMAND_LINE
+        assert namespace.provenance("hidden_option") is Source.DEFAULT
 
     def test_namespace_non_existent_options_with_values(self) -> None:
-        optionset = _option_set.OptionSet()
-
         with pytest.raises(KeyError):
-            optionset.namespace(non_existent_option="meep")
+            make_small_options().namespace(non_existent_option="meep")
 
     def test_parser_hidden_option(self) -> None:
-        optionset = _option_set.OptionSet()
-        optionset.add_options(
-            _option_set.Option(
-                "oh_boy_i_am_hidden", hidden=True, group=None, default="meep"
-            )
-        )
+        options = make_small_options()
 
-        parser = optionset.parser()
-        namespace = parser.parse_args([])
-        optionset._finalize_args(namespace)
+        parser = options.parser()
+        config = options.expand(parser.parse_args([]))
 
-        assert namespace.oh_boy_i_am_hidden == "meep"
+        assert config.hidden_option == "meep"
+        assert "hidden_option" not in parser.format_help()
 
     def test_parser_groupless_option(self) -> None:
-        optionset = _option_set.OptionSet()
-        optionset.add_options(
-            _option_set.Option("oh_no_i_have_no_group", group=None, default="meep")
-        )
+        @attrs.define(kw_only=True)
+        class GrouplessConfig(OptionsBase):
+            no_group: str = attrs.field(default="meep", metadata=opt("--no-group"))
+
+        options = Options(GrouplessConfig, GrouplessConfig, groups={}, description="")
 
         with pytest.raises(
             ValueError,
-            match="Option oh_no_i_have_no_group must either have a group or be hidden",
+            match="Option no_group must either have a group or be hidden",
         ):
-            optionset.parser()
+            options.parser()
 
     def test_session_completer(self) -> None:
         parsed_args = _options.options.namespace(
@@ -106,7 +96,7 @@ class TestOptionSet:
 
     def test_session_completer_invalid_sessions(self) -> None:
         parsed_args = _options.options.namespace(
-            sessions=("baz",), keywords=(), posargs=[]
+            sessions=("baz",), keywords=None, posargs=[]
         )
         all_nox_sessions = _options._session_completer(
             prefix="", parsed_args=parsed_args
@@ -164,10 +154,89 @@ class TestOptionSet:
         options.envdir = Path("envdir")
 
 
+def _forwardable_fields() -> list[str]:
+    return [
+        field.name
+        for field in attrs.fields(_options.NoxConfig)
+        if (o := field.metadata.get(_option_set.METADATA_KEY)) is not None
+        and o.forward is not Forward.NEVER
+    ]
+
+
+class TestToArgv:
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [],
+            ["-r"],
+            ["-R"],
+            ["--verbose", "--reuse-venv", "never", "--envdir", "elsewhere"],
+            ["--no-verbose", "--error-on-missing-interpreters"],
+            ["--forcecolor", "-s", "a", "b", "-p", "3.12", "3.13"],
+            ["--nocolor", "--install-only", "--non-interactive", "-ts"],
+            ["--default-venv-backend", "uv", "--download-python", "never"],
+            ["--force-python", "3.13", "--stop-on-first-error"],
+            ["-s", "test", "--", "-k", "foo", "--flag"],
+        ],
+    )
+    def test_round_trip(self, args: list[str]) -> None:
+        """Parsing to_argv's output must restore every forwardable value."""
+        config = _options.options.parse_args(args)
+        rebuilt = _options.options.parse_args(to_argv(config))
+
+        for name in _forwardable_fields():
+            assert getattr(rebuilt, name) == getattr(config, name), name
+
+    def test_never_forwarded(self) -> None:
+        config = _options.options.parse_args(
+            ["--list-sessions", "--json", "--no-venv", "-R"]
+        )
+        argv = to_argv(config)
+
+        for flag in ("--list-sessions", "--json", "--no-venv", "-R"):
+            assert flag not in argv
+        # The alias state is forwarded through the canonical options instead.
+        assert "--no-install" in argv
+        assert argv[argv.index("--reuse-venv") :][:2] == ["--reuse-venv", "yes"]
+
+    def test_flag_pairs_always_emitted(self) -> None:
+        """Environment-dependent pair defaults must be pinned for children."""
+        argv = to_argv(_options.options.parse_args([]))
+
+        assert (
+            "--error-on-missing-interpreters" in argv
+            or "--no-error-on-missing-interpreters" in argv
+        )
+        assert "--verbose" in argv or "--no-verbose" in argv
+
+    def test_noxfile_only_backend_skipped(self) -> None:
+        """The "a|b" fallback syntax is not valid on the CLI, so it is not
+        forwarded; children re-derive it from the noxfile."""
+        config = _options.options.namespace(default_venv_backend="uv|virtualenv")
+        argv = to_argv(config)
+
+        assert "--default-venv-backend" not in argv
+
+    def test_posargs_last(self) -> None:
+        config = _options.options.parse_args(["-v", "--", "posarg"])
+        argv = to_argv(config)
+
+        assert argv[-2:] == ["--", "posarg"]
+
+    def test_evolve_selects_session(self) -> None:
+        """The pattern used to spawn a child nox for a single session."""
+        config = _options.options.parse_args(["-s", "a", "b", "-k", "expr"])
+        child = attrs.evolve(config, sessions=["b"], keywords=None, tags=None)
+        argv = to_argv(child)
+
+        assert argv[argv.index("--session") :][:2] == ["--session", "b"]
+        assert "--keywords" not in argv
+
+
 class TestMerge:
     def parse_and_merge(
-        self, args: list[str], noxfile_config: _option_set.NoxOptions
-    ) -> argparse.Namespace:
+        self, args: list[str], noxfile_config: _options.NoxfileOptions
+    ) -> _options.NoxConfig:
         config = _options.options.parse_args(args)
         _options.options.merge_namespaces(config, noxfile_config)
         return config
@@ -221,6 +290,7 @@ class TestMerge:
         config = self.parse_and_merge([], noxfile_config)
 
         assert config.sessions == ["a", "b"]
+        assert config.provenance("sessions") is Source.ENVIRONMENT
 
     def test_noxfile_beats_ci_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CI", "1")
@@ -236,36 +306,3 @@ class TestMerge:
         assert config.envdir == ".nox"
         assert config.reuse_venv == "no"
         assert config.default_venv_backend == "virtualenv"
-
-
-class TestEnvVars:
-    def test_invalid_value_is_a_clean_error(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """A bad env-var value must produce a parser error, not a traceback."""
-        monkeypatch.setenv("NOX_DOWNLOAD_PYTHON", "bogus")
-
-        with pytest.raises(SystemExit):
-            _options.options.parse_args([])
-
-        assert "'download_python' must be in" in capsys.readouterr().err
-
-
-class TestReuseAliasPrecedence:
-    """An explicit --reuse-venv on the command line now wins over the -r/-N
-    aliases given alongside it (the aliases used to win). -R still wins."""
-
-    def test_r_with_explicit_reuse_venv(self) -> None:
-        config = _options.options.parse_args(["-r", "--reuse-venv", "never"])
-
-        assert config.reuse_venv == "never"
-
-    def test_no_reuse_with_explicit_reuse_venv(self) -> None:
-        config = _options.options.parse_args(["-N", "--reuse-venv", "always"])
-
-        assert config.reuse_venv == "always"
-
-    def test_R_beats_no_reuse(self) -> None:
-        config = _options.options.parse_args(["-N", "-R"])
-
-        assert config.reuse_venv == "yes"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -997,9 +997,7 @@ def test_main_noxfile_options_with_ci_override(
     if should_set_ci_env_var:
         monkeypatch.setenv("CI", "True")
     # Reload nox.options taking into consideration monkeypatch.{delenv|setenv}
-    monkeypatch.setattr(
-        nox._options, "noxfile_options", nox._options.options.noxfile_namespace()
-    )
+    monkeypatch.setattr(nox._options, "noxfile_options", nox._options.NoxfileOptions())
     monkeypatch.setattr(nox, "options", nox._options.noxfile_options)
 
     if noxfile_option_value is None:
@@ -1097,9 +1095,7 @@ def test_main_noxfile_options_reuse_venv_compat_check(
     cmd_args += ["--noxfile", str(noxfile_path)]
 
     # Reset nox.options
-    monkeypatch.setattr(
-        nox._options, "noxfile_options", nox._options.options.noxfile_namespace()
-    )
+    monkeypatch.setattr(nox._options, "noxfile_options", nox._options.NoxfileOptions())
     monkeypatch.setattr(nox, "options", nox._options.noxfile_options)
 
     # Execute

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,7 +76,7 @@ def test_main_no_args(monkeypatch: pytest.MonkeyPatch, main: Any) -> None:
         assert config.sessions is None
         assert not config.no_venv
         assert not config.reuse_existing_virtualenvs
-        assert not config.reuse_venv
+        assert config.reuse_venv == "no"
         assert not config.stop_on_first_error
         assert config.posargs == []
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1379,7 +1379,10 @@ class TestSessionRunner:
         ],
     )
     def test__reuse_venv_outcome(
-        self, reuse_venv: str, reuse_venv_func: bool | None, should_reuse: bool
+        self,
+        reuse_venv: Literal["no", "yes", "never", "always"],
+        reuse_venv_func: bool | None,
+        should_reuse: bool,
     ) -> None:
         runner = self.make_runner()
         runner.func.reuse_venv = reuse_venv_func
@@ -1388,10 +1391,8 @@ class TestSessionRunner:
 
     def test__reuse_venv_invalid(self) -> None:
         runner = self.make_runner()
-        runner.global_config.reuse_venv = True
-        msg = "nox.options.reuse_venv must be set to 'always', 'never', 'no', or 'yes', got True!"
-        with pytest.raises(AttributeError, match=re.escape(msg)):
-            runner.reuse_existing_venv()
+        with pytest.raises(ValueError, match="'reuse_venv' must be in"):
+            runner.global_config.reuse_venv = True  # type: ignore[assignment]
 
     def make_runner_with_mock_venv(self) -> nox.sessions.SessionRunner:
         runner = self.make_runner()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -193,7 +193,7 @@ def test_discover_session_functions_decorator() -> None:
             __name__=foo.__module__, foo=foo, bar=bar, notasession=notasession
         ),
     )
-    config = _options.options.namespace(sessions=(), keywords=(), posargs=[])
+    config = _options.options.namespace(sessions=(), keywords=None, posargs=[])
 
     # Get the manifest and establish that it looks like what we expect.
     manifest = tasks.discover_manifest(mock_module, config)
@@ -204,7 +204,7 @@ def test_discover_session_functions_decorator() -> None:
 
 def test_filter_manifest() -> None:
     config = _options.options.namespace(
-        sessions=None, pythons=(), keywords=(), posargs=[]
+        sessions=None, pythons=(), keywords=None, posargs=[]
     )
     manifest = Manifest({"foo": session_func, "bar": session_func}, config)
     return_value = tasks.filter_manifest(manifest, config)
@@ -214,7 +214,7 @@ def test_filter_manifest() -> None:
 
 def test_filter_manifest_not_found() -> None:
     config = _options.options.namespace(
-        sessions=("baz",), pythons=(), keywords=(), posargs=[]
+        sessions=("baz",), pythons=(), keywords=None, posargs=[]
     )
     manifest = Manifest({"foo": session_func, "bar": session_func}, config)
     return_value = tasks.filter_manifest(manifest, config)
@@ -223,7 +223,7 @@ def test_filter_manifest_not_found() -> None:
 
 def test_filter_manifest_pythons() -> None:
     config = _options.options.namespace(
-        sessions=None, pythons=("3.8",), keywords=(), posargs=[]
+        sessions=None, pythons=("3.8",), keywords=None, posargs=[]
     )
     manifest = Manifest(
         {"foo": session_func_with_python, "bar": session_func, "baz": session_func},
@@ -236,7 +236,7 @@ def test_filter_manifest_pythons() -> None:
 
 def test_filter_manifest_pythons_not_found(caplog: pytest.LogCaptureFixture) -> None:
     config = _options.options.namespace(
-        sessions=None, pythons=("1.2",), keywords=(), posargs=[]
+        sessions=None, pythons=("1.2",), keywords=None, posargs=[]
     )
     manifest = Manifest(
         {"foo": session_func_with_python, "bar": session_func, "baz": session_func},
@@ -599,21 +599,21 @@ def test_empty_session_None_in_noxfile() -> None:
 
 
 def test_verify_manifest_empty() -> None:
-    config = _options.options.namespace(sessions=(), keywords=())
+    config = _options.options.namespace(sessions=(), keywords=None)
     manifest = Manifest({}, config)
     return_value = tasks.filter_manifest(manifest, global_config=config)
     assert return_value == 3
 
 
 def test_verify_manifest_nonempty() -> None:
-    config = _options.options.namespace(sessions=None, keywords=(), posargs=[])
+    config = _options.options.namespace(sessions=None, keywords=None, posargs=[])
     manifest = Manifest({"session": session_func}, config)
     return_value = tasks.filter_manifest(manifest, global_config=config)
     assert return_value == manifest
 
 
 def test_verify_manifest_list(capsys: pytest.CaptureFixture[builtins.str]) -> None:
-    config = _options.options.namespace(sessions=(), keywords=(), posargs=[])
+    config = _options.options.namespace(sessions=(), keywords=None, posargs=[])
     manifest = Manifest({"session": session_func}, config)
     return_value = tasks.filter_manifest(manifest, global_config=config)
     assert return_value == 0
@@ -690,7 +690,7 @@ def test_run_manifest_abort_on_first_failure() -> None:
 def test_print_summary_one_result() -> None:
     results = [mock.sentinel.RESULT]
     with mock.patch("nox.tasks.logger", autospec=True) as logger:
-        answer = tasks.print_summary(results, argparse.Namespace())
+        answer = tasks.print_summary(results, _options.options.namespace())
         assert not logger.warning.called
         assert not logger.success.called
         assert not logger.error.called
@@ -731,7 +731,7 @@ def test_print_summary() -> None:
             ),
         ]
 
-        answer = tasks.print_summary(results, argparse.Namespace())
+        answer = tasks.print_summary(results, _options.options.namespace())
 
         assert mock_log.call_count == 4
         calls = mock_log.call_args_list
@@ -854,7 +854,7 @@ def test_honor_usage_request_session_not_found() -> None:
 
 
 def test_final_reduce() -> None:
-    config = argparse.Namespace()
+    config = _options.options.namespace()
     true = typing.cast("sessions.Result", True)  # noqa: FBT003
     false = typing.cast("sessions.Result", False)  # noqa: FBT003
     assert tasks.final_reduce([true, true], config) == 0

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -137,7 +137,7 @@ def reset_needs_version() -> Generator[None, None, None]:
 
 @pytest.fixture
 def reset_global_nox_options() -> None:
-    nox.options = _options.options.noxfile_namespace()
+    nox.options = _options.NoxfileOptions()
 
 
 def test_load_nox_module_needs_version_static(tmp_path: Path) -> None:


### PR DESCRIPTION
Refactors option handling to use statically typed classes, based on scikit-build-core (but using attrs instead of dataclasses, since we already have that dependency). Everything is declared on each option, and other stuff derives from it. Total LoC is about the same for now (and shortens #1131 a lot).

It also means that global options are now a real typed objects. MyPy now can check usage, etc.

:robot: _AI text below_ :robot:

Rewrites option handling around a statically-typed attrs model. Options are now declared once, as fields on `NoxfileOptions` (the `nox.options` object) and `NoxConfig` (the `global_config` threaded through tasks and sessions). Each field carries its CLI metadata, and everything else is derived from the model:

- the argparse parser (choices from `Literal` types, flag pairs, env vars, completers),
- merging, via per-field provenance (default < noxfile < environment < command line).

The motivation is #1131, which needs to spawn child nox processes and currently hand-rebuilds ~18 flags with a "keep in sync" comment. The model makes a generic reverse serializer (`to_argv`) possible; since nothing in this PR uses it, it ships with #1131 instead, where the child command line becomes `to_argv(attrs.evolve(config, sessions=[...], ...))`.

This removes the old triple bookkeeping (the `Option` registry, the argparse namespace, and the hand-duplicated `NoxOptions` field list), the five custom merge functions, and the `DefaultStr` sentinel. `global_config` is now a real typed object, so mypy checks about 40 previously dynamic attribute reads. Layout: `_options.py` holds only the model; the generic machinery is in `_option_set.py`, shell completion in `_completers.py`, and post-parse policy (aliases, noxfile merge) in `_merge.py`.

The precedence fixes this model implied landed separately in #1145; the provenance rule reproduces them generically, and the regression tests from #1145 carry over. One behavior change remains here: assigning an invalid value to `nox.options.*` now raises immediately instead of surfacing as a warning or crash mid-run.

`--help` output is unchanged apart from ordering within groups. Session-level options (a `SessionOptions` model on `Func`) are deferred to a follow-up; this PR only extracts the pure `resolve_*` functions in `sessions.py` as the seam.
