### PR TITLE
Support a callable for parametrize ids

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -410,6 +410,25 @@ Produces these sessions when running ``nox --list``:
     * tests(psql, new)
     * tests(mysql, new)
 
+Instead of a fixed list, ``ids`` can also be a callable, just like `pytest's parametrize <https://docs.pytest.org/en/stable/how-to/parametrize.html>`_. The callable is invoked with each argument value and returns the ID to use for that value, or ``None`` to fall back to the automatically generated ID. This is handy for deriving shell-friendly names from the parameter values so you don't have to quote them:
+
+.. code-block:: python
+
+    @nox.session
+    @nox.parametrize(
+        'dependency',
+        ['flask==1.0', 'flask==2.0'],
+        ids=lambda dependency: dependency.replace('==', '-'))
+    def tests(session, dependency):
+        ...
+
+Produces these sessions, which don't need quoting to run:
+
+.. code-block:: console
+
+    * tests(flask-1.0)
+    * tests(flask-2.0)
+
 
 Parametrizing the session Python
 --------------------------------

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -111,10 +111,30 @@ def _apply_param_specs(param_specs: Iterable[Param], f: Any) -> Any:
 ArgValue = Param | Iterable[Any]
 
 
+def _generate_id(
+    id_func: Callable[[Any], str | None],
+    arg_names: Sequence[str],
+    arg_values: Iterable[Any],
+) -> str:
+    """Build a parameter ID by applying ``id_func`` to each argument value.
+
+    For each argument, ``id_func`` is called with its value. A string return
+    value is used as-is; any other return value (including ``None``) falls back
+    to the default ``name=value`` representation for that argument. The
+    per-argument pieces are then joined the same way automatically generated
+    IDs are.
+    """
+    parts = []
+    for name, value in zip(arg_names, arg_values, strict=True):
+        result = id_func(value)
+        parts.append(result if isinstance(result, str) else f"{name}={value!r}")
+    return ", ".join(parts)
+
+
 def parametrize_decorator(
     arg_names: str | Sequence[str],
     arg_values_list: Iterable[ArgValue] | ArgValue,
-    ids: Iterable[str | None] | None = None,
+    ids: Iterable[str | None] | Callable[[Any], str | None] | None = None,
     tags: Iterable[Sequence[str]] | None = None,
 ) -> Callable[[Any], Any]:
     """Parametrize a session.
@@ -133,8 +153,13 @@ def parametrize_decorator(
             argument names were specified, this must be a list of N-tuples,
             where each tuple-element specifies a value for its respective
             argument name, for example ``[(1, 'a'), (2, 'b')]``.
-        ids (Sequence[str]): Optional sequence of test IDs to use for the
-            parametrized arguments.
+        ids (Sequence[str] | Callable[[Any], str | None]): Optional IDs used to
+            name the parametrized arguments. Either a sequence of IDs aligned
+            with ``arg_values_list``, or, mirroring pytest, a callable that is
+            invoked with each argument value and returns the ID to use for that
+            value (return ``None`` to fall back to the automatically generated
+            ID). A callable is convenient for producing shell-friendly session
+            names, for example ``ids=lambda v: v.replace(" ", "-")``.
         tags (Iterable[Sequence[str]]): Optional iterable of tags to associate
             with the parametrized arguments.
     """
