### PR TITLE
fix: drop stale type ignores for argcomplete 3.7.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         exclude: ^tests/resources/
         args: []
         additional_dependencies:
-          - argcomplete
+          - argcomplete>=3.7.2
           - attrs
           - colorlog
           - dependency-groups>=1.3.1

--- a/nox/_completers.py
+++ b/nox/_completers.py
@@ -46,13 +46,14 @@ def __dir__() -> list[str]:
 
 
 directory_completer: argcomplete.completers.DirectoriesCompleter = (
-    argcomplete.completers.DirectoriesCompleter()  # type: ignore[no-untyped-call]
+    argcomplete.completers.DirectoriesCompleter()
 )
 json_file_completer: argcomplete.completers.FilesCompleter = (
-    argcomplete.completers.FilesCompleter(("json",))  # type: ignore[no-untyped-call]
+    argcomplete.completers.FilesCompleter(("json",))
 )
+# argcomplete only iterates the choices, but it types them as a mapping.
 empty_completer: argcomplete.completers.ChoicesCompleter = (
-    argcomplete.completers.ChoicesCompleter(())  # type: ignore[no-untyped-call]
+    argcomplete.completers.ChoicesCompleter({})
 )
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

argcomplete 3.7.2 annotates its completers, which made the `no-untyped-call` ignores in `nox/_completers.py` unused and broke `lint` on main.

- Remove the three stale ignore comments.
- `ChoicesCompleter` now types its argument as a mapping, so pass `{}` instead of `()`. It only iterates the choices, so behavior is the same.
- Pin `argcomplete>=3.7.2` in the mypy hook so cached hook environments do not resolve an older release.