### PR TITLE
docs: fix broken examples, stale versions, and typos

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -101,13 +101,13 @@ And you can tell ``nox`` to run the session using the custom name:
 Configuring a session's virtualenv
 ----------------------------------
 
-By default, Nox will create a new virtualenv for each session using the same interpreter that Nox uses. If you installed Nox using Python 3.6, Nox will use Python 3.6 by default for all of your sessions.
+By default, Nox will create a new virtualenv for each session using the same interpreter that Nox uses. If you installed Nox using Python 3.12, Nox will use Python 3.12 by default for all of your sessions.
 
 You can tell Nox to use a different Python interpreter/version by specifying the ``python`` argument (or its alias ``py``) to ``@nox.session``:
 
 .. code-block:: python
 
-    @nox.session(python='2.7')
+    @nox.session(python='3.12')
     def tests(session):
         pass
 
@@ -123,11 +123,11 @@ You can tell Nox to use a different Python interpreter/version by specifying the
     .. _python-discovery: https://pypi.org/project/python-discovery/
     .. _PEP 514: https://peps.python.org/pep-0514/
 
-You can also tell Nox to run your session against multiple Python interpreters. Nox will create a separate virtualenv and run the session for each interpreter you specify. For example, this session will run twice - once for Python 2.7 and once for Python 3.6:
+You can also tell Nox to run your session against multiple Python interpreters. Nox will create a separate virtualenv and run the session for each interpreter you specify. For example, this session will run twice - once for Python 3.13 and once for Python 3.14:
 
 .. code-block:: python
 
-    @nox.session(python=['2.7', '3.6'])
+    @nox.session(python=['3.13', '3.14'])
     def tests(session):
         pass
 
@@ -135,7 +135,7 @@ When you provide a version number, Nox automatically prepends python to determin
 
 .. code-block:: python
 
-    @nox.session(python=['2.7', '3.6', 'pypy-6.0'])
+    @nox.session(python=['3.13', '3.14', 'pypy3.11'])
     def tests(session):
         pass
 
@@ -202,7 +202,7 @@ You can also specify that the virtualenv should *always* be reused instead of re
 .. code-block:: python
 
     @nox.session(
-        python=['2.7', '3.6'],
+        python=['3.13', '3.14'],
         reuse_venv=True)
     def tests(session):
         pass
@@ -268,7 +268,7 @@ particular file:
 
         session.run('pytest', *test_files)
 
-Now you if you run:
+Now if you run:
 
 
 .. code-block:: console
@@ -312,7 +312,7 @@ Session arguments can be parametrized with the :func:`nox.parametrize` decorator
         session.install(f'django=={django}')
         session.run('pytest')
 
-When you run ``nox``, it will create a two distinct sessions:
+When you run ``nox``, it will create two distinct sessions:
 
 .. code-block:: console
 
@@ -460,7 +460,7 @@ Just as tags can be :ref:`assigned to normal sessions <session tags>`, they can 
     @nox.parametrize('dependency',
         ['1.0', '2.0'],
         tags=[['old'], ['new']])