@@ -162,8 +187,14 @@ def parametrize_decorator(
     else:
         _arg_values_list = list(arg_values_list)
 
-    # if ids aren't specified at all, make them an empty list for zip.
-    if not ids:
+    # ``ids`` may be a callable that generates an ID from each parameter's
+    # value(s) (like pytest), or a sequence of IDs aligned with the values.
+    id_func: Callable[[Any], str | None] | None = None
+    if callable(ids):
+        id_func = ids
+        ids = []
+    elif not ids:
+        # if ids aren't specified at all, make them an empty list for zip.
         ids = []
 
     if tags is None:
@@ -181,6 +212,8 @@ def parametrize_decorator(
             param_spec = Param(
                 *param_arg_values, arg_names=arg_names, id=param_id, tags=param_tags
             )
+            if id_func is not None:
+                param_spec.id = _generate_id(id_func, arg_names, param_arg_values)
 
         param_specs.append(param_spec)
 

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -94,6 +94,74 @@ def test_parametrize_decorator_id_list() -> None:
     ]
 
 
+def test_parametrize_decorator_id_function() -> None:
+    def f() -> None:
+        pass
+
+    _parametrize.parametrize_decorator(
+        "abc", ["a b", "c d"], ids=lambda value: value.replace(" ", "-")
+    )(f)
+
+    arg_names = ("abc",)
+    assert f.parametrize == [  # type: ignore[attr-defined]
+        _parametrize.Param("a b", arg_names=arg_names, id="a-b"),
+        _parametrize.Param("c d", arg_names=arg_names, id="c-d"),
+    ]
+
+
+def test_parametrize_decorator_id_function_falls_back() -> None:
+    def f() -> None:
+        pass
+
+    # Returning a non-string (here ``None``) falls back to the default
+    # ``name=value`` representation for that value.
+    _parametrize.parametrize_decorator(
+        "abc", [1, 2], ids=lambda value: "one" if value == 1 else None
+    )(f)
+
+    arg_names = ("abc",)
+    assert f.parametrize == [  # type: ignore[attr-defined]
+        _parametrize.Param(1, arg_names=arg_names, id="one"),
+        _parametrize.Param(2, arg_names=arg_names, id="abc=2"),
+    ]
+
+
+def test_parametrize_decorator_id_function_multiple_args() -> None:
+    def f() -> None:
+        pass
+
+    _parametrize.parametrize_decorator(
+        "abc, def",
+        [("a", 1), ("b", 2)],
+        ids=lambda value: str(value) if isinstance(value, str) else None,
+    )(f)
+
+    arg_names = ("abc", "def")
+    assert f.parametrize == [  # type: ignore[attr-defined]
+        _parametrize.Param("a", 1, arg_names=arg_names, id="a, def=1"),
+        _parametrize.Param("b", 2, arg_names=arg_names, id="b, def=2"),
+    ]
+
+
+def test_parametrize_decorator_id_function_ignores_explicit_param_ids() -> None:
+    def f() -> None:
+        pass
+
+    # An explicit nox.param(..., id=...) keeps its own ID; the id callable only
+    # applies to bare values.
+    _parametrize.parametrize_decorator(
+        "abc",
+        [_parametrize.Param("a b", id="explicit"), "c d"],
+        ids=lambda value: value.replace(" ", "-"),
+    )(f)
+
+    arg_names = ("abc",)
+    assert f.parametrize == [  # type: ignore[attr-defined]
+        _parametrize.Param("a b", arg_names=arg_names, id="explicit"),
+        _parametrize.Param("c d", arg_names=arg_names, id="c-d"),
+    ]
+
+
 def test_parametrize_decorator_multiple_args_as_list() -> None:
     def f() -> None:
         pass


### PR DESCRIPTION
Closes #278.

## Motivation

Parametrized session names like `test_plugins-3.6(pip install)` contain characters (spaces, parentheses) that the shell parses, so they have to be quoted to run: `nox -s "test_plugins-3.6(pip install)"`. #278 asks for more control over how those names are formatted.

`nox.parametrize` is already documented as "intentionally similar to pytest's parametrize", and pytest's `ids` accepts a callable that derives an id from each value. That's exactly the missing lever here: it lets you strip the awkward characters out of the generated names. As suggested in the issue thread, this adds the callable form.

## What changed

`ids` can now be a callable in addition to the existing sequence form:

```python
@nox.session
@nox.parametrize(
    "dependency",
    ["flask==1.0", "flask==2.0"],
    ids=lambda dependency: dependency.replace("==", "-"),
)
def tests(session, dependency):
    ...
```

```console
$ nox --list
* tests(flask-1.0)
* tests(flask-2.0)
```

Semantics mirror pytest:

- The callable is invoked with each argument value.
- A `str` return is used as that argument's id.
- Any other return (including `None`) falls back to the default `name=value` representation for that argument, so you can override some values and leave the rest alone.
- An explicit `nox.param(..., id=...)` keeps its own id; the callable only applies to bare values.

Passing a callable used to raise `TypeError` (it was zipped against the values), so this is backward compatible.

## Tests / docs

- Added unit tests in `tests/test__parametrize.py` covering the single-arg case, the fall-back-on-non-string case, the multiple-argument case, and the interaction with explicit `nox.param` ids. `nox._parametrize` stays at 100% coverage.
- Documented the callable form under "Giving friendly names to parametrized sessions" in `docs/config.rst`.
- `ruff check`, `ruff format`, and `mypy` are clean.
