### PR TITLE
fix: translate PEP 440 range interpreters to conda version specs

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -507,6 +507,8 @@ class CondaEnv(ProcessEnv):
             * ``X.Y.Z``, e.g. ``3.4.9``
             * ``pythonX.Y``, e.g. ``python2.7``
             * A path in the filesystem to a Python executable
+            * A PEP 440 range, e.g. ``>=3.10``, passed to conda as a
+              version spec
 
             If not specified, this will use the currently running Python.
         reuse_existing (Optional[bool]): Flag indicating if the conda environment
@@ -604,7 +606,14 @@ class CondaEnv(ProcessEnv):
         # Ensure the pip package is installed.
         cmd.append("pip")
 
-        python_dep = f"python={self.interpreter}" if self.interpreter else "python"
+        if self.interpreter:
+            # Conda understands PEP 440 range operators (e.g. ">=3.10,<4")
+            # directly; only a bare version needs "=".
+            spec = self.interpreter.replace(" ", "")
+            prefix = "" if spec[0] in "<>!~=" else "="
+            python_dep = f"python{prefix}{spec}"
+        else:
+            python_dep = "python"
         cmd.append(python_dep)
 
         logger.info(

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -391,6 +391,29 @@ def test_conda_env_create_verbose(
     assert kwargs["log"]
 
 
+@pytest.mark.parametrize(
+    ("interpreter", "expected"),
+    [
+        (None, "python"),
+        ("3.12", "python=3.12"),
+        (">=3.10", "python>=3.10"),
+        (">= 3.10, <4", "python>=3.10,<4"),
+    ],
+)
+def test_condaenv_python_dep(
+    make_conda: Callable[..., tuple[CondaEnv, Path]],
+    interpreter: str | None,
+    expected: str,
+) -> None:
+    """PEP 440 ranges must become valid conda specs."""
+    venv, _dir = make_conda(interpreter=interpreter)
+    with mock.patch("nox.virtualenv.nox.command.run") as mock_run:
+        venv.create()
+
+    (cmd,), _kwargs = mock_run.call_args
+    assert cmd[-1] == expected
+
+
 @mock.patch("nox.virtualenv._PLATFORM", new="win32")
 def test_condaenv_bin_windows(make_conda: Callable[..., tuple[CondaEnv, Path]]) -> None:
     venv, dir_ = make_conda()


### PR DESCRIPTION
Pulling this out of #1148, as it's a simple fix and not related to that one.

:robot: _AI text below_ :robot:

Conda understands range operators directly, but the "python=" prefix made a range like ">=3.10" into an invalid spec.

Assisted-by: ClaudeCode:claude-fable-5
