### PR TITLE
Fix the subprocess leak issue in the nox/popen.py file

### DIFF
--- a/nox/popen.py
+++ b/nox/popen.py
@@ -189,17 +189,17 @@ def popen(
     if sys.platform.startswith("win") and args[0].casefold().endswith((".bat", ".cmd")):
         popen_args = _windows_batch_command(args, env)
 
-    proc = subprocess.Popen(popen_args, env=env, stdout=stdout, stderr=stderr)
-
-    try:
-        out, _err = proc.communicate()
-        sys.stdout.flush()
-
-    except KeyboardInterrupt:
-        out, _err = shutdown_process(proc, interrupt_timeout, terminate_timeout)
-        if proc.returncode != 0:
-            raise
-
-    return_code = proc.wait()
+    with subprocess.Popen(popen_args, env=env, stdout=stdout, stderr=stderr) as proc:
+        try:
+            out, _err = proc.communicate()
+            sys.stdout.flush()
+        except KeyboardInterrupt:
+            out, _err = shutdown_process(proc, interrupt_timeout, terminate_timeout)
+            if proc.returncode != 0:
+                raise
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        return_code = proc.returncode
 
     return return_code, decode_output(out) if out else ""


### PR DESCRIPTION
Problem description : The popen() function in nox/popen.py creates a child process with subprocess.Popen() and calls proc.communicate() inside a try block whose only except clause catches KeyboardInterrupt . On any other exception path (e.g. OSError from a broken pipe, subprocess.SubprocessError , or a disk-full error while writing to a redirected stdout file), the exception propagates without terminating or waiting on the child. Neither proc.terminate() / proc.kill() nor proc.wait() is invoked, and the Popen object's stdin / stdout / stderr pipe file descriptors are released only by non-deterministic garbage collection rather than deterministically.
	
Hazard statement : During stress testing, every session.run() invocation that hits a transient I/O error during communicate() leaks one orphaned child process (which keeps running and consuming memory/CPU) together with its pipe file descriptors. Long-term stress testing accumulates orphan processes and exhausts file descriptors, eventually causing "too many open files" errors or system resource exhaustion.
	
Repair solution : Wrap the subprocess.Popen() call in a with statement so that Popen.__exit__ waits for the process and closes its pipes, and add a finally block that calls proc.kill() whenever proc.poll() is None , ensuring the child is terminated and reaped on every exit path—including non- KeyboardInterrupt exceptions.