-    @nox.parametrize('database'
+    @nox.parametrize('database',
         ['postgres', 'mysql'],
         tags=[['psql'], ['mysql']])
     def tests(session, dependency, database):
@@ -501,7 +501,7 @@ More sophisticated tag assignment can be performed by passing a generator to the
     def tests(session, dependency, database):
         ...
 
-In this example, the ``quick`` tag is assigned to the single combination of the latest version of the dependency along with the SQLite database backend, allowing a developer to run the tests in a single configuration as a basic sanity test.  The ``standard`` tag, in contrast, selects combinations targeting either the latest version of the dependency *or* the SQLite database backend.  If the developer runs ``tox --tags standard``, the tests will be run against all supported versions of the dependency with the SQLite backend, as well as against all supported database backends under the latest version of the dependency, giving much more comprehensive test coverage while using only five of the potential nine test matrix combinations.
+In this example, the ``quick`` tag is assigned to the single combination of the latest version of the dependency along with the SQLite database backend, allowing a developer to run the tests in a single configuration as a basic sanity test.  The ``standard`` tag, in contrast, selects combinations targeting either the latest version of the dependency *or* the SQLite database backend.  If the developer runs ``nox --tags standard``, the tests will be run against all supported versions of the dependency with the SQLite backend, as well as against all supported database backends under the latest version of the dependency, giving much more comprehensive test coverage while using only five of the potential nine test matrix combinations.
 
 
 The session object
@@ -545,7 +545,7 @@ Or, if you wanted to provide a set of sessions that are run by default (this ove
 
     import nox
 
-    nox.options.sessions = ["lint", "tests-3.6"]
+    nox.options.sessions = ["lint", "tests-3.14"]
 
     ...
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -55,7 +55,7 @@ Enter the ``dev`` nox session:
         session.run("virtualenv", ".venv", silent=True)
 
         # Use the venv's interpreter to install the project along with
-        # all it's dev dependencies, this ensures it's installed in the right way
+        # all its dev dependencies, this ensures it's installed in the right way
         session.run(".venv/bin/pip", "install", "-e", ".[dev]", external=True)
 
 With this, a user can simply run ``nox -s dev`` and have their entire environment set up automatically!

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -29,24 +29,23 @@ Either way, Nox is usually installed *globally*, similar to ``tox``, ``pip``, an
 
 If you're interested in running ``nox`` within `docker`_, you can use the `thekevjames/nox images`_ on DockerHub which contain builds for all ``nox`` versions and all supported ``python`` versions. Nox is also supported via ``pipx run nox`` in the `manylinux images`_.
 
-If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/nox`` action, which installs the latest ``nox`` and makes available all active CPython and PyPY versions provided by the GitHub Actions environment:
+If you want to run ``nox`` within `GitHub Actions`_, you can use the ``wntrblm/nox`` action, which installs the latest ``nox`` and makes available a default set of active CPython versions:
 
 .. code-block:: yaml
 
-    # setup nox with all active CPython and PyPY versions provided by
-    # the GitHub Actions environment i.e.
-    # python-versions: "3.8, 3.9, 3.10, 3.11, 3.12, pypy-3.8, pypy-3.9, pypy-3.10"
+    # setup nox with the default set of CPython versions i.e.
+    # python-versions: "3.10, 3.11, 3.12, 3.13, 3.14"
     # Any Nox tag will work here
-    - uses: wntrblm/nox@2024.04.15
+    - uses: wntrblm/nox@2026.07.11
 
     # setup nox only for a given list of python versions
     # Limitations:
     # - Version specifiers shall be supported by actions/setup-python
     # - There can only be one "major.minor" per interpreter i.e. "3.12.0, 3.12.1" is invalid
     # Any Nox tag will work here
-    - uses: wntrblm/nox@2024.04.15
+    - uses: wntrblm/nox@2026.07.11
       with:
-          python-versions: "2.7, 3.5, 3.11, pypy-3.9"
+          python-versions: "3.10, 3.14, pypy-3.11"
 
 .. _pip: https://pip.readthedocs.org
 .. _user site: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
@@ -92,7 +91,7 @@ like this:
 
     $ nox
     nox > Running session lint
-    nox > Creating virtualenv using python3.7 in .nox/lint
+    nox > Creating virtualenv using python3.14 in .nox/lint
     nox > pip install flake8
     nox > flake8 example.py
     nox > Session lint was successful.
@@ -206,7 +205,7 @@ You can make a session for it like this:
    def peps(session):
        requirements = nox.project.load_toml("peps.py")["dependencies"]
        session.install(*requirements)
-       session.run("peps.py")
+       session.run("python", "peps.py")
 
 This is a common structure for scripts following this PEP, so a helper for it
 is provided:
@@ -489,7 +488,7 @@ Install packages with conda:
     session.conda_install("pytest", channels=["conda-forge"])
 
 It is possible to install packages with pip into the conda environment, but
-it's a best practice only install pip packages with the ``--no-deps`` option.
+it's a best practice to only install pip packages with the ``--no-deps`` option.
 This prevents pip from breaking the conda environment by installing incompatible
 versions of packages already installed with conda. You should always specify
 channels for consistency; default channels can vary (and ``micromamba`` has none).
@@ -641,7 +640,7 @@ Next steps
 
 Look at you! You're now basically an expert at Nox! ✨
 
-For this point you can:
+From this point you can:
 
 * Read more docs, such as :doc:`usage` and :doc:`config`.
 * Give us feedback or contribute, see :doc:`CONTRIBUTING`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -212,7 +212,7 @@ Similarly you can override ``nox.options.reuse_venvs`` from the Noxfile via the 
 
 .. note::
 
-    ``--reuse-existing-virtualenvs`` is a alias for ``--reuse-venv=yes`` and ``--no-reuse-existing-virtualenvs`` is an alias for ``--reuse-venv=no``.
+    ``--reuse-existing-virtualenvs`` is an alias for ``--reuse-venv=yes`` and ``--no-reuse-existing-virtualenvs`` is an alias for ``--reuse-venv=no``.
 
 Additionally, you can skip the re-installation of packages when a virtualenv is reused.
 Use ``-R`` or ``--reuse-existing-virtualenvs --no-install`` or ``--reuse-venv=yes --no-install``:
@@ -404,7 +404,7 @@ If being run on Continuous Integration (CI) systems, Nox will treat missing inte
 Disallowing external programs
 -----------------------------
 
-By default Nox will warn but ultimately allow you to run programs not installed in the session's virtualenv. You can use ``--error-on-external-run`` to make Nox fail the session if it uses any external program without explicitly passing ``external=True`` into :func:`session.run <nox.session.Session.run>`:
+By default Nox will warn but ultimately allow you to run programs not installed in the session's virtualenv. You can use ``--error-on-external-run`` to make Nox fail the session if it uses any external program without explicitly passing ``external=True`` into :func:`session.run <nox.sessions.Session.run>`:
 
 .. code-block:: console
 
@@ -482,9 +482,9 @@ Forcing non-interactive behavior
         ...
 
         if session.interactive:
-            nox.run("sphinx-autobuild", ...)
+            session.run("sphinx-autobuild", ...)
         else:
-            nox.run("sphinx-build", ...)
+            session.run("sphinx-build", ...)
 
 Sometimes it's useful to force Nox to see the session as non-interactive. You can use the ``--non-interactive`` argument to do this:
 
@@ -499,7 +499,7 @@ This will cause ``session.interactive`` to always return ``False``.
 Controlling color output
 ------------------------
 
-By default, Nox will output colorful logs if you're using in an interactive
+By default, Nox will output colorful logs if you're using it in an interactive
 terminal. However, if you are redirecting ``stderr`` to a file or otherwise
 not using an interactive terminal, or the environment variable ``NO_COLOR`` is
 set, Nox will output in plaintext. If this is not set, and ``FORCE_COLOR`` is


### PR DESCRIPTION
Ran a scan over the docs, found some issues.

:robot: _AI text below_ :robot:

Fix a missing comma in a parametrize example, run a PEP 723 script via python, use session.run instead of nox.run, and repair a dead cross-reference. Update the GitHub Actions examples to the current action tag and Python versions, and replace Python 2.7/3.6 examples with supported versions.

Assisted-by: ClaudeCode:claude-fable-5