### PR TITLE
ci: bump pinned conda to 26.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           channels: conda-forge
           conda-remove-defaults: true
-          conda-version: '26.5.2'
+          conda-version: '26.7.1'
           activate-environment:
       - name: Install Nox-under-test (uv)
         run:  uv pip install --system .


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `build (macos-latest, 3.14)` job fails on every recent PR in the "Set up Miniconda" step:

```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package anaconda-channel-guide-0.2.0-py314hca03da5_0 requires conda >=26.7.0
Currently pinned specs:
 - python=3.14
```

The macOS runner image now has a miniconda base environment on Python 3.14. Conda 26.5.2, pinned in #1079, has no Python 3.14 build, so the solve fails. This bumps the pin to 26.7.1.