### PR TITLE
fix: conda version constraints on Windows

### DIFF
--- a/nox/popen.py
+++ b/nox/popen.py
@@ -32,8 +32,6 @@ __all__ = [
     "popen",
 ]
 
-_CMD_META = frozenset("&<>^|")
-
 
 def __dir__() -> list[str]:
     return __all__
@@ -41,6 +39,8 @@ def __dir__() -> list[str]:
 
 DEFAULT_INTERRUPT_TIMEOUT = 0.3
 DEFAULT_TERMINATE_TIMEOUT = 0.2
+
+_CMD_META = frozenset("&<>^|")
 
 
 def _windows_batch_command(args: Sequence[str]) -> str:

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -32,6 +32,8 @@ __all__ = [
     "popen",
 ]
 
+_CMD_META = frozenset("&<>^|")
+
 
 def __dir__() -> list[str]:
     return __all__
@@ -39,6 +41,21 @@ def __dir__() -> list[str]:
 
 DEFAULT_INTERRUPT_TIMEOUT = 0.3
 DEFAULT_TERMINATE_TIMEOUT = 0.2
+
+
+def _windows_batch_command(args: Sequence[str]) -> str:
+    """Build a command line that protects cmd.exe metacharacters."""
+
+    quoted_args = []
+    for arg in args:
+        if _CMD_META.isdisjoint(arg):
+            quoted_args.append(subprocess.list2cmdline([arg]))
+        else:
+            # Force list2cmdline to quote the argument, then remove the
+            # temporary leading space without changing the argument itself.
+            quoted = subprocess.list2cmdline([f" {arg}"])
+            quoted_args.append(f"{quoted[0]}{quoted[2:]}")
+    return " ".join(quoted_args)
 
 
 def shutdown_process(
@@ -97,7 +114,11 @@ def popen(
     if silent:
         stdout = subprocess.PIPE
 
-    proc = subprocess.Popen(args, env=env, stdout=stdout, stderr=stderr)
+    popen_args: Sequence[str] | str = args
+    if sys.platform.startswith("win") and args[0].casefold().endswith((".bat", ".cmd")):
+        popen_args = _windows_batch_command(args)
+
+    proc = subprocess.Popen(popen_args, env=env, stdout=stdout, stderr=stderr)
 
     try:
         out, _err = proc.communicate()

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -44,15 +44,26 @@ DEFAULT_TERMINATE_TIMEOUT = 0.2
 
 
 def _windows_batch_command(args: Sequence[str]) -> str:
-    """Build a command line that protects cmd.exe metacharacters."""
+    """Build a command line that protects the cmd.exe metacharacters ``&<>^|``.
+
+    Note that ``%`` cannot be protected at this layer: cmd.exe expands
+    ``%VAR%`` references even inside double quotes.
+    """
 
     quoted_args = []
     for arg in args:
         if _CMD_META.isdisjoint(arg):
             quoted_args.append(subprocess.list2cmdline([arg]))
+        elif '"' in arg:
+            # list2cmdline escapes embedded quotes with backslashes, but
+            # cmd.exe knows no backslash escapes - it only counts quote
+            # characters - so such an argument cannot be quoted safely.
+            msg = f"Cannot escape argument for batch script: {arg}"
+            raise ValueError(msg)
         else:
             # Force list2cmdline to quote the argument, then remove the
-            # temporary leading space without changing the argument itself.
+            # temporary leading space without changing the argument itself:
+            # ' requests<99' -> '" requests<99"' -> '"requests<99"'
             quoted = subprocess.list2cmdline([f" {arg}"])
             quoted_args.append(f"{quoted[0]}{quoted[2:]}")
     return " ".join(quoted_args)

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = {"contextlib", "locale"}
+__lazy_modules__ = {"contextlib", "itertools", "locale"}
 
 import contextlib
+import itertools
 import locale
+import os
 import subprocess
 import sys
 from typing import IO, TYPE_CHECKING
@@ -40,24 +42,82 @@ def __dir__() -> list[str]:
 DEFAULT_INTERRUPT_TIMEOUT = 0.3
 DEFAULT_TERMINATE_TIMEOUT = 0.2
 
-_CMD_META = frozenset("&<>^|")
+_CMD_META = frozenset("&<>^|()")
+
+# Variables cmd.exe resolves dynamically or defines itself, so a reference to
+# one expands even when it is absent from the child process environment.
+_CMD_AUTO_VARS = frozenset(
+    {
+        "__APPDIR__",
+        "__CD__",
+        "CD",
+        "CMDCMDLINE",
+        "CMDEXTVERSION",
+        "COMSPEC",
+        "DATE",
+        "ERRORLEVEL",
+        "HIGHESTNUMANODENUMBER",
+        "PATHEXT",
+        "PROMPT",
+        "RANDOM",
+        "TIME",
+    }
+)
 
 
-def _windows_batch_command(args: Sequence[str]) -> str:
-    """Build a command line that protects the cmd.exe metacharacters ``&<>^|``.
+def _expandable_reference(arg: str, env: Mapping[str, str]) -> str | None:
+    """Find a ``%VAR%`` reference that cmd.exe would expand, if there is one.
 
-    Note that ``%`` cannot be protected at this layer: cmd.exe expands
-    ``%VAR%`` references even inside double quotes.
+    cmd.exe scans the text between each pair of ``%`` characters; when it
+    names a defined (or dynamic) variable - optionally followed by ``:``
+    modifiers, the value is substituted, even inside double quotes. An
+    undefined name is left alone and the scan resumes at the trailing ``%``.
     """
+    defined = {name.upper() for name in env}
+    percents = [index for index, char in enumerate(arg) if char == "%"]
+    for start, end in itertools.pairwise(percents):
+        name = arg[start + 1 : end].partition(":")[0].upper()
+        if name and (
+            name in defined
+            or name in _CMD_AUTO_VARS
+            # hidden variables such as the per-drive working directory "=C:"
+            or name.startswith("=")
+        ):
+            return arg[start : end + 1]
+    return None
+
+
+def _windows_batch_command(
+    args: Sequence[str], env: Mapping[str, str] | None = None
+) -> str:
+    """Build a command line that protects the cmd.exe metacharacters ``&<>^|()``.
+
+    Arguments cmd.exe would corrupt anyway are rejected: ``%VAR%`` references
+    are expanded even inside double quotes, and quote characters cannot be
+    escaped. cmd.exe doesn't have backslash escapes, it only counts quotes.
+    """
+    if env is None:
+        env = os.environ
 
     quoted_args = []
     for arg in args:
+        reference = _expandable_reference(arg, env)
+        if reference is not None:
+            msg = (
+                "Cannot escape argument for batch script, cmd.exe would"
+                f" expand {reference}: {arg}"
+            )
+            raise ValueError(msg)
         if _CMD_META.isdisjoint(arg):
             quoted_args.append(subprocess.list2cmdline([arg]))
+        elif len(arg) >= 2 and arg[0] == arg[-1] == '"' and '"' not in arg[1:-1]:
+            # A pre-quoted argument such as '"urllib3<1.25"' (the historical
+            # workaround): its outer quotes already protect the
+            # metacharacters, so pass it through unchanged.
+            quoted_args.append(arg)
         elif '"' in arg:
             # list2cmdline escapes embedded quotes with backslashes, but
-            # cmd.exe knows no backslash escapes - it only counts quote
-            # characters - so such an argument cannot be quoted safely.
+            # cmd.exe doesn't have backslash escapes.
             msg = f"Cannot escape argument for batch script: {arg}"
             raise ValueError(msg)
         else:
@@ -127,7 +187,7 @@ def popen(
 
     popen_args: Sequence[str] | str = args
     if sys.platform.startswith("win") and args[0].casefold().endswith((".bat", ".cmd")):
-        popen_args = _windows_batch_command(args)
+        popen_args = _windows_batch_command(args, env)
 
     proc = subprocess.Popen(popen_args, env=env, stdout=stdout, stderr=stderr)
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -132,32 +132,6 @@ def _normalize_path(envdir: str, path: str) -> str:
     return full_path
 
 
-def _dblquote_pkg_install_args(args: Iterable[str]) -> tuple[str, ...]:
-    """Double-quote package install arguments in case they contain '>' or '<' symbols"""
-
-    # routine used to handle a single arg
-    def _dblquote_pkg_install_arg(pkg_req_str: str) -> str:
-        # sanity check: we need an even number of double-quotes
-        if pkg_req_str.count('"') % 2 != 0:
-            msg = f"ill-formatted argument with odd number of quotes: {pkg_req_str}"
-            raise ValueError(msg)
-
-        if "<" in pkg_req_str or ">" in pkg_req_str:
-            if pkg_req_str[0] == pkg_req_str[-1] == '"':
-                # already double-quoted string
-                return pkg_req_str
-            # need to double-quote string
-            if '"' in pkg_req_str:
-                msg = f"Cannot escape requirement string: {pkg_req_str}"
-                raise ValueError(msg)
-            return f'"{pkg_req_str}"'
-        # no dangerous char: no need to double-quote string
-        return pkg_req_str
-
-    # double-quote all args that need to be and return the result
-    return tuple(_dblquote_pkg_install_arg(a) for a in args)
-
-
 class _SessionQuit(Exception):
     pass
 
@@ -800,10 +774,6 @@ class Session:
             isinstance(venv, PassthroughEnv) or venv._reused
         ):
             return
-
-        # Escape args that should be (conda-specific; pip install does not need this)
-        if sys.platform.startswith("win"):
-            args = _dblquote_pkg_install_args(args)
 
         if silent is None:
             silent = not self._runner.global_config.verbose

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,10 +93,11 @@ def xonda_tests(session: nox.Session, xonda: str) -> None:
     )
     env = {"COVERAGE_FILE": coverage_file}
 
-    # Windows breaks currently either with or without quoting, so it's omitted there.
-    extra_specs = [] if sys.platform.startswith("win32") else ["requests<99"]
     session.conda_install(
-        "--file", "requirements-conda-test.txt", *extra_specs, channel="conda-forge"
+        "--file",
+        "requirements-conda-test.txt",
+        "requests<99",
+        channel="conda-forge",
     )
     session.install("-e.", "--no-deps")
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -57,13 +57,14 @@ def _write_echo_batch(tmp_path: Path, suffix: str = ".bat") -> Path:
 
 def test_windows_batch_command() -> None:
     command = nox.popen._windows_batch_command(
-        [r"C:\Program Files\tool.cmd", "plain", "has space", "requests<99"]
+        [r"C:\Program Files\tool.cmd", "plain", "has space", "requests<99", "py(3)"]
     )
 
-    assert command == r'"C:\Program Files\tool.cmd" plain "has space" "requests<99"'
+    expected = r'"C:\Program Files\tool.cmd" plain "has space" "requests<99" "py(3)"'
+    assert command == expected
 
 
-@pytest.mark.parametrize("argument", ['"urllib3<1.25"', 'a"<b', 'a">b'])
+@pytest.mark.parametrize("argument", ['a"<b', 'a">b', '"urllib3<1.25', 'urllib3<1.25"'])
 def test_windows_batch_command_rejects_quoted_metacharacters(argument: str) -> None:
     # cmd.exe only counts quote characters, so an argument mixing quotes and
     # metacharacters cannot be escaped reliably; 'a">b' would even run
@@ -72,10 +73,62 @@ def test_windows_batch_command_rejects_quoted_metacharacters(argument: str) -> N
         nox.popen._windows_batch_command([r"C:\tool.bat", argument])
 
 
+def test_windows_batch_command_accepts_pre_quoted_argument() -> None:
+    # the historical workaround from #312: the caller quotes the constraint
+    # themselves, and the outer quotes already protect the metacharacters.
+    command = nox.popen._windows_batch_command([r"C:\tool.bat", '"urllib3<1.25"'])
+
+    assert command == r'C:\tool.bat "urllib3<1.25"'
+
+
+@pytest.mark.parametrize(
+    "argument",
+    ["%NOX_TEST_VAR%", "pre%NOX_TEST_VAR%post", "%%NOX_TEST_VAR%%", '"%NOX_TEST_VAR%"'],
+)
+def test_windows_batch_command_rejects_percent_expansion(argument: str) -> None:
+    # cmd.exe expands %VAR% references even inside double quotes, so an
+    # argument referencing a defined variable cannot be passed through
+    # faithfully; a variable value could even inject extra commands.
+    with pytest.raises(ValueError, match="would expand %NOX_TEST_VAR%"):
+        nox.popen._windows_batch_command(
+            [r"C:\tool.bat", argument], {"nox_test_var": "value"}
+        )
+
+
+@pytest.mark.parametrize("argument", ["%RANDOM%", "%__CD__%", "%=C:%", "%PATH:;=,%"])
+def test_windows_batch_command_rejects_dynamic_percent_expansion(
+    argument: str,
+) -> None:
+    # these expand even when the variable is missing from the child
+    # environment: cmd.exe resolves them dynamically or defines them itself.
+    with pytest.raises(ValueError, match="would expand"):
+        nox.popen._windows_batch_command([r"C:\tool.bat", argument], {"PATH": "C:;D:"})
+
+
+@pytest.mark.parametrize(
+    "argument", ["100%", "%%", "%undefined_variable%", "https://x.test/%20a%20b.whl"]
+)
+def test_windows_batch_command_allows_literal_percents(argument: str) -> None:
+    # cmd.exe leaves references to undefined variables alone, so these
+    # arguments survive verbatim and are safe to pass through.
+    command = nox.popen._windows_batch_command([r"C:\tool.bat", argument], {})
+
+    assert command == f"C:\\tool.bat {argument}"
+
+
 @only_on_windows
 @pytest.mark.parametrize("suffix", [".bat", ".cmd"])
 @pytest.mark.parametrize(
-    "argument", ["name&value", "name<value", "name>value", "name^value", "name|value"]
+    "argument",
+    [
+        "name&value",
+        "name<value",
+        "name>value",
+        "name^value",
+        "name|value",
+        "name(value",
+        "name)value",
+    ],
 )
 def test_run_windows_batch_metacharacter_arg(
     tmp_path: Path, suffix: str, argument: str
@@ -85,6 +138,34 @@ def test_run_windows_batch_metacharacter_arg(
     result = nox.command.run([batch, argument], silent=True)
 
     assert result.strip() == argument
+
+
+@only_on_windows
+def test_run_windows_batch_paren_arg_in_block(tmp_path: Path) -> None:
+    # conda.bat-style scripts wrap commands in if (...) blocks, where an
+    # unquoted ")" in an argument ends the block early and silently corrupts
+    # the argument (or aborts with "... was unexpected at this time").
+    batch = tmp_path / "block.bat"
+    batch.write_text(
+        f'@echo off\nif "1"=="1" (\n'
+        f'  "{PYTHON}" -c "import sys; print(sys.argv[1])" %*\n)\n',
+        encoding="utf-8",
+    )
+
+    result = nox.command.run([batch, "(pkg)"], silent=True)
+
+    assert result.strip() == "(pkg)"
+
+
+@only_on_windows
+def test_run_windows_batch_pre_quoted_arg(tmp_path: Path) -> None:
+    # the pre-quoted idiom from #312 keeps working; the child process sees
+    # the argument without the caller's quotes, which is what conda expects.
+    batch = _write_echo_batch(tmp_path)
+
+    result = nox.command.run([batch, '"urllib3<1.25"'], silent=True)
+
+    assert result.strip() == "urllib3<1.25"
 
 
 @only_on_windows

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -98,7 +98,7 @@ def test_run_windows_batch_quoted_metacharacter_arg(
         nox.command.run([batch, 'a">b'], silent=True)
 
     # the command must not have run at all, let alone create "b" via redirection
-    assert list(tmp_path.iterdir()) == [batch]
+    assert [path.name for path in tmp_path.iterdir()] == [batch.name]
 
 
 def test_run_defaults() -> None:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -45,6 +45,33 @@ only_on_windows = pytest.mark.skipif(
 )
 
 
+def test_windows_batch_command() -> None:
+    command = nox.popen._windows_batch_command(
+        [r"C:\Program Files\tool.cmd", "plain", "has space", "requests<99"]
+    )
+
+    assert command == (r'"C:\Program Files\tool.cmd" plain "has space" "requests<99"')
+
+
+@only_on_windows
+@pytest.mark.parametrize("suffix", [".bat", ".cmd"])
+@pytest.mark.parametrize(
+    "argument", ["name&value", "name<value", "name>value", "name^value", "name|value"]
+)
+def test_run_windows_batch_metacharacter_arg(
+    tmp_path: Path, suffix: str, argument: str
+) -> None:
+    batch = tmp_path / f"echo-arg{suffix}"
+    batch.write_text(
+        f'@"{PYTHON}" -c "import sys; print(sys.argv[1])" %*\n',
+        encoding="utf-8",
+    )
+
+    result = nox.command.run([batch, argument], silent=True)
+
+    assert result.strip() == argument
+
+
 def test_run_defaults() -> None:
     result = nox.command.run([PYTHON, "-c", "print(123)"])
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -45,12 +45,22 @@ only_on_windows = pytest.mark.skipif(
 )
 
 
+def _write_echo_batch(tmp_path: Path, suffix: str = ".bat") -> Path:
+    """Write a batch script that echoes its first argument."""
+    batch = tmp_path / f"echo-arg{suffix}"
+    batch.write_text(
+        f'@"{PYTHON}" -c "import sys; print(sys.argv[1])" %*\n',
+        encoding="utf-8",
+    )
+    return batch
+
+
 def test_windows_batch_command() -> None:
     command = nox.popen._windows_batch_command(
         [r"C:\Program Files\tool.cmd", "plain", "has space", "requests<99"]
     )
 
-    assert command == (r'"C:\Program Files\tool.cmd" plain "has space" "requests<99"')
+    assert command == r'"C:\Program Files\tool.cmd" plain "has space" "requests<99"'
 
 
 @pytest.mark.parametrize("argument", ['"urllib3<1.25"', 'a"<b', 'a">b'])
@@ -70,11 +80,7 @@ def test_windows_batch_command_rejects_quoted_metacharacters(argument: str) -> N
 def test_run_windows_batch_metacharacter_arg(
     tmp_path: Path, suffix: str, argument: str
 ) -> None:
-    batch = tmp_path / f"echo-arg{suffix}"
-    batch.write_text(
-        f'@"{PYTHON}" -c "import sys; print(sys.argv[1])" %*\n',
-        encoding="utf-8",
-    )
+    batch = _write_echo_batch(tmp_path, suffix)
 
     result = nox.command.run([batch, argument], silent=True)
 
@@ -85,11 +91,7 @@ def test_run_windows_batch_metacharacter_arg(
 def test_run_windows_batch_quoted_metacharacter_arg(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    batch = tmp_path / "echo-arg.bat"
-    batch.write_text(
-        f'@"{PYTHON}" -c "import sys; print(sys.argv[1])" %*\n',
-        encoding="utf-8",
-    )
+    batch = _write_echo_batch(tmp_path)
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(ValueError, match="Cannot escape"):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -53,6 +53,15 @@ def test_windows_batch_command() -> None:
     assert command == (r'"C:\Program Files\tool.cmd" plain "has space" "requests<99"')
 
 
+@pytest.mark.parametrize("argument", ['"urllib3<1.25"', 'a"<b', 'a">b'])
+def test_windows_batch_command_rejects_quoted_metacharacters(argument: str) -> None:
+    # cmd.exe only counts quote characters, so an argument mixing quotes and
+    # metacharacters cannot be escaped reliably; 'a">b' would even run
+    # successfully while silently redirecting output into a stray file "b".
+    with pytest.raises(ValueError, match="Cannot escape"):
+        nox.popen._windows_batch_command([r"C:\tool.bat", argument])
+
+
 @only_on_windows
 @pytest.mark.parametrize("suffix", [".bat", ".cmd"])
 @pytest.mark.parametrize(
@@ -70,6 +79,24 @@ def test_run_windows_batch_metacharacter_arg(
     result = nox.command.run([batch, argument], silent=True)
 
     assert result.strip() == argument
+
+
+@only_on_windows
+def test_run_windows_batch_quoted_metacharacter_arg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    batch = tmp_path / "echo-arg.bat"
+    batch.write_text(
+        f'@"{PYTHON}" -c "import sys; print(sys.argv[1])" %*\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="Cannot escape"):
+        nox.command.run([batch, 'a">b'], silent=True)
+
+    # the command must not have run at all, let alone create "b" via redirection
+    assert list(tmp_path.iterdir()) == [batch]
 
 
 def test_run_defaults() -> None:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -700,11 +700,11 @@ class TestSession:
         assert run.called is run_called
 
     @pytest.mark.parametrize(
-        "version_constraint",
-        ["no", "yes", "already_dbl_quoted"],
-        ids="version_constraint={}".format,
+        "pkg_requirement",
+        ["urllib3", "urllib3<1.25", '"urllib3<1.25"'],
+        ids=["no_constraint", "version_constraint", "pre_quoted"],
     )
-    def test_conda_install_non_default_kwargs(self, version_constraint: str) -> None:
+    def test_conda_install_non_default_kwargs(self, pkg_requirement: str) -> None:
         runner = nox.sessions.SessionRunner(
             name="test",
             signatures=["test"],
@@ -724,15 +724,6 @@ class TestSession:
 
         session = SessionNoSlots(runner=runner)
 
-        if version_constraint == "no":
-            pkg_requirement = passed_arg = "urllib3"
-        elif version_constraint == "yes":
-            pkg_requirement = passed_arg = "urllib3<1.25"
-        elif version_constraint == "already_dbl_quoted":
-            pkg_requirement = passed_arg = '"urllib3<1.25"'
-        else:
-            raise ValueError(version_constraint)
-
         with mock.patch.object(session, "_run", autospec=True) as run:
             session.conda_install("requests", pkg_requirement, silent=False)
             run.assert_called_once_with(
@@ -742,7 +733,7 @@ class TestSession:
                 "--prefix",
                 "/path/to/conda/env",
                 "requests",
-                passed_arg,
+                pkg_requirement,
                 **_run_with_defaults(silent=False, external="error"),
             )
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -742,7 +742,6 @@ class TestSession:
                 "--prefix",
                 "/path/to/conda/env",
                 "requests",
-                # this will be double quoted if unquoted constraint is present
                 passed_arg,
                 **_run_with_defaults(silent=False, external="error"),
             )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -609,26 +609,6 @@ class TestSession:
         with pytest.raises(ValueError, match="arg"):
             session.conda_install()
 
-    @pytest.mark.skipif(not sys.platform.startswith("win32"), reason="Only on Windows")
-    def test_conda_install_bad_args_odd_nb_double_quotes(self) -> None:
-        session, runner = self.make_session_and_runner()
-        runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
-        assert runner.venv
-        runner.venv.location = "./not/a/location"
-
-        with pytest.raises(ValueError, match="odd number of quotes"):
-            session.conda_install('a"a')
-
-    @pytest.mark.skipif(not sys.platform.startswith("win32"), reason="Only on Windows")
-    def test_conda_install_bad_args_cannot_escape(self) -> None:
-        session, runner = self.make_session_and_runner()
-        runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
-        assert runner.venv
-        runner.venv.location = "./not/a/location"
-
-        with pytest.raises(ValueError, match="Cannot escape"):
-            session.conda_install('a"o"<a')
-
     def test_conda_install_not_a_condaenv(self) -> None:
         session, runner = self.make_session_and_runner()
 
@@ -685,7 +665,7 @@ class TestSession:
                 *args,
                 "--prefix",
                 "/path/to/conda/env",
-                '"requests<99"' if sys.platform.startswith("win32") else "requests<99",
+                "requests<99",
                 "urllib3",
                 **_run_with_defaults(silent=True, external="error"),
             )
@@ -746,11 +726,8 @@ class TestSession:
 
         if version_constraint == "no":
             pkg_requirement = passed_arg = "urllib3"
-        elif version_constraint == "yes" and not sys.platform.startswith("win32"):
+        elif version_constraint == "yes":
             pkg_requirement = passed_arg = "urllib3<1.25"
-        elif version_constraint == "yes" and sys.platform.startswith("win32"):
-            pkg_requirement = "urllib3<1.25"
-            passed_arg = f'"{pkg_requirement}"'
         elif version_constraint == "already_dbl_quoted":
             pkg_requirement = passed_arg = '"urllib3<1.25"'
         else:


### PR DESCRIPTION
## Summary
- quote cmd.exe metacharacters at the command-line layer when Nox invokes `.bat` or `.cmd` launchers
- remove the conda-specific workaround that passed literal quotes through to newer conda versions
- exercise constrained conda installs on Windows again and add regression coverage for batch launchers

Fixes #951.

## Validation
- `python -m pytest tests/test_command.py tests/test_sessions.py -q` (203 passed, 6 skipped)
- `prek run ruff-check --files nox/popen.py nox/sessions.py noxfile.py tests/test_command.py tests/test_sessions.py`
- `prek run ruff-format --files nox/popen.py nox/sessions.py noxfile.py tests/test_command.py tests/test_sessions.py`
- `prek run mypy --files nox/popen.py nox/sessions.py noxfile.py`