### PR TITLE
docs: prepare 2026.08.17 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2026.08.17
+
+This is a small follow-up release to better support running the parallel mode
+on legacy windows.
+
+We'd like to thank the following folks who contributed to this release:
+
+* @henryiii
+* @nightcityblade (first contribution)
+
+Fixes:
+
+* Support legacy encodings in the parallel reporter by @nightcityblade in https://github.com/wntrblm/nox/pull/1160
+
+Internal changes:
+
+* Tighten mypy and pytest config by @henryiii in https://github.com/wntrblm/nox/pull/1167
+* Bump pre-commit hooks, hold pyproject-fmt at 2.26.0 by @henryiii in https://github.com/wntrblm/nox/pull/1163
+* Bump the github-actions group with 2 updates by @dependabot in https://github.com/wntrblm/nox/pull/1162
+
+
 ## 2026.08.10
 
 This release can run sessions in parallel with `--parallel`/`-j` (experimental

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "nox"
-version = "2026.08.10"
+version = "2026.08.17"
 description = "Flexible test automation."
 readme = "README.md"
 keywords = [


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Prepares the 2026.08.17 release: bumps the version in `pyproject.toml` and adds the changelog section.

This is a small follow-up to 2026.08.10. Only one change is user-facing, the ASCII fallback in the parallel reporter (#1160); the rest is config and dependency updates.
