### PR TITLE
fix: support legacy encodings in parallel reporter

### DIFF
--- a/nox/_parallel.py
+++ b/nox/_parallel.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from nox.sessions import SessionRunner
 
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_ASCII_SPINNER = "|/-\\"
 _SYMBOLS = {
     Status.SUCCESS: "✓",
     Status.SKIPPED: "⊘",
@@ -127,6 +128,15 @@ def _status_symbol(status: Status, encoding: str | None) -> str:
     except UnicodeEncodeError:
         return _ASCII_SYMBOLS[status]
     return symbol
+
+
+def _spinner_frame(spin: int, encoding: str | None) -> str:
+    frame = _SPINNER[spin % len(_SPINNER)]
+    try:
+        frame.encode(encoding or "utf-8")
+    except UnicodeEncodeError:
+        return _ASCII_SPINNER[spin % len(_ASCII_SPINNER)]
+    return frame
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -206,7 +216,7 @@ class _Reporter:
             header = plain_header[: width - 1]
         lines = [self._banner(width), header]
 
-        frame = _SPINNER[self._spin % len(_SPINNER)]
+        frame = _spinner_frame(self._spin, self.stream.encoding)
         for name, start in self._active.items():
             # Plain and colored renderings are built from the same segments so
             # the width math can't drift from what is actually displayed.

--- a/nox/_parallel.py
+++ b/nox/_parallel.py
@@ -73,6 +73,12 @@ _SYMBOLS = {
     Status.FAILED: "✗",
     Status.ABORTED: "↯",
 }
+_ASCII_SYMBOLS = {
+    Status.SUCCESS: "+",
+    Status.SKIPPED: "-",
+    Status.FAILED: "x",
+    Status.ABORTED: "!",
+}
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
 
 # How long a child gets to exit after SIGTERM before it is SIGKILLed.
@@ -112,6 +118,15 @@ def _preview_text(line: str) -> str:
     an escape sequence and corrupt the terminal.
     """
     return _ANSI.sub("", line.rstrip("\r\n").rsplit("\r", 1)[-1]).strip()
+
+
+def _status_symbol(status: Status, encoding: str | None) -> str:
+    symbol = _SYMBOLS[status]
+    try:
+        symbol.encode(encoding or "utf-8")
+    except UnicodeEncodeError:
+        return _ASCII_SYMBOLS[status]
+    return symbol
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -237,7 +252,7 @@ class _Reporter:
             self._board_lines = 0
 
     def _emit_block(self, name: str, result: Result, output: str) -> None:
-        symbol = _SYMBOLS[result.status]
+        symbol = _status_symbol(result.status, self.stream.encoding)
         duration = _duration_str(result.duration, ", {time}")
         rule = "=" * 10
         self.stream.write(

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import signal
@@ -709,6 +710,20 @@ def test_reporter_block_without_output_or_reason(
     )
     out = capsys.readouterr().out
     assert "✓ x: success" in out
+
+
+def test_reporter_block_uses_ascii_symbol_for_legacy_encoding() -> None:
+    buffer = io.BytesIO()
+    with io.TextIOWrapper(buffer, encoding="cp1252") as stream:
+        reporter = _parallel._Reporter(color=False, tty=False)
+        reporter.stream = stream
+        reporter._emit_block(
+            "x",
+            Result(_fake_runner(FakeSession("x")), Status.SUCCESS, duration=0),
+            "",
+        )
+        stream.flush()
+        assert "+ x: success" in buffer.getvalue().decode("cp1252")
 
 
 def test_run_session_spawns_subprocess(

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -613,6 +613,15 @@ def test_reporter_render_truncates_to_width() -> None:
     assert "\x1b" not in line
 
 
+def test_reporter_render_uses_ascii_spinner_for_legacy_encoding() -> None:
+    buffer = io.BytesIO()
+    with io.TextIOWrapper(buffer, encoding="cp1252") as stream:
+        reporter = _parallel._Reporter(color=False, tty=True, total=1)
+        reporter.stream = stream
+        reporter._active = {"a": 100.0}
+        assert reporter._render(105.0, width=0)[2] == "| a (5s)"
+
+
 def test_reporter_render_color() -> None:
     reporter = _parallel._Reporter(color=True, tty=False, total=1)
     reporter._active = {"a": 100.0}


### PR DESCRIPTION
Fixes #1159

## Summary

- Preserve Unicode status symbols when the output stream supports them.
- Fall back to ASCII status symbols for legacy encodings such as Windows `cp1252`.
- Add a regression test that writes a successful parallel-session result to a `cp1252` stream.

## Test Plan

- `uv run pytest tests/test_parallel.py -q` (57 passed)
- `uvx prek run --files nox/_parallel.py tests/test_parallel.py`
- `uv run coverage report --show-missing nox/_parallel.py` (100% statement and branch coverage)
