### PR TITLE
chore(deps): bump pre-commit hooks, hold pyproject-fmt at 2.26.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,7 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+    ignore:
+      # 2.27+ rewrites the zero-padded CalVer in project.version
+      - dependency-name: "https://github.com/tox-dev/pyproject-fmt"
+        versions: [ ">=2.27" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         files: '^nox/'
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.27.0"
+    rev: "v2.26.0"
     hooks:
       - id: pyproject-fmt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
         files: '^nox/'
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.25.3"
+    rev: "v2.27.0"
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
@@ -74,6 +74,6 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.28.0
+    rev: v1.29.0
     hooks:
       - id: zizmor


### PR DESCRIPTION
See https://github.com/tox-dev/toml-fmt/issues/430, we can't update because it changes our version _value_.

:robot: _AI text below_ :robot:

Supersedes #1161. Takes the ruff 0.16.1 and zizmor 1.29.0 bumps, but holds pyproject-fmt at 2.26.0.

pyproject-fmt 2.27.0 canonicalizes `project.version`, so it rewrites `version = "2026.08.10"` to `"2026.8.10"`, which breaks the zero-padded CalVer this project uses for tags and the changelog. Bisected: 2.26.0 leaves it alone, 2.27.0 changes it. `--keep-full-version` only affects dependency specifiers, so there is no way to opt out. Dependabot is told to ignore pyproject-fmt 2.27+.

Closes #1161