### PR TITLE
feat: add `session.background` for long-running background commands

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -516,6 +516,11 @@ class.
     :members:
     :undoc-members:
 
+:meth:`Session.background` returns a handle to the running command:
+
+.. autoclass:: nox.command.BackgroundCommand
+    :members:
+
 The pyproject.toml helpers
 --------------------------
 

--- a/nox/command.py
+++ b/nox/command.py
@@ -24,13 +24,26 @@ import sys
 from typing import TYPE_CHECKING, Literal, overload
 
 from nox.logger import logger
-from nox.popen import DEFAULT_INTERRUPT_TIMEOUT, DEFAULT_TERMINATE_TIMEOUT, popen
+from nox.popen import (
+    DEFAULT_INTERRUPT_TIMEOUT,
+    DEFAULT_TERMINATE_TIMEOUT,
+    popen,
+    popen_background,
+    shutdown_process,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
     from typing import IO
 
-__all__ = ["CommandFailed", "ExternalType", "run", "which"]
+__all__ = [
+    "BackgroundCommand",
+    "CommandFailed",
+    "ExternalType",
+    "run",
+    "run_background",
+    "which",
+]
 
 _PLATFORM = sys.platform
 
@@ -86,6 +99,45 @@ def _clean_env(env: Mapping[str, str | None] | None = None) -> dict[str, str] | 
 
 def _shlex_join(args: Sequence[str | os.PathLike[str]]) -> str:
     return " ".join(shlex.quote(os.fspath(arg)) for arg in args)
+
+
+def _prepare_run(
+    args: Sequence[str | os.PathLike[str]],
+    *,
+    paths: Sequence[str | os.PathLike[str]] | None,
+    log: bool,
+    external: ExternalType,
+) -> tuple[list[str], str]:
+    """Resolve the executable, log the command, and enforce the external policy."""
+    cmd, args = args[0], args[1:]
+    full_cmd = f"{cmd} {_shlex_join(args)}"
+
+    cmd_path = which(os.fspath(cmd), paths)
+    str_args = [os.fspath(arg) for arg in args]
+
+    if log:
+        logger.info(full_cmd)
+
+    is_external_tool = paths is not None and not any(
+        cmd_path.startswith(str(path)) for path in paths
+    )
+    if is_external_tool:
+        if external == "error":
+            logger.error(
+                f"Error: {cmd} is not installed into the virtualenv, it is located"
+                f" at {cmd_path}. Pass external=True into run() to explicitly allow"
+                " this."
+            )
+            msg = "External program disallowed."
+            raise CommandFailed(msg)
+        if external is False and log:
+            logger.warning(
+                f"Warning: {cmd} is not installed into the virtualenv, it is"
+                f" located at {cmd_path}. This might cause issues! Pass"
+                " external=True into run() to silence this message."
+            )
+
+    return [cmd_path, *str_args], full_cmd
 
 
 @overload
@@ -158,39 +210,13 @@ def run(
     if success_codes is None:
         success_codes = [0]
 
-    cmd, args = args[0], args[1:]
-    full_cmd = f"{cmd} {_shlex_join(args)}"
-
-    cmd_path = which(os.fspath(cmd), paths)
-    str_args = [os.fspath(arg) for arg in args]
-
-    if log:
-        logger.info(full_cmd)
-
-    is_external_tool = paths is not None and not any(
-        cmd_path.startswith(str(path)) for path in paths
-    )
-    if is_external_tool:
-        if external == "error":
-            logger.error(
-                f"Error: {cmd} is not installed into the virtualenv, it is located"
-                f" at {cmd_path}. Pass external=True into run() to explicitly allow"
-                " this."
-            )
-            msg = "External program disallowed."
-            raise CommandFailed(msg)
-        if external is False and log:
-            logger.warning(
-                f"Warning: {cmd} is not installed into the virtualenv, it is"
-                f" located at {cmd_path}. This might cause issues! Pass"
-                " external=True into run() to silence this message."
-            )
+    popen_args, full_cmd = _prepare_run(args, paths=paths, log=log, external=external)
 
     env = _clean_env(env)
 
     try:
         return_code, output = popen(
-            [cmd_path, *str_args],
+            popen_args,
             silent=silent,
             env=env,
             stdout=stdout,
@@ -219,3 +245,83 @@ def run(
         raise
 
     return output if silent else True
+
+
+class BackgroundCommand:
+    """A handle to a command started in the background.
+
+    Instances are returned by :meth:`nox.sessions.Session.background`. The
+    process keeps running while the rest of the session executes; call
+    :meth:`stop` (or use the object as a context manager) to shut it down. Any
+    background commands still running when the session ends are stopped
+    automatically.
+    """
+
+    def __init__(
+        self,
+        process: subprocess.Popen[bytes],
+        *,
+        interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
+        terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
+    ) -> None:
+        self.process = process
+        self.interrupt_timeout = interrupt_timeout
+        self.terminate_timeout = terminate_timeout
+
+    @property
+    def returncode(self) -> int | None:
+        """The command's exit code, or ``None`` while it is still running."""
+        return self.process.returncode
+
+    def poll(self) -> int | None:
+        """Check whether the command has finished without blocking."""
+        return self.process.poll()
+
+    def wait(self, timeout: float | None = None) -> int:
+        """Wait for the command to finish and return its exit code."""
+        return self.process.wait(timeout)
+
+    def stop(self) -> int:
+        """Gracefully stop the command and return its exit code.
+
+        Nothing happens if the command has already finished. Otherwise it is
+        given ``interrupt_timeout`` seconds to exit before being terminated, and
+        ``terminate_timeout`` seconds more before being killed.
+        """
+        if self.process.poll() is None:
+            shutdown_process(
+                self.process, self.interrupt_timeout, self.terminate_timeout
+            )
+        return self.process.wait()
+
+    def __enter__(self) -> BackgroundCommand:  # noqa: PYI034
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.stop()
+
+
+def run_background(
+    args: Sequence[str | os.PathLike[str]],
+    *,
+    env: Mapping[str, str | None] | None = None,
+    paths: Sequence[str | os.PathLike[str]] | None = None,
+    log: bool = True,
+    external: ExternalType = False,
+    stdout: int | IO[str] | None = None,
+    stderr: int | IO[str] | None = None,
+    interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
+    terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
+) -> BackgroundCommand:
+    """Start a command-line program in the background."""
+    popen_args, _full_cmd = _prepare_run(args, paths=paths, log=log, external=external)
+
+    process = popen_background(
+        popen_args, env=_clean_env(env), stdout=stdout, stderr=stderr
+    )
+
+    return BackgroundCommand(
+        process,
+        interrupt_timeout=interrupt_timeout,
+        terminate_timeout=terminate_timeout,
+    )

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -32,6 +32,7 @@ __all__ = [
     "DEFAULT_TERMINATE_TIMEOUT",
     "decode_output",
     "popen",
+    "popen_background",
 ]
 
 
@@ -165,6 +166,32 @@ def decode_output(output: bytes) -> str:
         return output.decode(second_encoding)
 
 
+def _popen_args(
+    args: Sequence[str], env: Mapping[str, str] | None
+) -> Sequence[str] | str:
+    if sys.platform.startswith("win") and args[0].casefold().endswith((".bat", ".cmd")):
+        return _windows_batch_command(args, env)
+    return args
+
+
+def popen_background(
+    args: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    stdout: int | IO[str] | None = None,
+    stderr: int | IO[str] | None = None,
+) -> subprocess.Popen[bytes]:
+    """Start a command in the background and return the process without waiting.
+
+    Unlike :func:`popen`, this does not block for the command to finish. The
+    caller is responsible for eventually stopping the process, for example with
+    :func:`shutdown_process`.
+    """
+    return subprocess.Popen(
+        _popen_args(args, env), env=env, stdout=stdout, stderr=stderr
+    )
+
+
 def popen(
     args: Sequence[str],
     *,
@@ -185,11 +212,9 @@ def popen(
     if silent:
         stdout = subprocess.PIPE
 
-    popen_args: Sequence[str] | str = args
-    if sys.platform.startswith("win") and args[0].casefold().endswith((".bat", ".cmd")):
-        popen_args = _windows_batch_command(args, env)
-
-    proc = subprocess.Popen(popen_args, env=env, stdout=stdout, stderr=stderr)
+    proc = subprocess.Popen(
+        _popen_args(args, env), env=env, stdout=stdout, stderr=stderr
+    )
 
     try:
         out, _err = proc.communicate()

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -525,6 +525,100 @@ class Session:
             terminate_timeout=terminate_timeout,
         )
 
+    def background(
+        self,
+        *args: str | os.PathLike[str],
+        env: Mapping[str, str | None] | None = None,
+        include_outer_env: bool = True,
+        log: bool = True,
+        external: ExternalType | None = None,
+        stdout: int | IO[str] | None = None,
+        stderr: int | IO[str] | None = None,
+        interrupt_timeout: float | None = DEFAULT_INTERRUPT_TIMEOUT,
+        terminate_timeout: float | None = DEFAULT_TERMINATE_TIMEOUT,
+    ) -> nox.command.BackgroundCommand:
+        """Start a command in the background and return a handle to it.
+
+        Unlike :func:`run`, this does not wait for the command to finish. It is
+        handy for commands that should keep running while the session does
+        something else, such as a server that the tests talk to::
+
+            server = session.background("python", "-m", "my_app")
+            try:
+                session.run("pytest", "tests/")
+            finally:
+                server.stop()
+
+        The returned :class:`nox.command.BackgroundCommand` can also be used as a
+        context manager, which stops the command on exit::
+
+            with session.background("python", "-m", "my_app"):
+                session.run("pytest", "tests/")
+
+        Any background commands still running when the session ends are stopped
+        automatically, so an explicit :meth:`~nox.command.BackgroundCommand.stop`
+        is only needed to shut one down earlier.
+
+        The arguments behave the same as :func:`run`, except that ``stdout`` and
+        ``stderr`` are inherited from Nox by default so the command's output is
+        shown as it happens. ``interrupt_timeout`` and ``terminate_timeout``
+        control how long :meth:`~nox.command.BackgroundCommand.stop` waits before
+        escalating from an interrupt to a terminate and then a kill.
+
+        :param env: A dictionary of environment variables to expose to the
+            command. By default, all environment variables are passed. You
+            can block an environment variable from the outer environment by
+            setting it to None.
+        :type env: dict or None
+        :param include_outer_env: Boolean parameter that determines if the
+            environment variables from the nox invocation environment should
+            be passed to the command. ``True`` by default.
+        :type include_outer_env: bool
+        :param external: If False (the default) then programs not in the
+            virtualenv path will cause a warning. If True, no warning will be
+            emitted. These warnings can be turned into errors using
+            ``--error-on-external-run``. This has no effect for sessions that
+            do not have a virtualenv.
+        :type external: bool
+        :param interrupt_timeout: The timeout (in seconds) that Nox should wait
+            when stopping the command before sending it a terminate signal. Set
+            to ``None`` to never send a terminate signal. Default: ``0.3``
+        :type interrupt_timeout: float or None
+        :param terminate_timeout: The timeout (in seconds) that Nox should wait
+            after it sends a terminate signal before sending a kill signal. Set
+            to ``None`` to never send a kill signal. Default: ``0.2``
+        :type terminate_timeout: float or None
+        :param stdout: Redirect standard output of the command into a file.
+        :type stdout: file or file descriptor
+        :param stderr: Redirect standard error of the command into a file.
+        :type stderr: file or file descriptor
+        """
+        if not args:
+            msg = "At least one argument required to background()."
+            raise ValueError(msg)
+
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            msg = "First argument to `session.background` is a list. Did you mean to use `session.background(*args)`?"
+            raise ValueError(msg)
+
+        args, env, external = self._resolve_run_args(
+            args, env=env, include_outer_env=include_outer_env, external=external
+        )
+
+        command = nox.command.run_background(
+            args,
+            env=env,
+            paths=self.bin_paths,
+            log=log,
+            external=external,
+            stdout=stdout,
+            stderr=stderr,
+            interrupt_timeout=interrupt_timeout,
+            terminate_timeout=terminate_timeout,
+        )
+        self._runner.background_commands.append(command)
+        return command
+
     def run_install(
         self,
         *args: str | os.PathLike[str],
@@ -660,6 +754,34 @@ class Session:
         if callable(args[0]):
             return self._run_func(args[0], args[1:])  # type: ignore[unreachable]
 
+        args, env, external = self._resolve_run_args(
+            args, env=env, include_outer_env=include_outer_env, external=external
+        )
+
+        # Run a shell command.
+        return nox.command.run(
+            args,
+            env=env,
+            paths=self.bin_paths,
+            silent=silent,
+            success_codes=success_codes,
+            log=log,
+            external=external,
+            stdout=stdout,
+            stderr=stderr,
+            interrupt_timeout=interrupt_timeout,
+            terminate_timeout=terminate_timeout,
+        )
+
+    def _resolve_run_args(
+        self,
+        args: tuple[str | os.PathLike[str], ...],
+        *,
+        env: Mapping[str, str | None] | None,
+        include_outer_env: bool,
+        external: ExternalType | None,
+    ) -> tuple[tuple[str | os.PathLike[str], ...], dict[str, str | None], ExternalType]:
+        """Apply the uv shim, virtualenv env, and external policy shared by runs."""
         # Using `"uv"` or `"uvx" when `uv` is the backend is guaranteed to
         # work, even if it was co-installed with nox.
         if self.virtualenv.venv_backend == "uv" and nox.virtualenv.UV != "uv":
@@ -689,20 +811,7 @@ class Session:
         if external is None:
             external = False
 
-        # Run a shell command.
-        return nox.command.run(
-            args,
-            env=env,
-            paths=self.bin_paths,
-            silent=silent,
-            success_codes=success_codes,
-            log=log,
-            external=external,
-            stdout=stdout,
-            stderr=stderr,
-            interrupt_timeout=interrupt_timeout,
-            terminate_timeout=terminate_timeout,
-        )
+        return args, env, external
 
     def conda_install(
         self,
@@ -1065,6 +1174,7 @@ class SessionRunner:
         self.posargs: list[str] = global_config.posargs[:]
         self.result: Result | None = None
         self.multi = multi
+        self.background_commands: list[nox.command.BackgroundCommand] = []
 
         if getattr(func, "parametrize", None):
             self.multi = True
@@ -1165,6 +1275,11 @@ class SessionRunner:
         """
         return resolve_reuse_existing_venv(self.global_config, self.func)
 
+    def _stop_background_commands(self) -> None:
+        """Stop any background commands the session left running."""
+        while self.background_commands:
+            self.background_commands.pop().stop()
+
     def execute(self) -> Result:
         logger.session_info(f"Running session {self.friendly_name}")
 
@@ -1184,7 +1299,10 @@ class SessionRunner:
                 self._create_venv()
                 session = Session(self)
                 session.env["NOX_CURRENT_SESSION"] = session.name
-                self.func(session)
+                try:
+                    self.func(session)
+                finally:
+                    self._stop_background_commands()
 
             # Nothing went wrong; return a success.
             self.result = Result(

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -727,3 +727,48 @@ def test_output_decoding_both_fail(monkeypatch: pytest.MonkeyPatch) -> None:
         nox.popen.decode_output(b"\x95")
 
     assert exc.value.encoding == "ascii"
+
+
+def test_run_background_and_stop() -> None:
+    command = nox.command.run_background([PYTHON, "-c", "import time; time.sleep(30)"])
+    try:
+        # The process keeps running until we stop it.
+        assert command.poll() is None
+        assert command.returncode is None
+    finally:
+        command.stop()
+
+    assert command.poll() is not None
+    assert command.returncode is not None
+
+
+def test_run_background_wait() -> None:
+    command = nox.command.run_background([PYTHON, "-c", "pass"])
+
+    assert command.wait() == 0
+    assert command.returncode == 0
+
+
+def test_background_command_context_manager() -> None:
+    with nox.command.run_background(
+        [PYTHON, "-c", "import time; time.sleep(30)"]
+    ) as command:
+        assert command.poll() is None
+
+    # Leaving the context stops the command.
+    assert command.poll() is not None
+
+
+def test_background_command_stop_after_exit() -> None:
+    command = nox.command.run_background([PYTHON, "-c", "pass"])
+    command.wait()
+
+    # Stopping a command that already exited just returns its exit code.
+    assert command.stop() == 0
+
+
+def test_run_background_external_error() -> None:
+    with pytest.raises(nox.command.CommandFailed, match="External"):
+        nox.command.run_background(
+            [PYTHON, "--version"], paths=["/no/such/path"], external="error"
+        )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -356,6 +356,41 @@ class TestSession:
         with pytest.raises(nox.command.CommandFailed):
             session.run(sys.executable, "-c", "import sys; sys.exit(1)")
 
+    def test_background(self) -> None:
+        session, runner = self.make_session_and_runner()
+
+        with mock.patch("nox.command.run_background", autospec=True) as run_background:
+            handle = session.background(sys.executable, "--version")
+
+        run_background.assert_called_once_with(
+            (sys.executable, "--version"),
+            env=mock.ANY,
+            paths=["/no/bin/for/you"],
+            log=True,
+            external=False,
+            stdout=None,
+            stderr=None,
+            interrupt_timeout=nox.popen.DEFAULT_INTERRUPT_TIMEOUT,
+            terminate_timeout=nox.popen.DEFAULT_TERMINATE_TIMEOUT,
+        )
+        assert handle is run_background.return_value
+        # The handle is tracked so it can be cleaned up when the session ends.
+        assert runner.background_commands == [handle]
+
+    def test_background_no_args(self) -> None:
+        session, _ = self.make_session_and_runner()
+
+        with pytest.raises(
+            ValueError, match="At least one argument required to background"
+        ):
+            session.background()
+
+    def test_background_list_arg(self) -> None:
+        session, _ = self.make_session_and_runner()
+
+        with pytest.raises(ValueError, match="is a list"):
+            session.background([sys.executable, "--version"])  # type: ignore[arg-type]
+
     def test_run_install_script(self) -> None:
         session, _ = self.make_session_and_runner()
 
@@ -1378,6 +1413,40 @@ class TestSessionRunner:
         assert result
         runner.func.assert_called_once_with(mock.ANY)  # type: ignore[attr-defined]
         assert "Running session test(1, 2)" in caplog.text
+
+    def test_execute_stops_background_commands(self) -> None:
+        runner = self.make_runner_with_mock_venv()
+        command = mock.Mock(spec=nox.command.BackgroundCommand)
+
+        def func(session: nox.Session) -> None:
+            session._runner.background_commands.append(command)
+
+        func.requires = []  # type: ignore[attr-defined]
+        runner.func = func  # type: ignore[assignment]
+
+        result = runner.execute()
+
+        assert result.status == nox.sessions.Status.SUCCESS
+        command.stop.assert_called_once_with()
+        assert runner.background_commands == []
+
+    def test_execute_stops_background_commands_on_failure(self) -> None:
+        runner = self.make_runner_with_mock_venv()
+        command = mock.Mock(spec=nox.command.BackgroundCommand)
+
+        def func(session: nox.Session) -> None:
+            session._runner.background_commands.append(command)
+            msg = "boom"
+            raise ValueError(msg)
+
+        func.requires = []  # type: ignore[attr-defined]
+        runner.func = func  # type: ignore[assignment]
+
+        result = runner.execute()
+
+        assert result.status == nox.sessions.Status.FAILED
+        command.stop.assert_called_once_with()
+        assert runner.background_commands == []
 
     def test_execute_quit(self) -> None:
         runner = self.make_runner_with_mock_venv()


### PR DESCRIPTION
Closes #198.

This adds `session.background(...)`, which starts a command and returns right away instead of waiting for it to finish. That makes it possible to keep something like a server running while the rest of the session does its thing:

```python
@nox.session
def integration(session):
    session.install("-e.")
    server = session.background("python", "-m", "my_app")
    try:
        session.run("pytest", "tests/")
    finally:
        server.stop()
```

The returned handle also works as a context manager, and any background commands still running when the session ends get stopped automatically, so nothing leaks past the session.

It reuses the same argument handling as `run()` (the virtualenv env, external checks, the uv shim), and `stop()` reuses the existing `shutdown_process` escalation from interrupt to terminate to kill. Docs and tests are included and coverage stays at 100%.
