### PR TITLE
chore: fix flake8-lazy merge

### DIFF
--- a/nox/project.py
+++ b/nox/project.py
@@ -5,6 +5,7 @@ __lazy_modules__ = {
     "packaging",
     "packaging.requirements",
     "packaging.specifiers",
+    "packaging.version",
     "pathlib",
     "tomllib",
 }


### PR DESCRIPTION
A PR was merged without rebasing it first, so it missed the flake8-lazy addition, causing it to pass previously but fail now. Rerunning `prek -a`.
