### PR TITLE
fix: explicit command-line options beat noxfile and alias values

### DIFF
--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -321,20 +321,28 @@ class OptionSet:
 
             value = getattr(args, option.name)
 
+            # argparse only checks choices for values given on the command
+            # line; re-check here so bad environment-variable defaults produce
+            # a clean error instead of misbehaving later.
+            choices = option.kwargs.get("choices")
+            if choices is not None and value is not None and value not in choices:
+                msg = f"{option.name!r} must be in {choices!r} (got {value!r})"
+                raise ArgumentError(None, msg)
+
             # Handle options that have finalizer functions.
             if option.finalizer_func:
                 setattr(args, option.name, option.finalizer_func(value, args))
 
-    def parse_args(self) -> Namespace:
+    def parse_args(self, args: Sequence[str] | None = None) -> Namespace:
         parser = self.parser()
         argcomplete.autocomplete(parser)
-        args = parser.parse_args()
+        parsed_args = parser.parse_args(args)
 
         try:
-            self._finalize_args(args)
+            self._finalize_args(parsed_args)
         except ArgumentError as err:
             parser.error(str(err))
-        return args
+        return parsed_args
 
     def namespace(self, **kwargs: Any) -> argparse.Namespace:
         """Return a namespace that contains all of the options in this set.
@@ -360,13 +368,18 @@ class OptionSet:
     def noxfile_namespace(self) -> NoxOptions:
         """Returns a namespace of options that can be set in the configuration
         file."""
-        return NoxOptions(
-            **{
-                option.name: option.default
-                for option in self.options.values()
-                if option.noxfile
-            }  # type: ignore[arg-type]
-        )
+        values = {}
+        for option in self.options.values():
+            if not option.noxfile:
+                continue
+            value = option.default
+            choices = option.kwargs.get("choices")
+            if choices is not None and value not in choices:
+                # A bad environment-variable default; this runs at import
+                # time, so leave it unset and let parse_args report it.
+                value = None
+            values[option.name] = value
+        return NoxOptions(**values)  # type: ignore[arg-type]
 
     def merge_namespaces(
         self, command_args: Namespace, noxfile_args: NoxOptions

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -104,10 +104,12 @@ def _sessions_merge_func(
             command-line.
         noxfile_Args (NoxOptions): The options specified in the
             Noxfile."""
+    # A bare flag parses to an empty value, which is still an explicit choice
+    # that must win over the Noxfile, so compare against None here.
     if (
-        not command_args.sessions
-        and not command_args.keywords
-        and not command_args.tags
+        command_args.sessions is None
+        and command_args.keywords is None
+        and command_args.tags is None
     ):
         return getattr(noxfile_args, key)  # type: ignore[no-any-return]
     return getattr(command_args, key)  # type: ignore[no-any-return]
