### PR TITLE
Fix the zombie process leak issue in the _parallel.py file

### DIFF
--- a/nox/_parallel.py
+++ b/nox/_parallel.py
@@ -477,6 +477,7 @@ def _stop_procs(procs: Collection[subprocess.Popen[bytes]]) -> None:
             proc.wait(timeout=max(0.0, deadline - time.monotonic()))
         except subprocess.TimeoutExpired:  # noqa: PERF203 - cold shutdown path
             _signal_group(proc, kill=True)
+            proc.wait()
 
 
 def run_manifest_parallel(


### PR DESCRIPTION
Problem description (EN): The _stop_procs function in the _parallel.py file sends SIGKILL (via _signal_group(proc, kill=True) ) to child processes that do not exit within the terminate timeout, but it does not call proc.wait() afterwards to reap the killed process.

Hazard statement (EN): During parallel interrupt/shutdown, each SIGKILL ed child process becomes a zombie (POSIX) or retains an unreleased process handle (Windows). Under long-running parallel stress, zombies accumulate, leaking file descriptors and exhausting the PID table, which may eventually cause new process spawning to fail.

Repair solution (EN): Add a proc.wait() call immediately after _signal_group(proc, kill=True) in the except subprocess.TimeoutExpired branch to reap the killed process and release its file descriptors/handle.