### PR TITLE
fix: do not write ~/.local/bin shims when provisioning with uv

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -248,9 +248,13 @@ def uv_version(uv_bin: str) -> version.Version:
 def uv_install_python(python_version: str) -> bool:
     """Attempts to install a given python version with uv"""
     _, uv, _ = _uv_state()
+    # Do not write python3.X shims to ~/.local/bin (uv >= 0.8 default); an
+    # explicit user setting still wins. See #1139.
+    env = {"UV_PYTHON_INSTALL_BIN": "0", **os.environ}
     ret = subprocess.run(
         [uv, "python", "install", python_version],
         check=False,
+        env=env,
     )
     return ret.returncode == 0
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1343,6 +1343,30 @@ def test_uv_install(requested_python: str, expected_result: bool) -> None:
     assert nox.virtualenv.uv_install_python(requested_python) == expected_result
 
 
+def test_uv_install_no_bin_shims(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provisioning must not write python3.X shims into ~/.local/bin (#1139)."""
+    captured: dict[str, object] = {}
+
+    def mock_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args=[], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    monkeypatch.delenv("UV_PYTHON_INSTALL_BIN", raising=False)
+
+    assert nox.virtualenv.uv_install_python("3.12")
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["UV_PYTHON_INSTALL_BIN"] == "0"
+
+    # An explicit user setting wins over our default.
+    monkeypatch.setenv("UV_PYTHON_INSTALL_BIN", "1")
+    assert nox.virtualenv.uv_install_python("3.12")
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["UV_PYTHON_INSTALL_BIN"] == "1"
+
+
 def test_create_reuse_venv_environment(
     make_one: Callable[..., tuple[VirtualEnv | ProcessEnv, Path]],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

uv >= 0.8 makes `uv python install` create versioned shims in `~/.local/bin` by default, so nox provisioning a missing interpreter changed the user's PATH as a side effect (reported in #1139). Set `UV_PYTHON_INSTALL_BIN=0` on the subprocess environment. An explicit user setting of that variable still wins. The env var is used instead of `--no-bin` because nox supports uv versions that predate the flag, and older uv ignores the variable.

Addresses the independent minimal fix from #1139; the discovery part of that issue is handled by python-discovery (#1086).