### PR TITLE
test: make the remaining uv download tests pass without uv installed

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1697,7 +1697,12 @@ def test_download_python_auto_missing_interpreter(
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
     patch_discover: Callable[[str | None], list[str]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Pretend uv is available so the uv install path is exercised even on
+    # hosts without uv installed (gh-1045).
+    monkeypatch.setattr(nox.virtualenv, "HAS_UV", True)
+    monkeypatch.setattr(nox.virtualenv, "UV_VERSION", version.Version("0.10.0"))
     specs = patch_discover(None)
     venv, _ = make_one(
         interpreter="python3.11",
@@ -1736,7 +1741,12 @@ def test_download_python_always_preexisting_interpreter(
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
     patch_discover: Callable[[str | None], list[str]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Pretend uv is available so the uv install path is exercised even on
+    # hosts without uv installed (gh-1045).
+    monkeypatch.setattr(nox.virtualenv, "HAS_UV", True)
+    monkeypatch.setattr(nox.virtualenv, "UV_VERSION", version.Version("0.10.0"))
     specs = patch_discover("/usr/bin/python3.11")
     venv, _ = make_one(
         interpreter="python3.11",
@@ -1809,7 +1819,12 @@ def test_download_python_range_installs_floor(
     venv_backend: str,
     make_one: Callable[..., tuple[VirtualEnv, Path]],
     patch_discover: Callable[[str | None], list[str]],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Pretend uv is available so the uv install path is exercised even on
+    # hosts without uv installed (gh-1045).
+    monkeypatch.setattr(nox.virtualenv, "HAS_UV", True)
+    monkeypatch.setattr(nox.virtualenv, "UV_VERSION", version.Version("0.10.0"))
     # A range that isn't found installs its floor (">=3.14" -> "python3.14").
     patch_discover(None)
     venv, _ = make_one(


### PR DESCRIPTION
Fixes #1045. Same root cause as #1046 — three call sites #1137 did not cover.

## Reproduction on main @7519a98

```
$ python -m pytest tests/test_virtualenv.py -k download_python -q
33 passed

$ env -i PATH="$PWD/.venv/bin:/usr/bin:/bin" python -m pytest tests/test_virtualenv.py -k download_python -q
FAILED test_download_python_auto_missing_interpreter[uv]
FAILED test_download_python_always_preexisting_interpreter[uv]
FAILED test_download_python_range_installs_floor[always-uv]
FAILED test_download_python_range_installs_floor[auto-uv]
4 failed, 29 passed
```

## Cause

`nox/virtualenv.py:941-949`:

```python
if self.venv_backend == "uv":
    has_uv, _, uv_ver = _uv_state()
    if (
        has_uv
        and version.Version("0.4.16") <= uv_ver
        and uv_install_python(cleaned_interpreter)
    ):
```

Without uv on the host, `has_uv` is `False` and the mocked `uv_install_python`
is never reached, so `assert_called_once_with(...)` cannot hold.

This issue surfaces as `InterpreterNotFound` rather than #1046's assertion
error only because `test_download_python_failed_install` already wraps the call
in `pytest.raises`. Same short-circuit, different symptom.

## Change

The guard #1137 added, applied to the three remaining tests that assert
`uv_install_mock.assert_called_once_with(...)`. No production code touched, so
coverage is unaffected.

## Verification

`pytest tests/test_virtualenv.py` (whole file):

| | without uv | with uv |
|---|---|---|
| before | 4 failed, 156 passed | 7 failed, 187 passed |
| after | **0 failed, 160 passed** | 7 failed, 187 passed |

The 7 with-uv failures are conda tests. They are byte-identical before and
after — I diffed the two `FAILED` lists — and I did not investigate their
cause, since this change does not touch that path.

Removing `HAS_UV` from one of the three new guards turns exactly that one test
red again, so the guard is load-bearing rather than decorative.

`ruff check` and `ruff format --check` pass on the changed file.
