### PR TITLE
fix: isolate script mode from inherited PYTHONPATH

### DIFF
--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -334,7 +334,10 @@ def run_script_mode(
                     f' does not satisfy "requires-python": {requires_python!r}'
                 )
                 raise SystemExit(msg)
-    env = {k: v for k, v in venv._get_env({}).items() if v is not None}
+    # An outer PYTHONPATH can make the installer and the child Nox process load
+    # packages from outside the script environment instead of its dependencies.
+    env_overrides = {"PYTHONPATH": None} if venv.is_sandboxed else {}
+    env = {k: v for k, v in venv._get_env(env_overrides).items() if v is not None}
     env["NOX_SCRIPT_MODE"] = "none"
     if venv.venv_backend == "uv":
         cmd = [nox.virtualenv.UV, "pip", "install"]

--- a/nox/_cli.py
+++ b/nox/_cli.py
@@ -336,7 +336,14 @@ def run_script_mode(
                 raise SystemExit(msg)
     # An outer PYTHONPATH can make the installer and the child Nox process load
     # packages from outside the script environment instead of its dependencies.
-    env_overrides = {"PYTHONPATH": None} if venv.is_sandboxed else {}
+    # Stash it so the child can restore it for sessions, which must see the
+    # same environment as a NOX_SCRIPT_MODE=none run.
+    env_overrides: dict[str, str | None] = {}
+    if venv.is_sandboxed:
+        env_overrides["PYTHONPATH"] = None
+        outer_pythonpath = os.environ.get("PYTHONPATH")
+        if outer_pythonpath is not None:
+            env_overrides["NOX_OUTER_PYTHONPATH"] = outer_pythonpath
     env = {k: v for k, v in venv._get_env(env_overrides).items() if v is not None}
     env["NOX_SCRIPT_MODE"] = "none"
     if venv.venv_backend == "uv":
@@ -389,6 +396,11 @@ def _main(*, main_ep: bool) -> None:
     setup_logging(
         color=args.color, verbose=args.verbose, add_timestamp=args.add_timestamp
     )
+    # run_script_mode stripped PYTHONPATH so the re-exec'd Nox interpreter does
+    # not import from the outer environment; sessions must still see it.
+    outer_pythonpath = os.environ.pop("NOX_OUTER_PYTHONPATH", None)
+    if outer_pythonpath is not None:
+        os.environ["PYTHONPATH"] = outer_pythonpath
     nox_script_mode = os.environ.get("NOX_SCRIPT_MODE", "") or args.script_mode
     if nox_script_mode not in {"none", "reuse", "fresh"}:
         msg = f"Invalid NOX_SCRIPT_MODE: {nox_script_mode!r}, must be one of 'none', 'reuse', or 'fresh'"

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -94,6 +94,7 @@ _BLACKLISTED_ENV_VARS = frozenset(
     [
         "PIP_RESPECT_VIRTUALENV",
         "PIP_REQUIRE_VIRTUALENV",
+        "PYTHONHOME",
         "__PYVENV_LAUNCHER__",
         "UV_SYSTEM_PYTHON",
         "UV_PYTHON",

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -379,6 +379,67 @@ def test_run_script_mode_pip_resolution(
 
 
 @pytest.mark.parametrize(
+    ("is_sandboxed", "backend", "expected_pythonpath"),
+    [(True, "uv", None), (False, "none", "/outer/packages")],
+)
+def test_run_script_mode_pythonpath_isolation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    is_sandboxed: bool,
+    backend: str,
+    expected_pythonpath: str | None,
+) -> None:
+    """A sandboxed script environment must not import from the outer environment."""
+    seen_envs: list[dict[str, str]] = []
+
+    def fake_get_env(env: dict[str, str | None]) -> dict[str, str | None]:
+        return {
+            "PATH": "/fake/venv/bin",
+            "PYTHONPATH": "/outer/packages",
+            "OUTER_VAR": "kept",
+            **env,
+        }
+
+    def fake_run(_cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        seen_envs.append(typing.cast("dict[str, str]", kwargs["env"]))
+        return SimpleNamespace(returncode=0)
+
+    def fake_execle(_path: str, *_args: object) -> typing.NoReturn:
+        seen_envs.append(typing.cast("dict[str, str]", _args[-1]))
+        raise SystemExit(0)
+
+    fake_venv = make_fake_script_venv(
+        _get_env=fake_get_env,
+        is_sandboxed=is_sandboxed,
+        venv_backend=backend,
+    )
+    monkeypatch.setattr(
+        nox.virtualenv, "get_virtualenv", lambda *_args, **_kwargs: fake_venv
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(shutil, "which", lambda cmd, path=None: f"{path}/{cmd}")
+    monkeypatch.setattr(os, "execle", fake_execle)
+    monkeypatch.setattr(sys, "argv", ["nox"])
+
+    with pytest.raises(SystemExit):
+        nox._cli.run_script_mode(
+            "noxfile.py",
+            tmp_path,
+            reuse=False,
+            dependencies=["nox", "cowsay"],
+            venv_backend=backend,
+            download_python="never",
+            requires_python=None,
+        )
+
+    assert len(seen_envs) == 2
+    assert all(env.get("PYTHONPATH") == expected_pythonpath for env in seen_envs)
+    assert all(env["OUTER_VAR"] == "kept" for env in seen_envs)
+    assert all(env["PATH"] == "/fake/venv/bin" for env in seen_envs)
+    assert all(env["NOX_SCRIPT_MODE"] == "none" for env in seen_envs)
+
+
+@pytest.mark.parametrize(
     ("script_env", "global_env", "toml_value", "cli_args", "expected"),
     [
         ("always", "never", "never", ["--download-python", "never"], "always"),

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -287,18 +287,27 @@ def make_fake_script_venv(**overrides: object) -> SimpleNamespace:
 
 
 @pytest.fixture
-def script_mode_exec(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+def script_mode_exec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[list[str], dict[str, str]]]:
     """Stub the install/exec plumbing at the end of run_script_mode.
 
-    Returns the list of commands passed to subprocess.run.
+    Returns the (command, env) pairs passed to subprocess.run and os.execle.
     """
-    calls: list[list[str]] = []
+    calls: list[tuple[list[str], dict[str, str]]] = []
 
-    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
-        calls.append(list(cmd))
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        # Interpreter-probe calls pass no env; record them with an empty one.
+        calls.append((list(cmd), typing.cast("dict[str, str]", kwargs.get("env", {}))))
         return SimpleNamespace(returncode=0, stdout="")
 
-    def fake_execle(_path: str, *_args: object) -> typing.NoReturn:
+    def fake_execle(_path: str, *args: object) -> typing.NoReturn:
+        calls.append(
+            (
+                [str(a) for a in args[:-1]],
+                typing.cast("dict[str, str]", args[-1]),
+            )
+        )
         raise SystemExit(0)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -351,7 +360,7 @@ def test_run_script_mode_pip_resolution(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     backend: str,
-    script_mode_exec: list[list[str]],
+    script_mode_exec: list[tuple[list[str], dict[str, str]]],
 ) -> None:
     """pip must be resolved against the venv's PATH (Windows searches the parent's)."""
     fake_venv = make_fake_script_venv(venv_backend=backend)
@@ -375,22 +384,19 @@ def test_run_script_mode_pip_resolution(
         if backend == "uv"
         else ["/fake/venv/bin/pip", "install"]
     )
-    assert script_mode_exec[0] == [*expected, "nox", "cowsay"]
+    assert script_mode_exec[0][0] == [*expected, "nox", "cowsay"]
 
 
-@pytest.mark.parametrize(
-    ("is_sandboxed", "backend", "expected_pythonpath"),
-    [(True, "uv", None), (False, "none", "/outer/packages")],
-)
+@pytest.mark.parametrize(("is_sandboxed", "backend"), [(True, "uv"), (False, "none")])
 def test_run_script_mode_pythonpath_isolation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     is_sandboxed: bool,
     backend: str,
-    expected_pythonpath: str | None,
+    script_mode_exec: list[tuple[list[str], dict[str, str]]],
 ) -> None:
     """A sandboxed script environment must not import from the outer environment."""
-    seen_envs: list[dict[str, str]] = []
+    monkeypatch.setenv("PYTHONPATH", "/outer/packages")
 
     def fake_get_env(env: dict[str, str | None]) -> dict[str, str | None]:
         return {
@@ -400,14 +406,6 @@ def test_run_script_mode_pythonpath_isolation(
             **env,
         }
 
-    def fake_run(_cmd: list[str], **kwargs: object) -> SimpleNamespace:
-        seen_envs.append(typing.cast("dict[str, str]", kwargs["env"]))
-        return SimpleNamespace(returncode=0)
-
-    def fake_execle(_path: str, *_args: object) -> typing.NoReturn:
-        seen_envs.append(typing.cast("dict[str, str]", _args[-1]))
-        raise SystemExit(0)
-
     fake_venv = make_fake_script_venv(
         _get_env=fake_get_env,
         is_sandboxed=is_sandboxed,
@@ -416,10 +414,6 @@ def test_run_script_mode_pythonpath_isolation(
     monkeypatch.setattr(
         nox.virtualenv, "get_virtualenv", lambda *_args, **_kwargs: fake_venv
     )
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(shutil, "which", lambda cmd, path=None: f"{path}/{cmd}")
-    monkeypatch.setattr(os, "execle", fake_execle)
-    monkeypatch.setattr(sys, "argv", ["nox"])
 
     with pytest.raises(SystemExit):
         nox._cli.run_script_mode(
@@ -432,11 +426,31 @@ def test_run_script_mode_pythonpath_isolation(
             requires_python=None,
         )
 
-    assert len(seen_envs) == 2
-    assert all(env.get("PYTHONPATH") == expected_pythonpath for env in seen_envs)
-    assert all(env["OUTER_VAR"] == "kept" for env in seen_envs)
-    assert all(env["PATH"] == "/fake/venv/bin" for env in seen_envs)
-    assert all(env["NOX_SCRIPT_MODE"] == "none" for env in seen_envs)
+    envs = [env for _cmd, env in script_mode_exec]
+    assert len(envs) == 2
+    if is_sandboxed:
+        # "not in" rather than "is None": a None value would crash the real exec.
+        assert all("PYTHONPATH" not in env for env in envs)
+        assert all(env["NOX_OUTER_PYTHONPATH"] == "/outer/packages" for env in envs)
+    else:
+        assert all(env["PYTHONPATH"] == "/outer/packages" for env in envs)
+        assert all("NOX_OUTER_PYTHONPATH" not in env for env in envs)
+    assert all(env["OUTER_VAR"] == "kept" for env in envs)
+    assert all(env["PATH"] == "/fake/venv/bin" for env in envs)
+    assert all(env["NOX_SCRIPT_MODE"] == "none" for env in envs)
+
+
+def test_main_restores_outer_pythonpath(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The re-exec'd child must give sessions the PYTHONPATH the user exported."""
+    monkeypatch.setenv("NOX_OUTER_PYTHONPATH", "/outer/packages")
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    run_main_with_script(monkeypatch, tmp_path, "")
+
+    assert os.environ["PYTHONPATH"] == "/outer/packages"
+    assert "NOX_OUTER_PYTHONPATH" not in os.environ
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1141,9 +1141,18 @@ def test_symlink_sym_not(monkeypatch: pytest.MonkeyPatch) -> None:
     assert res.returncode == 1
 
 
-@xfail_mingw_uv
-def test_noxfile_script_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_noxfile_script_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("NOX_SCRIPT_MODE", raising=False)
+    monkeypatch.delenv("NOX_SCRIPT_VENV_BACKEND", raising=False)
+    monkeypatch.delenv("NOX_SCRIPT_DOWNLOAD_PYTHON", raising=False)
+    monkeypatch.delenv("NOX_DOWNLOAD_PYTHON", raising=False)
+    outer_packages = tmp_path / "outer-packages"
+    dist_info = outer_packages / "nox-999.dist-info"
+    dist_info.mkdir(parents=True)
+    dist_info.joinpath("METADATA").write_text(
+        "Metadata-Version: 2.1\nName: nox\nVersion: 999\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("PYTHONPATH", str(outer_packages))
     job = subprocess.run(
         [
             sys.executable,
@@ -1153,6 +1162,12 @@ def test_noxfile_script_mode(monkeypatch: pytest.MonkeyPatch) -> None:
             Path(RESOURCES) / "noxfile_script_mode.py",
             "-s",
             "example",
+            "--script-mode",
+            "fresh",
+            "--script-venv-backend",
+            "virtualenv",
+            "--envdir",
+            tmp_path / "envs",
         ],
         check=False,
         capture_output=True,

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -561,6 +561,16 @@ def test_blacklisted_env(
     assert "__PYVENV_LAUNCHER__" not in venv.bin
 
 
+def test_pythonhome_blacklisted(
+    monkeypatch: pytest.MonkeyPatch,
+    make_one: Callable[..., tuple[VirtualEnv, Path]],
+) -> None:
+    """A mismatched outer PYTHONHOME is fatal to any venv interpreter."""
+    monkeypatch.setenv("PYTHONHOME", "/outer/python")
+    venv, _ = make_one()
+    assert venv._get_env({})["PYTHONHOME"] is None
+
+
 def test__clean_location(
     monkeypatch: pytest.MonkeyPatch,
     make_one: Callable[..., tuple[VirtualEnv, Path]],


### PR DESCRIPTION
Fixes #1044.

## Problem

I reproduced the failure by placing a second Nox distribution on the outer `PYTHONPATH` and forcing a fresh `virtualenv` script environment.

`run_script_mode()` carried that path into both the dependency installer and the re-executed Nox process. Pip could therefore treat the outer Nox distribution as already installed, while the child process could resolve packages outside the script environment instead of using the dependencies installed there.

## Change

I remove `PYTHONPATH` from the environment passed to the installer and the re-executed Nox process when the selected backend is sandboxed.

The `none` backend continues to inherit `PYTHONPATH`, preserving its existing non-isolated behavior.

I also added:

- a parameterized regression test covering sandboxed and `none` backends across both process handoffs;
- an end-to-end regression that exposes an outer Nox distribution and forces a fresh `virtualenv` script environment.

## Tests

- `pytest tests/test__cli.py::test_run_script_mode_pythonpath_isolation tests/test_main.py::test_noxfile_script_mode` — 3 passed
- `pytest tests/test_main.py::test_noxfile_script_mode_url_req` — 1 passed
- Ruff lint and format checks passed
- Mypy passed
- codespell passed
- `git diff --check` passed
