### PR TITLE
chore: tighten mypy and pytest config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: mypy
-        files: ^(nox/|tests/)
+        files: ^(nox/|tests/|\.github/|noxfile\.py$)
         exclude: ^tests/resources/
         args: []
         additional_dependencies:

--- a/noxfile.py
+++ b/noxfile.py
@@ -122,13 +122,13 @@ def conda_tests(session: nox.Session) -> None:
     xonda_tests(session, "conda")
 
 
-@nox.session(venv_backend="mamba", default=shutil.which("mamba"))
+@nox.session(venv_backend="mamba", default=bool(shutil.which("mamba")))
 def mamba_tests(session: nox.Session) -> None:
     """Run test suite set up with mamba."""
     xonda_tests(session, "mamba")
 
 
-@nox.session(venv_backend="micromamba", default=shutil.which("micromamba"))
+@nox.session(venv_backend="micromamba", default=bool(shutil.which("micromamba")))
 def micromamba_tests(session: nox.Session) -> None:
     """Run test suite set up with micromamba."""
     xonda_tests(session, "micromamba")
@@ -183,6 +183,8 @@ def docs(session: nox.Session) -> None:
 
 # The following sessions are only to be run in CI to check the nox GHA action
 def _check_python_version(session: nox.Session) -> None:
+    # Callers parametrize with a list of version strings, so this is always a str.
+    assert isinstance(session.python, str)
     if session.python.startswith("pypy"):
         # Drop starting "pypy" and maybe "-"
         python_version = session.python.lstrip("py-")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3.15",
+  "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Testing",
+  "Typing :: Typed",
 ]
 dependencies = [
   "argcomplete>=1.9.4,<4",
@@ -124,17 +126,20 @@ max_supported_python = "3.15"
 
 [tool.mypy]
 mypy_path = [ ".github" ]
+files = [ ".github", "nox", "noxfile.py", "tests" ]
+exclude = [ "^tests/resources/" ]
 python_version = "3.10"
 warn_unreachable = true
 enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
 strict = true
+native_parser = true
 overrides = [ { module = [ "tox.*" ], ignore_missing_imports = true } ]
 
 [tool.pytest]
 ini_options.minversion = "7.0"
 ini_options.testpaths = [ "tests" ]
 ini_options.pythonpath = [ ".github/" ]
-ini_options.addopts = [ "-ra", "--strict-markers", "--strict-config" ]
+ini_options.addopts = [ "-ra", "--strict-markers", "--strict-config", "-p", "no:legacypath" ]
 ini_options.markers = [
   "conda: test requires conda",
 ]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A few ideas ported from `pypa/packaging`'s `pyproject.toml`.

- Add `-p no:legacypath` to the pytest addopts. No test uses `tmpdir` or `testdir`, so this stops the legacy fixtures from coming back.
- Enable mypy's `native_parser`.
- Set mypy `files` and `exclude`, so a bare `mypy` checks the same paths as pre-commit. This also adds `.github/` and `noxfile.py`, which were not checked before, and widens the pre-commit hook regex to match.
- Add the `Typing :: Typed` and `Implementation :: CPython` classifiers. `nox/py.typed` already ships.

Checking `noxfile.py` for the first time found two type errors: the `mamba` and `micromamba` sessions passed `default=shutil.which(...)`, which is `str | None`, where a `bool` is declared. The `conda` session next to them already wrapped the call in `bool()`. Behavior does not change, because the value was only used as a truthy value; `nox -l` skips the same sessions as before.

Not taken from `packaging`: `--capture=sys` and `-p no:logging`. The first gives no measurable gain here, because the runtime is mostly subprocess work, not per-test file descriptor calls. The second is not possible, because five test modules use `caplog`.
