### PR TITLE
fix: require virtualenv 21+ on Python 3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
   "platformdirs>=2",
   "python-discovery>=1",
   "tomli>=1.1; python_version<'3.11'",
-  "virtualenv>=20.15",
+  "virtualenv>=20.15; python_version<'3.15'",
+  "virtualenv>=21; python_version>='3.15'",
 ]
 optional-dependencies.pbs = [
   "pbs-installer[all]>=2025.1.6",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

On Python 3.15, a pip older than 25.2 does not work: pip 24.0–25.1 fail on import (the vendored `typing_extensions` uses `typing.no_type_check_decorator`, removed in 3.15), and older pips hit the now-enforced abstract `importlib.metadata.Distribution.locate_file`. virtualenv 20.x seeds at most pip 25.0.1 from its bundled wheels, so a fresh machine with the current `virtualenv>=20.15` floor gets a script/session environment whose pip cannot install anything on 3.15. virtualenv 21 is the first release that seeds a working pip (26.0.1).

This adds a `virtualenv>=21` floor for Python 3.15+. Verified locally by seeding 3.15 environments with a clean virtualenv app-data (as on a fresh CI runner) across virtualenv 20.24–21.0, and by reproducing the `test_noxfile_script_mode` failure from #1157's min-version 3.15 jobs (forced virtualenv backend) before the change and confirming it passes after.

CI on `main` does not currently hit this because the script-mode tests pick the uv backend there; #1157 surfaced it by forcing the virtualenv backend.