### PR TITLE
docs: clarify supported session Python versions

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -123,6 +123,13 @@ You can tell Nox to use a different Python interpreter/version by specifying the
     .. _python-discovery: https://pypi.org/project/python-discovery/
     .. _PEP 514: https://peps.python.org/pep-0514/
 
+Nox does not impose a separate supported-version range on the Python
+interpreters used by sessions. A target version works when Nox can discover or
+download its interpreter and the selected environment backend can create an
+environment with it. Backends and the packages they use may have their own
+Python support ranges; see the end-of-life Python guidance below when targeting
+older versions.
+
 You can also tell Nox to run your session against multiple Python interpreters. Nox will create a separate virtualenv and run the session for each interpreter you specify. For example, this session will run twice - once for Python 3.13 and once for Python 3.14:
 
 .. code-block:: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ To run both of these sessions, just run::
 
     nox
 
-For each session, Nox will automatically create a `virtualenv`_ with the appropriate interpreter, install the specified dependencies, and run the commands in order.
+For each session, Nox will automatically create an isolated environment with the appropriate Python interpreter using the configured :ref:`environment backend <virtualenv config>`, install the specified dependencies, and run the commands in order.
 
 To learn how to install and use Nox, see the :doc:`tutorial`. For documentation on configuring sessions, see :doc:`config`. For documentation on running ``nox``, see :doc:`usage`.
 


### PR DESCRIPTION
### Summary

- document how interpreter discovery and the selected environment backend
  determine session Python support
- avoid implying that all Nox sessions use virtualenv
- point readers targeting old Python versions to the existing EOL guidance

### Testing

- targeted pre-commit suite
- Sphinx HTML build

Closes #681