@@ -173,22 +175,22 @@ def _reuse_venv_merge_func(
     """Merge reuse_venv from command args and Noxfile while maintaining
     backwards compatibility with reuse_existing_virtualenvs. Default is "no".
 
+    The -r/-N/-R aliases are already folded into the command-line reuse_venv
+    by :func:`_reuse_venv_finalizer`, so any command-line value wins over the
+    Noxfile.
+
     Args:
         command_args (_option_set.Namespace): The options specified on the
             command-line.
         noxfile_Args (NoxOptions): The options specified in the
             Noxfile.
     """
-    # back-compat scenario with no_reuse_existing_virtualenvs/reuse_existing_virtualenvs
-    if command_args.no_reuse_existing_virtualenvs:
-        return "no"
-    if (
-        command_args.reuse_existing_virtualenvs
-        or noxfile_args.reuse_existing_virtualenvs
-    ):
+    if command_args.reuse_venv is not None:
+        return command_args.reuse_venv  # type: ignore[no-any-return]
+    # back-compat scenario with reuse_existing_virtualenvs in the Noxfile
+    if noxfile_args.reuse_existing_virtualenvs:
         return "yes"
-    # regular option behavior
-    return command_args.reuse_venv or noxfile_args.reuse_venv or "no"
+    return noxfile_args.reuse_venv or "no"
 
 
 def default_env_var_list_factory(env_var: str) -> Callable[[], list[str] | None]:
@@ -242,21 +244,26 @@ def _force_pythons_finalizer(
 
 
 def _R_finalizer(value: bool, args: argparse.Namespace) -> bool:  # noqa: FBT001
-    """Propagate -R to --reuse-existing-virtualenvs and --no-install and --reuse-venv=yes."""
+    """Propagate -R to --reuse-existing-virtualenvs and --no-install."""
     if value:
-        args.reuse_venv = "yes"
         args.reuse_existing_virtualenvs = args.no_install = value
     return value
 
 
-def _reuse_existing_virtualenvs_finalizer(
-    value: bool,  # noqa: FBT001
-    args: argparse.Namespace,
-) -> bool:
-    """Propagate --reuse-existing-virtualenvs to --reuse-venv=yes."""
-    if value:
-        args.reuse_venv = "yes"
-    return value
+def _reuse_venv_finalizer(
+    value: ReuseVenvType | None, args: argparse.Namespace
+) -> ReuseVenvType | None:
+    """Fold the -r/-N/-R aliases into --reuse-venv. An explicit --reuse-venv
+    wins over -r and -N given alongside it, but -R always forces reuse."""
+    if args.R:
+        return "yes"
+    if value is not None:
+        return value
+    if args.no_reuse_existing_virtualenvs:
+        return "no"
+    if args.reuse_existing_virtualenvs:
+        return "yes"
+    return None
 
 
 def _posargs_finalizer(
@@ -501,6 +508,7 @@ options.add_options(
         group=options.groups["environment"],
         noxfile=True,
         merge_func=_reuse_venv_merge_func,
+        finalizer_func=_reuse_venv_finalizer,
         help=(
             "Controls existing virtualenvs recreation. This is ``'no'`` by"
             " default, but any of ``('yes', 'no', 'always', 'never')`` are accepted."
@@ -516,7 +524,6 @@ options.add_options(
         ),
         group=options.groups["environment"],
         help="This is an alias for '--reuse-venv=yes|no'.",
-        finalizer_func=_reuse_existing_virtualenvs_finalizer,
     ),
     _option_set.Option(
         "R",

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -15,10 +15,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from nox import _option_set, _options
+
+if TYPE_CHECKING:
+    import argparse
 
 # The vast majority of _option_set is tested by test_main, but the test helper
 # :func:`OptionSet.namespace` needs a bit of help to get to full coverage.
@@ -158,3 +162,110 @@ class TestOptionSet:
 
         options.envdir = "envdir"
         options.envdir = Path("envdir")
+
+
+class TestMerge:
+    def parse_and_merge(
+        self, args: list[str], noxfile_config: _option_set.NoxOptions
+    ) -> argparse.Namespace:
+        config = _options.options.parse_args(args)
+        _options.options.merge_namespaces(config, noxfile_config)
+        return config
+
+    def test_noxfile_beats_default(self) -> None:
+        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config.sessions = ["lint"]
+        config = self.parse_and_merge([], noxfile_config)
+
+        assert config.sessions == ["lint"]
+
+    def test_cli_beats_noxfile(self) -> None:
+        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config.sessions = ["lint"]
+        config = self.parse_and_merge(["-s", "test"], noxfile_config)
+
+        assert config.sessions == ["test"]
+
+    def test_cli_reuse_venv_beats_noxfile_alias(self) -> None:
+        """An explicit CLI --reuse-venv wins over the noxfile's legacy
+        reuse_existing_virtualenvs alias (this used to be reversed)."""
+        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config.reuse_existing_virtualenvs = True
+        config = self.parse_and_merge(["--reuse-venv", "never"], noxfile_config)
+
+        assert config.reuse_venv == "never"
+
+    def test_bare_sessions_flag_beats_noxfile(self) -> None:
+        """An explicit but empty -s means "no sessions", not "use the
+        noxfile's list" (this used to fall through to the noxfile)."""
+        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config.sessions = ["lint"]
+        config = self.parse_and_merge(["-s"], noxfile_config)
+
+        assert config.sessions == []
+
+    def test_cli_keywords_suppress_noxfile_sessions(self) -> None:
+        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config.sessions = ["lint"]
+        config = self.parse_and_merge(["-k", "test"], noxfile_config)
+
+        assert config.sessions is None
+        assert config.keywords == "test"
+
+    def test_env_sessions_suppress_noxfile_sessions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NOXSESSION", "a,b")
+        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config.sessions = ["lint"]
+        config = self.parse_and_merge([], noxfile_config)
+
+        assert config.sessions == ["a", "b"]
+
+    def test_noxfile_beats_ci_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CI", "1")
+        noxfile_config = _options.options.noxfile_namespace()
+        noxfile_config.error_on_missing_interpreters = False
+        config = self.parse_and_merge([], noxfile_config)
+
+        assert config.error_on_missing_interpreters is False
+
+    def test_merged_defaults(self) -> None:
+        config = self.parse_and_merge([], _options.options.noxfile_namespace())
+
+        assert config.envdir == ".nox"
+        assert config.reuse_venv == "no"
+        assert config.default_venv_backend == "virtualenv"
+
+
+class TestEnvVars:
+    def test_invalid_value_is_a_clean_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A bad env-var value must produce a parser error, not a traceback."""
+        monkeypatch.setenv("NOX_DOWNLOAD_PYTHON", "bogus")
+
+        with pytest.raises(SystemExit):
+            _options.options.parse_args([])
+
+        assert "'download_python' must be in" in capsys.readouterr().err
+
+
+class TestReuseAliasPrecedence:
+    """An explicit --reuse-venv on the command line now wins over the -r/-N
+    aliases given alongside it (the aliases used to win). -R still wins."""
+
+    def test_r_with_explicit_reuse_venv(self) -> None:
+        config = _options.options.parse_args(["-r", "--reuse-venv", "never"])
+
+        assert config.reuse_venv == "never"
+
+    def test_no_reuse_with_explicit_reuse_venv(self) -> None:
+        config = _options.options.parse_args(["-N", "--reuse-venv", "always"])
+
+        assert config.reuse_venv == "always"
+
+    def test_R_beats_no_reuse(self) -> None:
+        config = _options.options.parse_args(["-N", "-R"])
+
+        assert config.reuse_venv == "yes"


### PR DESCRIPTION
Pulled out just the behavior changes to make it easier to review.

:robot: _AI text below_ :robot:

Fixes three option-precedence bugs, split out of #1144 so that PR can be a pure refactor:

- An explicit `--reuse-venv` on the command line now wins over the noxfile's legacy `reuse_existing_virtualenvs` alias, and over `-r`/`-N` given alongside it (`-R` still forces reuse). The aliases are folded into `reuse_venv` in a finalizer, so the merge step just prefers any command-line value.
- A bare `-s` now means "no sessions" instead of falling back to the noxfile's session list; the merge distinguishes an empty selection from an absent one.
- An invalid environment-variable value like `NOX_DOWNLOAD_PYTHON=bogus` now produces a clean parser error; it used to crash with a traceback at import time. argparse only checks `choices` for command-line values, so defaults are re-checked during finalization.

Each fix has a regression test that fails without it. `OptionSet.parse_args` also gained an optional argv list parameter for the tests.